### PR TITLE
Add server_name parameter to the launch function in interface.py .

### DIFF
--- a/triton_viz/interface.py
+++ b/triton_viz/interface.py
@@ -6,7 +6,7 @@ from .tooltip import create_tooltip
 import pandas as pd
 
 
-def launch(share=True):
+def launch(share=True, server_name=None):
     cache = {}
     analysis_data = analyze_records()
     program_records, tt, failures = triton_viz.collect_grid()
@@ -95,5 +95,5 @@ def launch(share=True):
         b1.click(precompute, inputs={s1, s2, s3}, outputs=img, show_progress=True)
         demo.load(update, inputs={s1, s2, s3}, outputs=[img, b1])
 
-    demo.launch(share=share, debug=False, height=800, quiet=True, show_api=False)
+    demo.launch(share=share, debug=False, height=800, quiet=True, show_api=False, server_name=server_name)
     return failures


### PR DESCRIPTION
To address the access limitations when running Jupyter Notebook in non-local environments (such as remote servers), modifications to the launch function in interface.py are required. 

Since Gradio by default only allows access requests from localhost (127.0.0.1), remote users are unable to connect to the Gradio interface. 

Therefore, I add a server_name parameter to the launch function, which users can set to "0.0.0.0" to enable remote Jupyter access.

The result is as follows:
![image](https://github.com/user-attachments/assets/d562d243-68dc-445c-a226-22159a987b1a)