### PR TITLE
[OPT] Cache optimizations

### DIFF
--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -4,6 +4,7 @@ from ...core.data import Op, Load, Store
 from .data import LoadStoreBytes
 from triton.runtime.interpreter import _get_np_dtype, TensorHandle
 import numpy as np
+from typing import Callable
 
 
 class Profiler(Client):
@@ -14,7 +15,13 @@ class Profiler(Client):
         self.load_bytes = LoadStoreBytes("load", 0, 0)
         self.store_bytes = LoadStoreBytes("store", 0, 0)
 
-    def arg_callback(self, arg, arg_cvt):
+    def pre_run_callback(self, fn: Callable) -> bool:
+        return True
+    
+    def post_run_callback(self, fn: Callable) -> bool:
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
         pass
 
     def grid_idx_callback(self, grid_idx: tuple[int]):

--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -17,7 +17,7 @@ class Profiler(Client):
 
     def pre_run_callback(self, fn: Callable) -> bool:
         return True
-    
+
     def post_run_callback(self, fn: Callable) -> bool:
         return True
 

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -512,7 +512,7 @@ class SymbolicExpr:
         ),
         "addptr": Spec(req=("ptr", "offset"), post=_addptr_post),
         # Broadcasting / shape manipulation
-        "splat": Spec(req=("arg", "shape"), post=_broadcast_dtype),
+        "splat": Spec(req=("shape", "arg"), post=_broadcast_dtype),
         "expand_dims": Spec(req=("arg", "axis"), post=_broadcast_dtype),
         "broadcast": Spec(req=("arg", "shape"), post=_broadcast_dtype),
         # Casting
@@ -1348,7 +1348,7 @@ class SanitizerSymbolicExecution(Sanitizer):
             d_sym = SymbolicExpr.from_value(d)
             return SymbolicExpr("dot", a_sym, b_sym, d_sym)
 
