### PR TITLE
[REFACTOR] Remove unused dependency and make Triton version configurable

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -25,6 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TRITON_INTERPRET: "1"
+      TRITON_VERSION: "3.3.1"
 
     steps:
     - uses: actions/checkout@v3
@@ -50,7 +51,7 @@ jobs:
 
     - name: Install Triton
       run: |
-        pip install triton==3.3.1
+        pip install triton==${{ env.TRITON_VERSION }}
 
     - name: Install Triton-Viz
       run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "cairocffi",
   "flask",
   "flask_cloudflared",
+  "tqdm",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,11 +23,9 @@ classifiers = [
 dependencies = [
   "setuptools",
   "triton",
-  "gradio",
   "pyarrow",
   "pre-commit",
   "pytest",
-  "chalk-diagrams @ git+https://github.com/chalk-diagrams/chalk.git",
   "z3-solver",
   "anytree",
   "cairocffi",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-chalk-diagrams @ git+https://github.com/chalk-diagrams/chalk.git
-gradio
 pre-commit
 pyarrow
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-pre-commit
-pyarrow
-pytest
-setuptools
-triton

--- a/triton_viz/visualizer/draw.py
+++ b/triton_viz/visualizer/draw.py
@@ -1,4 +1,3 @@
-from colour import Color
 from triton_viz.core.data import (
     Tensor,
     Grid,
@@ -8,7 +7,6 @@ from triton_viz.core.data import (
     ExpandDims,
 )
 import numpy as np
-import planar
 from ..core.trace import launches
 from ..clients.sanitizer.data import OutOfBoundsRecordBruteForce
 import sys
@@ -16,27 +14,6 @@ import torch
 import uuid
 
 sys.setrecursionlimit(100000)
-
-
-planar.EPSILON = 0.0
-BG = Color("white")
-WHITE = Color("white")
-DEFAULT = Color("grey")
-BLACK = Color("black")
-GREY = Color("grey")
-palette = [
-    "#f29f05",
-    "#f25c05",
-    "#d6568c",
-    "#4d8584",
-    "#a62f03",
-    "#400d01",
-    "#274001",
-    "#828a00",
-]
-ACTIVE = [Color(p) for p in palette]
-
-MRATIO = 1 / 3
 
 LAST_RECORD_ONLY = True
 

--- a/triton_viz/visualizer/draw.py
+++ b/triton_viz/visualizer/draw.py
@@ -10,8 +10,6 @@ from triton_viz.core.data import (
 import numpy as np
 import planar
 import math
-import chalk
-from chalk import Diagram, rectangle
 from ..core.trace import launches
 from ..clients.sanitizer.data import OutOfBoundsRecordBruteForce
 import sys
@@ -22,7 +20,6 @@ sys.setrecursionlimit(100000)
 
 
 planar.EPSILON = 0.0
-chalk.set_svg_draw_height(500)
 BG = Color("white")
 WHITE = Color("white")
 DEFAULT = Color("grey")
@@ -45,23 +42,6 @@ MRATIO = 1 / 3
 LAST_RECORD_ONLY = True
 
 # Generic render helpers
-
-
-def box(d: Diagram, width: float, height: float, outer=0.2) -> Diagram:
-    "Put diagram in a box of shape height, width"
-    h, w = d.get_envelope().height, d.get_envelope().width
-    m = max(h, w)
-    back = rectangle(outer + m, outer + m).line_width(0).fill_color(BG).center_xy()
-    d = (back + d.center_xy()).with_envelope(back)
-    return d.scale_x(width / m).scale_y(height / m)
-
-
-def reshape(d: Diagram) -> Diagram:
-    "Use log-scale if ratio is too sharp"
-    h, w = d.get_envelope().height, d.get_envelope().width
-    if (h / w > MRATIO) or (w / h > MRATIO):
-        d = d.scale_y(math.log(h + 1, 2) / h).scale_x(math.log(w + 1, 2) / w)
-    return d
 
 
 def collect_grid():

--- a/triton_viz/visualizer/draw.py
+++ b/triton_viz/visualizer/draw.py
@@ -9,7 +9,6 @@ from triton_viz.core.data import (
 )
 import numpy as np
 import planar
-import math
 from ..core.trace import launches
 from ..clients.sanitizer.data import OutOfBoundsRecordBruteForce
 import sys

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -2,8 +2,6 @@ import threading
 from flask import Flask, render_template, jsonify, request
 from .analysis import analyze_records
 from .draw import get_visualization_data
-from .tooltip import get_tooltip_data
-import pandas as pd
 import os
 import torch
 from flask_cloudflared import _run_cloudflared
@@ -69,9 +67,15 @@ def update_global_data():
         if "input_data" in op_data and "other_data" in op_data:
             precomputed_c_values[uuid] = precompute_c_values(op_data)
 
-    df = pd.DataFrame(analysis_data, columns=["Metric", "Value"])
-    analysis_with_tooltip = get_tooltip_data(df)
-    global_data["analysis"] = analysis_with_tooltip
+    # Convert analysis_data to a dictionary format similar to pandas DataFrame.to_dict()
+    # analysis_data is a list of lists where each inner list contains [metric, value] pairs
+    df_dict = {"Metric": [], "Value": []}
+    for record in analysis_data:
+        for metric, value in record:
+            df_dict["Metric"].append(metric)
+            df_dict["Value"].append(value)
+
+    global_data["analysis"] = df_dict
 
 
 @app.route("/")

--- a/triton_viz/visualizer/tooltip.py
+++ b/triton_viz/visualizer/tooltip.py
@@ -14,12 +14,7 @@ tooltip_descriptions = {
 }
 
 
-def get_tooltip_data(df):
-    """Return the tooltip data in a format suitable for JSON serialization."""
-    return df.to_dict()
-
-
-def create_tooltip(df):
+def create_tooltip(df_dict):
     styles = """
     <style>
         .dataframe {
@@ -67,16 +62,20 @@ def create_tooltip(df):
     """
 
     html = styles + '<table class="dataframe"><thead><tr>'
-    for col in df.columns:
+    for col in df_dict.keys():
         html += f"<th>{col}</th>"
     html += "</tr></thead><tbody>"
 
-    for _, row in df.iterrows():
-        tooltip_text = tooltip_descriptions.get(
-            row["Metric"], "No description available."
-        )
-        html += f'<tr><td class="tooltip">{row["Metric"]}<span class="tooltiptext">{tooltip_text}</span></td>'
-        html += f'<td>{row["Value"]}</td></tr>'
+    # Iterate through rows by index
+    metrics = df_dict.get("Metric", [])
+    values = df_dict.get("Value", [])
+
+    for i in range(len(metrics)):
+        metric = metrics[i]
+        value = values[i]
+        tooltip_text = tooltip_descriptions.get(metric, "No description available.")
+        html += f'<tr><td class="tooltip">{metric}<span class="tooltiptext">{tooltip_text}</span></td>'
+        html += f"<td>{value}</td></tr>"
 
     html += "</tbody></table>"
 


### PR DESCRIPTION
- Remove chalk, chalk-diagrams from pyproject.toml and their usage from draw.py
- Remove gradio from pyproject.toml (unused dependency)
- Remove pandas and replace with built-in functions.
- Make Triton version configurable in GitHub workflow using TRITON_VERSION env var
- Remove requirements.txt

🤖 Generated with [Claude Code](https://claude.ai/code)