### PR TITLE
[DEV] Dynamic Sanitizer Configuration

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+import pytest
+import triton_viz.core.config as cfg
+
+
+def test_switch_backend():
+    """Switch back and forth at runtime."""
+    original = cfg.sanitizer_backend
+
+    cfg.sanitizer_backend = "symexec"
+    assert cfg.sanitizer_backend == "symexec"
+
+    cfg.sanitizer_backend = "off"
+    assert cfg.sanitizer_backend == "off"
+
+    cfg.sanitizer_backend = original
+
+
+def test_invalid_backend_raises():
+    """Setting an unknown backend should raise ValueError."""
+    with pytest.raises(ValueError):
+        cfg.sanitizer_backend = "does_not_exist"

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -13,11 +13,10 @@ class Config(types.ModuleType):
         if env_backend:
             self.sanitizer_backend = env_backend  # verify using setter
         else:
-            print(
-                f"TRITON_SANITIZER_BACKEND not set. "
-                f"Available backends are: {AVAILABLE_SANITIZER_BACKENDS}. Defaulting to 'off'."
+            raise ValueError(
+                f"TRITON_SANITIZER_BACKEND is not set!"
+                f"Available backends are: {AVAILABLE_SANITIZER_BACKENDS}"
             )
-            self._sanitizer_backend = "off"
 
         # --- Grid execution progress flag ---
         env_flag = os.getenv("REPORT_GRID_EXECUTION_PROGRESS", "0")

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -1,17 +1,67 @@
-import os
+import os, sys, types
 
 
-# global configs
-report_grid_execution_progress = os.getenv('REPORT_GRID_EXECUTION_PROGRESS', '0') == '1'
+# Back-end options recognised by the sanitizer
+AVAILABLE_SANITIZER_BACKENDS = ("off", "brute_force", "symexec")
 
-# sanitizer configs
-sanitizer_backend = os.getenv("TRITON_SANITIZER_BACKEND", "")
-available_backends = ["off", "brute_force", "z3", "symexec"]
-if sanitizer_backend == "":
-    print(f"TRITON_SANITIZER_BACKEND not set. Available backends are: {available_backends}. Defaulting to 'off'.")
-    sanitizer_backend = "off"
-if sanitizer_backend == "off":
-    print("Triton Sanitizer is disabled since TRITON_SANITIZER_BACKEND=off.")
-if sanitizer_backend not in available_backends:
-    raise ValueError(f"Invalid TRITON_SANITIZER_BACKEND: {sanitizer_backend}. Available backends are: {available_backends}")
+class Config(types.ModuleType):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
 
+        # --- Sanitizer backend ---
+        env_backend = os.getenv("TRITON_SANITIZER_BACKEND", "")
+        if env_backend:
+            self.sanitizer_backend = env_backend  # verify using setter
+        else:
+            print(
+                f"TRITON_SANITIZER_BACKEND not set. "
+                f"Available backends are: {AVAILABLE_SANITIZER_BACKENDS}. Defaulting to 'off'."
+            )
+            self._sanitizer_backend = "off"
+
+        # --- Grid execution progress flag ---
+        env_flag = os.getenv("REPORT_GRID_EXECUTION_PROGRESS", "0")
+        self.report_grid_execution_progress = env_flag == "1"  # verify using setter
+
+    # ---------- sanitizer_backend ----------
+    @property
+    def sanitizer_backend(self) -> str:
+        return self._sanitizer_backend
+
+    @sanitizer_backend.setter
+    def sanitizer_backend(self, value: str) -> None:
+        if value not in AVAILABLE_SANITIZER_BACKENDS:
+            raise ValueError(
+                f"Invalid sanitizer_backend: {value!r}. "
+                f"Valid choices: {AVAILABLE_SANITIZER_BACKENDS}"
+            )
+
+        previous = getattr(self, "_sanitizer_backend", None)
+        self._sanitizer_backend = value
+
+        # User-friendly status messages
+        if value == "off" and previous != "off":
+            print("Triton Sanitizer disabled.")
+        elif value != "off" and (previous == "off" or previous is None):
+            print(f"Triton Sanitizer enabled with backend: {value!r}")
+
+    # ---------- report_grid_execution_progress ----------
+    @property
+    def report_grid_execution_progress(self) -> bool:
+        return self._report_grid_execution_progress
+
+    @report_grid_execution_progress.setter
+    def report_grid_execution_progress(self, flag: bool) -> None:
+        if not isinstance(flag, bool):
+            raise TypeError("report_grid_execution_progress expects a bool.")
+        self._report_grid_execution_progress = flag
+        if flag:
+            print("Grid-progress reporting is now ON.")
+
+    # ---------- read-only helpers ----------
+    @property
+    def available_backends(self):
+        return AVAILABLE_SANITIZER_BACKENDS
+
+# Replace the current module object with a live Config instance
+sys.modules[__name__] = Config(__name__)


### PR DESCRIPTION
- Convert the old global flags into a single `Config` module that lets us change  
  `sanitizer_backend` and `report_grid_execution_progress` at runtime.
- Validate values against a fixed `AVAILABLE_SANITIZER_BACKENDS` list.
- Add `tests/test_config.py` to check backend switching and error handling.