-        def op_make_range_overrider(start, end):
+        def op_make_range_overrider(ret_ty, start, end):
             return SymbolicExpr(
                 "arange",
                 SymbolicExpr.from_value(start),
@@ -1365,8 +1365,8 @@ class SanitizerSymbolicExecution(Sanitizer):
             ret = SymbolicExpr("sum", SymbolicExpr.from_value(input), axis, keep_dims)
             return ret
 
-        def op_splat_overrider(arg, shape):
-            return SymbolicExpr("splat", SymbolicExpr.from_value(arg), shape)
+        def op_splat_overrider(shape, arg):
+            return SymbolicExpr("splat", shape, SymbolicExpr.from_value(arg))
 
         def op_make_block_ptr_overrider(
             base, shape, strides, offsets, tensor_shape, order

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -255,6 +255,7 @@ class Sanitizer(Client):
 def _get_last_grid(grid: tuple[int]) -> tuple[int]:
     return (grid[0] - 1, grid[1] - 1, grid[2] - 1)
 
+
 class SanitizerBruteForce(Sanitizer):
     def __init__(
         self,
@@ -1014,10 +1015,13 @@ class SymbolicExpr:
             result = obj.concrete_fn(obj.axis.to_py())
         elif obj.op == "arange":
             # FIXME: The "+1" is a workaround for the exclusive end in arange
-            result = obj.concrete_fn(obj.ret_ty.to_py(), obj.start.to_py(), obj.end.to_py() + 1)
+            result = obj.concrete_fn(
+                obj.ret_ty.to_py(), obj.start.to_py(), obj.end.to_py() + 1
+            )
         elif obj.op == "splat":
             result = obj.concrete_fn(
-               obj.children["shape"].to_py(), obj.arg.concretize(), 
+                obj.children["shape"].to_py(),
+                obj.arg.concretize(),
             )
         elif obj.op in SymbolicExpr.BINARY_OPS:
             result = obj.concrete_fn(
@@ -1122,7 +1126,7 @@ class LoopContext:
 
 @dataclass(frozen=True)
 class _FnSymbolicCache:
-    fn:   Callable
+    fn: Callable
     grid: tuple[int, ...]
     args: tuple
 
@@ -1135,6 +1139,7 @@ class _FnSymbolicCache:
 
 
 _fn_symbolic_cache_set: set[_FnSymbolicCache] = set()
+
 
 class SanitizerSymbolicExecution(Sanitizer):
     def __init__(self, abort_on_error: bool = False):
@@ -1196,7 +1201,9 @@ class SanitizerSymbolicExecution(Sanitizer):
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.cache_grid:
             # First time we launch this program, compute the hash
-            fn_hash = hash(_FnSymbolicCache(fn, self.cache_grid, tuple(self.cache_args)))
+            fn_hash = hash(
+                _FnSymbolicCache(fn, self.cache_grid, tuple(self.cache_args))
+            )
             self._clear_cache()
             if fn_hash not in _fn_symbolic_cache_set:
                 _fn_symbolic_cache_set.add(fn_hash)

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -2,6 +2,8 @@ import traceback
 from collections import namedtuple
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from functools import cached_property
+
 
 import numpy as np
 from torch import Tensor
@@ -225,6 +227,12 @@ class Sanitizer(Client):
 
         raise ValueError(f"Invalid TRITON_SANITIZER_BACKEND: {backend!r} ")
 
+    def pre_run_callback(self, fn: Callable) -> bool:
+        return True
+
+    def post_run_callback(self, fn: Callable) -> bool:
+        return True
+
     def arg_callback(self, *args, **kwargs):  # type: ignore[override]
         raise NotImplementedError
 
@@ -244,6 +252,9 @@ class Sanitizer(Client):
         raise NotImplementedError
 
 
+def _get_last_grid(grid: tuple[int]) -> tuple[int]:
+    return (grid[0] - 1, grid[1] - 1, grid[2] - 1)
+
 class SanitizerBruteForce(Sanitizer):
     def __init__(
         self,
@@ -254,6 +265,8 @@ class SanitizerBruteForce(Sanitizer):
         self.abort_on_error = abort_on_error
         self.tensors: list[Tensor] = []
         self.records: list = []
+        self.grid_idx = None
+        self.last_grid = None
 
     def _report(self, op_type, record):
         traceback_info = _get_traceback_info()
@@ -269,7 +282,15 @@ class SanitizerBruteForce(Sanitizer):
         else:
             self.records.append(oob_record)
 
-    def arg_callback(self, arg, arg_cvt):
+    def pre_run_callback(self, fn: Callable) -> bool:
+        return True
+
+    def post_run_callback(self, fn: Callable) -> bool:
+        if self.grid_idx == self.last_grid:
+            self.tensors.clear()
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
         if hasattr(arg, "data_ptr"):
             assert check_storage_contiguous(
                 arg
@@ -277,9 +298,10 @@ class SanitizerBruteForce(Sanitizer):
             self.tensors.append(arg)
 
     def grid_idx_callback(self, grid_idx: tuple[int]):
-        pass
+        self.grid_idx = grid_idx
 
     def grid_callback(self, grid: tuple[int]):
+        self.last_grid = _get_last_grid(grid)
         self.tensors = sorted(self.tensors, key=lambda x: x.data_ptr())
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
@@ -459,7 +481,7 @@ class SymbolicExpr:
 
     OP_SPEC = {
         # Core / primitive ops
-        "arange": Spec(req=("start", "end"), post=_arange_post),
+        "arange": Spec(req=("ret_ty", "start", "end"), post=_arange_post),
         "pid": Spec(req=("grid", "axis"), post=_pid_post),
         # Memory access ops
         "load": Spec(req=("ptr",), opt=("mask", "other"), post=_load_post),
@@ -991,10 +1013,11 @@ class SymbolicExpr:
         elif obj.op == "pid":
             result = obj.concrete_fn(obj.axis.to_py())
         elif obj.op == "arange":
-            result = obj.concrete_fn(obj.start.to_py(), obj.end.to_py() + 1)
+            # FIXME: The "+1" is a workaround for the exclusive end in arange
+            result = obj.concrete_fn(obj.ret_ty.to_py(), obj.start.to_py(), obj.end.to_py() + 1)
         elif obj.op == "splat":
             result = obj.concrete_fn(
-                obj.arg.concretize(), obj.children["shape"].to_py()
+               obj.children["shape"].to_py(), obj.arg.concretize(), 
             )
         elif obj.op in SymbolicExpr.BINARY_OPS:
             result = obj.concrete_fn(
@@ -1097,6 +1120,22 @@ class LoopContext:
     )
 
 
+@dataclass(frozen=True)
+class _FnSymbolicCache:
+    fn:   Callable
+    grid: tuple[int, ...]
+    args: tuple
+
+    @cached_property
+    def _hash(self):
+        return hash((self.fn, self.grid, self.args))
+
+    def __hash__(self):
+        return self._hash
+
+
+_fn_symbolic_cache_set: set[_FnSymbolicCache] = set()
+
 class SanitizerSymbolicExecution(Sanitizer):
     def __init__(self, abort_on_error: bool = False):
         self.abort_on_error: bool = abort_on_error
@@ -1107,6 +1146,9 @@ class SanitizerSymbolicExecution(Sanitizer):
         self.unique_load_store_id: int = 0
         self.need_full_grid: bool = False
         self.loop_stack: list[LoopContext] = []
+        self.last_grid: tuple[int, ...] | None = None
+        self.cache_args = []
+        self.cache_grid = None
         SymbolicExpr.set_loop_ctx_provider(
             lambda: self.loop_stack[-1] if self.loop_stack else None
         )
@@ -1147,8 +1189,34 @@ class SanitizerSymbolicExecution(Sanitizer):
         else:
             self.records.append(oob_record)
 
-    def arg_callback(self, arg, arg_cvt):
+    def _clear_cache(self):
+        self.cache_args.clear()
+        self.cache_grid = None
+
+    def pre_run_callback(self, fn: Callable) -> bool:
+        if self.cache_grid:
+            # First time we launch this program, compute the hash
+            fn_hash = hash(_FnSymbolicCache(fn, self.cache_grid, tuple(self.cache_args)))
+            self._clear_cache()
+            if fn_hash not in _fn_symbolic_cache_set:
+                _fn_symbolic_cache_set.add(fn_hash)
+                # Must continue to run the program at least once
+                # We don't clear up tensors at this point
+                return True
+        # 2nd time we launch this program, depends on whether we need a full grid
+        return self.need_full_grid
+
+    def post_run_callback(self, fn: Callable) -> None:
+        if self.grid_idx == self.last_grid or not self.need_full_grid:
+            self._clear_cache()
+            self.tensors.clear()
+            self.tensor_addrs.clear()
+        return self.need_full_grid
+
+    def arg_callback(self, name, arg, arg_cvt):
         if not hasattr(arg, "data_ptr"):
+            if name not in ["num_warps", "num_stages", "maxnreg", "num_ctas"]:
+                self.cache_args.append(arg)
             return
         if arg.is_contiguous or check_storage_contiguous(arg):
             start = arg.data_ptr()
@@ -1160,11 +1228,14 @@ class SanitizerSymbolicExecution(Sanitizer):
             raise ValueError(
                 "The address sanitizer only supports contiguouly stored tensors for now!"
             )
-
+        # To uniquely identify the metadata of a tensor
+        self.cache_args.append((arg.shape, arg.stride(), arg.dtype))
         self.tensors.append(arg)
         self.tensor_addrs.extend(tensor_physical_addresses)
 
     def grid_callback(self, grid: tuple[int]) -> None:
+        self.cache_grid = grid
+        self.last_grid = _get_last_grid(grid)
         self.grid = tuple(int(g) for g in grid)
         addr = Int("addr")
         self._addr_ok = Or(*[And(addr >= s, addr <= e) for s, e in self.tensor_addrs])
@@ -1172,7 +1243,7 @@ class SanitizerSymbolicExecution(Sanitizer):
         self._addr_sym = addr
 
     def grid_idx_callback(self, grid_idx: tuple[int]):
-        pass
+        self.grid_idx = grid_idx
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
         def op_program_id_overrider(axis):
@@ -1351,6 +1422,7 @@ class SanitizerSymbolicExecution(Sanitizer):
         def op_make_range_overrider(ret_ty, start, end):
             return SymbolicExpr(
                 "arange",
+                SymbolicExpr.from_value(ret_ty),
                 SymbolicExpr.from_value(start),
                 SymbolicExpr.from_value(end - 1),
             )
@@ -1362,8 +1434,7 @@ class SanitizerSymbolicExecution(Sanitizer):
             return SymbolicExpr("broadcast", SymbolicExpr.from_value(arg), shape)
 
         def op_reduce_sum_overrider(input, axis=None, keep_dims=False, **kwargs):
-            ret = SymbolicExpr("sum", SymbolicExpr.from_value(input), axis, keep_dims)
-            return ret
+            return SymbolicExpr("sum", SymbolicExpr.from_value(input), axis, keep_dims)
 
         def op_splat_overrider(shape, arg):
             return SymbolicExpr("splat", shape, SymbolicExpr.from_value(arg))

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -1,6 +1,7 @@
 from ...core.client import Client
 from ...core.callbacks import OpCallbacks
 from ...core.data import Op, Load, Store, ReduceSum, Dot, Grid
+from typing import Callable
 import numpy as np
 
 
@@ -40,7 +41,13 @@ class Tracer(Client):
             ret_idx = i
         return self.tensors[ret_idx]
 
-    def arg_callback(self, arg, arg_cvt):
+    def pre_run_callback(self, fn: Callable) -> bool:
+        return True
+
+    def post_run_callback(self, fn: Callable) -> bool:
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
         if hasattr(arg, "data_ptr"):
             self.tensors.append(arg)
 
@@ -107,4 +114,5 @@ class Tracer(Client):
         return None, None, None
 
     def finalize(self) -> list:
+        self.tensors.clear()
         return self.records

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -22,16 +22,16 @@ class Client(ABC):
 
     @abstractmethod
     def pre_run_callback(self, fn: Callable) -> bool:
-        '''
+        """
         Returns True if the function should continue running, False if it should be skipped.
-        '''
+        """
         ...
 
     @abstractmethod
     def post_run_callback(self, fn: Callable) -> bool:
-        '''
+        """
         Returns True if the function should continue running, False if it should be skipped.
-        '''
+        """
         ...
 
     @abstractmethod

--- a/triton_viz/core/data.py
+++ b/triton_viz/core/data.py
@@ -201,5 +201,5 @@ class Grid:
 @dataclass
 class Launch:
     grid: tuple | None = None
-    tensors: list[Tensor] = field(default_factory=list)
+    tensors: set[Tensor] = field(default_factory=set)
     records: list = field(default_factory=list)

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -360,7 +360,7 @@ def unpatch_lang():
 def _grid_executor_call(self, *args_dev, **kwargs):
     if kwargs.pop("warmup", False):
         return
-    
+
     def run_grid_loops(grid):
         for x in tqdm(
             range(grid[0]),

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -1,4 +1,4 @@
-from triton.runtime import KernelInterface
+from triton.runtime import KernelInterface, Autotuner
 from triton.runtime.interpreter import InterpretedFunction
 from triton import JITFunction
 
@@ -10,6 +10,10 @@ from .data import Launch
 
 launches: list[Launch] = []
 
+
+def dummy_benchmarker(fn, quantiles):
+    fn()
+    return (1.0, 1.0, 1.0)
 
 class Trace(KernelInterface):
     @staticmethod
@@ -37,9 +41,16 @@ class Trace(KernelInterface):
         client: str | Client,
     ) -> None:
         self.fn = kernel
-        if isinstance(kernel, InterpretedFunction):
+        if isinstance(kernel, Autotuner):
+            self.base_fn = kernel.base_fn
+            kernel._do_bench = dummy_benchmarker
+            kernel.fn = InterpretedFunction(kernel.base_fn)
+            self.interpreter_fn = kernel
+        elif isinstance(kernel, InterpretedFunction):
+            self.base_fn = kernel.fn
             self.interpreter_fn = kernel
         elif isinstance(kernel, JITFunction):
+            self.base_fn = kernel.fn
             self.interpreter_fn = InterpretedFunction(kernel.fn)
         else:
             raise TypeError(
@@ -50,7 +61,7 @@ class Trace(KernelInterface):
         self.add_client(client)
 
     def run(self, *args, **kwargs):
-        with self.client_manager.patch():
+        with self.client_manager.patch(self.base_fn):
             kwargs.update({"client_manager": self.client_manager})
             ret = self.interpreter_fn.run(*args, **kwargs)
             self.finalize()
@@ -83,7 +94,7 @@ def trace(clients: str | Client | None = None):
             return kernel
 
         # First-time wrapping
-        if isinstance(kernel, (JITFunction, InterpretedFunction)):
+        if isinstance(kernel, (JITFunction, InterpretedFunction, Autotuner)):
             return Trace(kernel, clients)
 
         # If the object is already a Trace, just append the new client(s)

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -15,6 +15,7 @@ def dummy_benchmarker(fn, quantiles):
     fn()
     return (1.0, 1.0, 1.0)
 
+
 class Trace(KernelInterface):
     @staticmethod
     def _normalize_client(client: str | Client) -> Client:


### PR DESCRIPTION
Essentially our optimizations can be categorized as 4d caches

1. control flow cache. caching variables across iterations
2. triton program cache. caching parallel ids across multiple triton programs
3. launch cache. if a function is run multiple times with the same inputs, we can skip the rest and only run once. 
4. jit cache or semantic. Even when kernels are invoked with different inputs, some of them may not impact the checking results, like number of warps or the values stored on the tensor.

Reducing time from 28s -> 0.9s