### PR TITLE
[DEV] Add enhanced PDB-style diagnostic report for OOB errors

### DIFF
--- a/examples/ima_example.py
+++ b/examples/ima_example.py
@@ -11,7 +11,7 @@ cfg.sanitizer_backend = "symexec"
 
 
 @triton.jit
-def kernel_B(ptr, offset):
+def inner(ptr, offset):
     # a simple function that adds 1
     val = tl.load(ptr + offset)
     return val + 1
@@ -19,19 +19,16 @@ def kernel_B(ptr, offset):
 
 @triton_viz.trace(clients=Sanitizer(abort_on_error=True))
 @triton.jit
-def kernel_A(ptr, n):
+def kernel(ptr, n):
     pid = tl.program_id(0)
     # if pid >= n, there will be an out-of-bounds error
-    val = kernel_B(ptr, pid)
+    val = inner(ptr, pid)
     tl.store(ptr + pid, val)
 
 
 if __name__ == "__main__":
     x = torch.arange(4, dtype=torch.float32)
-    print("Input:", x)
 
     # We'll launch a grid bigger than x.numel() to force a out-of-bounds error
     grid = (x.numel() + 4,)
-    kernel_A[grid](x, x.numel())
-
-    print("Output:", x)
+    kernel[grid](x, x.numel())

--- a/triton_viz/clients/sanitizer/data.py
+++ b/triton_viz/clients/sanitizer/data.py
@@ -2,7 +2,7 @@ from ...core.data import Store, Load
 import numpy as np
 from numpy.typing import NDArray
 from dataclasses import dataclass
-from typing import Union
+from typing import Union, Any
 import torch
 import z3
 
@@ -51,7 +51,11 @@ class OutOfBoundsRecordZ3(OutOfBoundsRecord):
 
             In this scenario, 200 is an out-of-bounds address because it
             falls outside the valid ranges described by these constraints.
+
+        symbolic_expr (Optional[Any]):
+            The symbolic expression tree that led to the OOB access, if available.
     """
 
     constraints: list[z3.z3.BoolRef]
     violation_address: int
+    symbolic_expr: "Any" = None  # Optional symbolic expression tree


### PR DESCRIPTION
This commit introduces a comprehensive diagnostic reporting system for out-of-bounds memory access errors in the Triton sanitizer, providing developers with rich context for debugging.

Key improvements:
- Add print_oob_record_pdb_style() function with enhanced visual formatting
- Display PDB-style code context with line numbers and surrounding context
- Show comprehensive tensor information (dtype, shape, strides, memory range)
- Provide clear call stack with proper frame ordering
- Visualize symbolic expression trees that led to violations
- Use ANSI colors for better readability (red for stores, yellow for loads)

Fix traceback extraction to correctly identify user code:
- Rewrite _get_traceback_info() to intelligently filter framework code
- Properly handle nested @triton.jit function calls
- Show the actual error location (e.g., kernel_B line 16) before callers
- Remove duplicate traceback entries while preserving order

Enhance symbolic execution integration:
- Update OutOfBoundsRecordZ3 to store symbolic expressions
- Modify _report() to pass symbolic expressions through the pipeline
- Add _check_range_satisfiable_with_expr() for expression-aware checking
- Update LoopContext to track expressions alongside Z3 constraints
- Ensure deferred loop checks preserve symbolic expression data

This provides developers with a complete picture of memory violations, from the exact problematic code line to the underlying symbolic computation that caused the error, significantly improving debugging efficiency.

🤖 Generated with Claude Code