### PR TITLE
[REFACTOR] Refactor register_op_callback to return OpCallbacks dataclass

### DIFF
--- a/tests/indirect_load/utils.py
+++ b/tests/indirect_load/utils.py
@@ -43,9 +43,11 @@ class CaptureSanitizer(SanitizerSymbolicExecution):
         return self._offset_lists
 
     def register_op_callback(self, op_type):
-        pre, post, orig_overrider = super().register_op_callback(op_type)
-        if op_type not in (Load, RawLoad) or orig_overrider is None:
-            return pre, post, orig_overrider
+        op_callbacks = super().register_op_callback(op_type)
+        if op_type not in (Load, RawLoad) or op_callbacks.op_overrider is None:
+            return op_callbacks
+
+        orig_overrider = op_callbacks.op_overrider
 
         def new_load_overrider(ptr, *a, **k):
             # exec original overrider
@@ -65,4 +67,10 @@ class CaptureSanitizer(SanitizerSymbolicExecution):
                     self._offset_lists.append(offs.tolist())
             return load_expr
 
-        return pre, post, new_load_overrider
+        # Return OpCallbacks with the new overrider, preserving other callbacks
+        from triton_viz.core.callbacks import OpCallbacks
+        return OpCallbacks(
+            before_callback=op_callbacks.before_callback,
+            after_callback=op_callbacks.after_callback,
+            op_overrider=new_load_overrider
+        )

--- a/tests/symbolic_execution/test_addptr.py
+++ b/tests/symbolic_execution/test_addptr.py
@@ -24,8 +24,8 @@ def test_addptr_overrider():
     ptr_th = TensorHandle(np.array([1000]), ptr_dtype)
     offset_th = TensorHandle(np.array([3]), tl.int32)
     sanitizer = SanitizerSymbolicExecution(abort_on_error=False)
-    _, _, addptr_fn = sanitizer.register_op_callback(AddPtr)
-    assert addptr_fn is not None
-    expr = addptr_fn(ptr_th, offset_th)  # offset = 3
+    op_callbacks = sanitizer.register_op_callback(AddPtr)
+    assert op_callbacks.op_overrider is not None
+    expr = op_callbacks.op_overrider(ptr_th, offset_th)  # offset = 3
     assert expr.op == "addptr"
     assert expr.eval()[0] == 1000 + 3 * 4  # element_bytewidth = 4

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -1,4 +1,5 @@
 from ...core.client import Client
+from ...core.callbacks import OpCallbacks
 from ...core.data import Op, Load, Store, ReduceSum, Dot, Grid
 from collections.abc import Callable
 import numpy as np
@@ -56,9 +57,7 @@ class Tracer(Client):
     def grid_callback(self, grid: tuple[int]):
         self.tensors = sorted(self.tensors, key=lambda x: x.data_ptr())
 
-    def register_op_callback(
-        self, op_type: type[Op]
-    ) -> tuple[Callable | None, Callable | None, Callable | None]:
+    def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
         def pre_load_callback(
             ptr, mask, other, cache_modifier, eviction_policy, is_volatile
         ):
@@ -95,15 +94,15 @@ class Tracer(Client):
             self.records.append(Dot(input_shape, other_shape, ret_shape))
 
         if op_type is Load:
-            return pre_load_callback, None, None
+            return OpCallbacks(before_callback=pre_load_callback)
         elif op_type is Store:
-            return pre_store_callback, None, None
+            return OpCallbacks(before_callback=pre_store_callback)
         elif op_type is ReduceSum:
-            return None, post_reduce_sum_callback, None
+            return OpCallbacks(after_callback=post_reduce_sum_callback)
         elif op_type is Dot:
-            return None, post_dot_callback, None
+            return OpCallbacks(after_callback=post_dot_callback)
 
-        return None, None, None
+        return OpCallbacks()
 
     def finalize(self) -> list:
         return self.records

--- a/triton_viz/core/callbacks.py
+++ b/triton_viz/core/callbacks.py
@@ -1,0 +1,9 @@
+from collections.abc import Callable
+from dataclasses import dataclass
+
+
+@dataclass
+class OpCallbacks:
+    before_callback: Callable | None = None
+    after_callback: Callable | None = None
+    op_overrider: Callable | None = None

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 
 from .data import Op, Launch
 from .patch import patch_op, unpatch_op, op_list, patch_calls
+from .callbacks import OpCallbacks
 
 
 class Client(ABC):
@@ -24,9 +25,7 @@ class Client(ABC):
         ...
 
     @abstractmethod
-    def register_op_callback(
-        self, op: type[Op]
-    ) -> tuple[Callable | None, Callable | None, Callable | None]:
+    def register_op_callback(self, op: type[Op]) -> OpCallbacks:
         ...
 
     @abstractmethod
@@ -58,12 +57,8 @@ class ClientManager:
         with patch_calls():
             for client in self.clients.values():
                 for op in op_list:
-                    (
-                        before_callback,
-                        after_callback,
-                        op_overrider,
-                    ) = client.register_op_callback(op)
-                    patch_op(op, before_callback, after_callback, op_overrider)
+                    callbacks = client.register_op_callback(op)
+                    patch_op(op, callbacks)
             try:
                 yield
             finally:


### PR DESCRIPTION
Replace tuple return type (before_callback, after_callback, op_overrider) with a structured OpCallbacks dataclass to improve maintainability and extensibility.

Changes:
- Add OpCallbacks dataclass with three optional callback fields
- Update Client.register_op_callback() to return OpCallbacks
- Refactor patch_op() to accept OpCallbacks instead of individual params
- Update PatchOp class to use OpCallbacks internally
- Migrate all client implementations (Tracer, Profiler, Sanitizer)
- Update affected test files

This change makes it easier to add new callback types in the future without modifying all function signatures and call sites.

🤖 Generated with [Claude Code](https://claude.ai/code)