### PR TITLE
[DEV] Fix and rename op overrider

### DIFF
--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -43,11 +43,11 @@ class Profiler(Client):
             self._report_load_store_bytes("store", ptr, mask)
 
         if isinstance(op, Load):
-            return pre_load_callback, None
+            return pre_load_callback, None, None
         elif isinstance(op, Store):
-            return pre_store_callback, None
+            return pre_store_callback, None, None
 
-        return None, None
+        return None, None, None
 
     def finalize(self) -> list:
         return [self.load_bytes, self.store_bytes]

--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -35,7 +35,7 @@ class Profiler(Client):
             self.store_bytes.total_bytes_attempted += total_bytes_attempted
             self.store_bytes.total_bytes_true += total_bytes_true
 
-    def register_op_callback(self, op: Type[Op]) -> Tuple[Optional[Callable], Optional[Callable]]:
+    def register_op_callback(self, op: Type[Op]) -> Tuple[Optional[Callable], Optional[Callable], Optional[Callable]]:
         def pre_load_callback(ptr, mask, other, cache_modifier, eviction_policy, is_volatile):
             self._report_load_store_bytes("load", ptr, mask)
 

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -216,12 +216,12 @@ class SanitizerZ3(Client):
                 upper_bound = valid_addresses.max()
                 self._check_if_range_statisfy_constraints(lower_bound, upper_bound)
 
-        def op_load_callback(ptr, mask, other, cache_modifier, eviction_policy, is_volatile):
+        def op_load_overrider(ptr, mask, other, cache_modifier, eviction_policy, is_volatile):
             dtype_tt = ptr.get_element_ty()
             dtype_np = _get_np_dtype(dtype_tt)
             return TensorHandle(np.zeros_like(ptr.data, dtype=dtype_np), dtype_tt)
 
-        def op_store_callback(ptr, value, mask, cache_modifier, eviction_policy):
+        def op_store_overrider(ptr, value, mask, cache_modifier, eviction_policy):
             pass
 
         def pre_store_callback(ptr, value, mask, cache_modifier, eviction_policy):
@@ -235,9 +235,9 @@ class SanitizerZ3(Client):
             self._check_if_range_statisfy_constraints(lower_bound, upper_bound)
 
         if op_type is Load:
-            return pre_load_callback, None, op_load_callback
+            return pre_load_callback, None, op_load_overrider
         elif op_type is Store:
-            return pre_store_callback, None, op_store_callback
+            return pre_store_callback, None, op_store_overrider
         else:
             return None, None, None
 

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -78,15 +78,15 @@ class Tracer(Client):
             self.records.append(Dot(input_shape, other_shape, ret_shape))
 
         if op_type is Load:
-            return pre_load_callback, None
+            return pre_load_callback, None, None
         elif op_type is Store:
-            return pre_store_callback, None
+            return pre_store_callback, None, None
         elif op_type is ReduceSum:
-            return None, post_reduce_sum_callback
+            return None, post_reduce_sum_callback, None
         elif op_type is Dot:
-            return None, post_dot_callback
+            return None, post_dot_callback, None
 
-        return None, None
+        return None, None, None
 
     def finalize(self) -> list:
         return self.records

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -41,8 +41,8 @@ class ClientManager:
         with patch_calls():
             for client in self.clients:
                 for op in op_list:
-                    before_callback, after_callback, op_callback = client.register_op_callback(op)
-                    patch_op(op, before_callback, after_callback, op_callback)
+                    before_callback, after_callback, op_overrider = client.register_op_callback(op)
+                    patch_op(op, before_callback, after_callback, op_overrider)
             try:
                 yield
             finally:


### PR DESCRIPTION
- Adapted to new return value (from 2-tuple to 3-tuple) of `pre_store_callback` and `pre_load_callback` in `profiler`, `tracer` and `client`.
- Renamed from `op_callback` to `op_overrider` in `patch.py` and `sanitizer.py`.