### PR TITLE
[DEV] Enable visualization for Load and Store operations in tracer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
   "chalk-diagrams @ git+https://github.com/chalk-diagrams/chalk.git",
   "z3-solver",
   "anytree",
+  "cairocffi",
 ]
 
 [project.urls]

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -4,9 +4,11 @@ import tempfile
 from .analysis import analyze_records
 from .tooltip import create_tooltip
 import pandas as pd
+import cairocffi
 
 
 def launch(share=True, server_name=None):
+    cairocffi.install_as_pycairo()
     cache = {}
     program_records, tt, failures = triton_viz.visualizer.collect_grid()
     analysis_data = analyze_records(program_records)


### PR DESCRIPTION
- Add handling for plain Load and Store records in draw_launch() dispatcher
- Implement draw_load_simple() and draw_store_simple() functions to visualize Load/Store operations without requiring Triton dtype objects
- Fix cairocffi import issue by installing it as pycairo in interface.py
- Temporarily disable text rendering in pair_draw() and draw_dot() due to chalk library compatibility issues
- Remove unused 'text' import from chalk to prevent linting errors

This enables the tracer to properly visualize tl.load and tl.store operations, showing accessed memory regions and data shapes.

🤖 Generated with [Claude Code](https://claude.ai/code)