### PR TITLE
[DEV] Locate First Pointer with Valid Mask Using Unravel Index

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -45,14 +45,16 @@ class Sanitizer(Client):
 
     def register_op_callback(self, op_type: Type[Op]) -> Tuple[Optional[Callable], Optional[Callable]]:
         def pre_load_callback(ptr, mask, other, cache_modifier, eviction_policy, is_volatile):
-            first_ptr = np.reshape(ptr.data, (-1))[0]
+            first_loc = np.unravel_index(np.argmax(mask, axis=None), mask.data.shape)
+            first_ptr = ptr.data[first_loc]
             tensor = self._get_tensor(first_ptr)
             oob = check_out_of_bounds_access(ptr.data, mask.data, tensor)
             self._report(op_type, oob)
             ptr.data = tensor.data_ptr() + oob[-1]
 
         def pre_store_callback(ptr, value, mask, cache_modifier, eviction_policy):
-            first_ptr = np.reshape(ptr.data, (-1))[0]
+            first_loc = np.unravel_index(np.argmax(mask, axis=None), mask.data.shape)
+            first_ptr = ptr.data[first_loc]
             tensor = self._get_tensor(first_ptr)
             oob = check_out_of_bounds_access(ptr.data, mask.data, tensor)
             self._report(op_type, check_out_of_bounds_access(ptr.data, mask.data, tensor))


### PR DESCRIPTION
Update to find the first valid pointer by locating the first `True` in the `mask` using `argmax`. `unravel_index` is used to handle multi-dimensional indexing and extract the correct pointer from `ptr.data`.