### PR TITLE
[DEV] Make Tracer the default client for @triton_viz.trace()

### DIFF
--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -64,15 +64,15 @@ class Trace(KernelInterface):
         launches.append(self.client_manager.launch)
 
 
-def trace(clients: str | Client):
+def trace(clients: str | Client | None = None):
     """
     Create a trace object that can be used to run a kernel with instrumentation clients.
 
     :param kernel: The kernel to run.
-    :param client: A client to run with the kernel.
+    :param client: A client to run with the kernel. Defaults to Tracer() if not specified.
     """
-    if not clients:
-        raise ValueError("At least one client must be specified!")
+    if clients is None:
+        clients = Tracer()
 
     if not isinstance(clients, (str, Client)):
         raise TypeError(f"Expected str or Client, got {type(clients)}")


### PR DESCRIPTION
Changed trace() function to accept None as default parameter and use Tracer() when no client is specified. This simplifies usage from @triton_viz.trace(clients=Tracer()) to just @triton_viz.trace().

🤖 Generated with [Claude Code](https://claude.ai/code)