### PR TITLE
[CI FIX] Repository-wide Type Annotation Fixes & CI Pre-commit Lint Activation

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -36,11 +36,11 @@ jobs:
       with:
         python-version: '3.10'
 
-    # - name: Lint with pre-commit
-    #   run: |
-    #     cd triton_viz
-    #     pip install pre-commit
-    #     pre-commit run --all-files
+    - name: Lint with pre-commit
+      run: |
+        cd triton_viz
+        pip install pre-commit
+        pre-commit run --all-files
 
     - name: Install Dependencies
       if: steps.cache-pip.outputs.cache-hit != 'true'

--- a/tests/test_null_sanitizer.py
+++ b/tests/test_null_sanitizer.py
@@ -16,6 +16,7 @@ def null_sanitizer_kernel(idx_ptr):
     a = tl.load(idx_ptr)
     tl.store(idx_ptr, a + 5)
 
+
 def test_null_sanitizer():
     idx = torch.arange(128, dtype=torch.int32)
     null_sanitizer_kernel[(1,)](idx)

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -53,7 +53,7 @@ class Tracer(Client):
 
     def register_op_callback(
         self, op_type: Type[Op]
-    ) -> Tuple[Optional[Callable], Optional[Callable]]:
+    ) -> Tuple[Optional[Callable], Optional[Callable], Optional[Callable]]:
         def pre_load_callback(
             ptr, mask, other, cache_modifier, eviction_policy, is_volatile
         ):

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -25,7 +25,7 @@ class Client(ABC):
     @abstractmethod
     def register_op_callback(
         self, op: Type[Op]
-    ) -> Tuple[Optional[Callable], Optional[Callable]]:
+    ) -> Tuple[Optional[Callable], Optional[Callable], Optional[Callable]]:
         pass
 
     @abstractmethod

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -1,7 +1,13 @@
 import os
 import sys
 import types
+from typing import TYPE_CHECKING, Literal, Tuple
 
+
+if TYPE_CHECKING:
+    sanitizer_backend: Literal["off", "brute_force", "symexec"]
+    report_grid_execution_progress: bool
+    available_backends: Tuple[str, ...]
 
 # Back-end options recognised by the sanitizer
 AVAILABLE_SANITIZER_BACKENDS = ("off", "brute_force", "symexec")

--- a/triton_viz/visualizer/draw.py
+++ b/triton_viz/visualizer/draw.py
@@ -21,7 +21,7 @@ from chalk import Diagram, rectangle, text, hcat, vcat, empty, Path, Trail, V2, 
 from dataclasses import dataclass
 from numpy.typing import ArrayLike
 from ..core.trace import Trace
-from ..clients.sanitizer.data import OutOfBoundsRecord
+from ..clients.sanitizer.data import OutOfBoundsRecordBruteForce
 import sys
 
 sys.setrecursionlimit(100000)
@@ -99,7 +99,7 @@ def collect_launch(launch):
             last_grid = r
         program_records.append(r)
         if (
-            isinstance(r, (OutOfBoundsRecord))
+            isinstance(r, (OutOfBoundsRecordBruteForce))
             and (r.invalid_access_masks & r.op.masks).any()
         ):
             failures[last_grid.idx] = True
@@ -118,7 +118,7 @@ def draw_launch(program_records, tensor_table, base) -> Diagram:
             return draw_tensor(x)
         if isinstance(x, Grid):
             return draw_grid(x)
-        if isinstance(x, OutOfBoundsRecord):
+        if isinstance(x, OutOfBoundsRecordBruteForce):
             if isinstance(x.op, Load):
                 return draw_load(x, tensor_table)
             elif isinstance(x.op, Store):
@@ -253,7 +253,7 @@ def make_3d(shape):
 
 
 def store_load(
-    x: OutOfBoundsRecord, tensor_table: Dict[int, Tuple[Tensor, int]]
+    x: OutOfBoundsRecordBruteForce, tensor_table: Dict[int, Tuple[Tensor, int]]
 ) -> Tuple[Diagram, Diagram]:
     tensor, tensor_id = tensor_table[x.tensor.data_ptr]
     # inp = base_tensor(tensor.shape, DEFAULT)


### PR DESCRIPTION
- **CI workflow (`python-app.yml`)**
  - Reactivates the *pre-commit* linting step (previously commented out), ensuring code style checks run during the GitHub Actions build.  

- **`triton_viz/clients/sanitizer/sanitizer.py`**
  - Refactors the sanitizer hierarchy:  
    - Makes `SanitizerBruteForce`, `SanitizerSymbolicExecution`, and `NullSanitizer` inherit from `Sanitizer` factory base class.  
    - Provides placeholders for required methods of `Sanitizer`.
  - Fixes type annotation of `register_op_callback`.
  - Provides explicit type annotation for `OP_TYPE_TO_OVERRIDER`.  

- **`triton_viz/clients/tracer/tracer.py` & `triton_viz/core/client.py`**
  -  Fixes type annotation of `register_op_callback`.

- **`triton_viz/core/config.py`**
  - Adds a `TYPE_CHECKING` block supplying precise **`Literal` and `Tuple` type hints** (`sanitizer_backend`, `report_grid_execution_progress`, `available_backends`) to satisfy static analyzers like *mypy*.  

- **`triton_viz/visualizer/draw.py`**
  - Renames type references from `OutOfBoundsRecord` to **`OutOfBoundsRecordBruteForce`** and updates related `isinstance` checks and function signatures to match the new class names.  


