### PR TITLE
[REFACTOR] Introduce ForLoopCallbacks dataclass for better encapsulation

### DIFF
--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -1,5 +1,5 @@
 from ...core.client import Client
-from ...core.callbacks import OpCallbacks
+from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import Op, Load, Store
 from .data import LoadStoreBytes
 from triton.runtime.interpreter import _get_np_dtype, TensorHandle
@@ -61,7 +61,7 @@ class Profiler(Client):
         return OpCallbacks()
 
     def register_for_loop_callback(self):
-        return None, None, None, None
+        return ForLoopCallbacks()
 
     def finalize(self) -> list:
         return [self.load_bytes, self.store_bytes]

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -28,7 +28,7 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 from ...core.client import Client
-from ...core.callbacks import OpCallbacks
+from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import (
     Op,
     RawLoad,
@@ -573,7 +573,7 @@ class SanitizerBruteForce(Sanitizer):
         return OpCallbacks()
 
     def register_for_loop_callback(self):
-        return None, None, None, None
+        return ForLoopCallbacks()
 
     def finalize(self) -> list:
         return self.records
@@ -2004,11 +2004,11 @@ class SanitizerSymbolicExecution(Sanitizer):
                     f"(checked {len(ctx.pending_checks)} unique addr patterns)"
                 )
 
-        return (
-            loop_hook_before,
-            loop_hook_iter_overrider,
-            loop_hook_iter_listener,
-            loop_hook_after,
+        return ForLoopCallbacks(
+            before_loop_callback=loop_hook_before,
+            loop_iter_overrider=loop_hook_iter_overrider,
+            loop_iter_listener=loop_hook_iter_listener,
+            after_loop_callback=loop_hook_after,
         )
 
     def finalize(self) -> list:

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -1,5 +1,5 @@
 from ...core.client import Client
-from ...core.callbacks import OpCallbacks
+from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import Op, Load, Store, ReduceSum, Dot, Grid
 from typing import Callable, Optional, Union
 import numpy as np
@@ -111,7 +111,7 @@ class Tracer(Client):
         return OpCallbacks()
 
     def register_for_loop_callback(self):
-        return None, None, None
+        return ForLoopCallbacks()
 
     def finalize(self) -> list:
         self.tensors.clear()

--- a/triton_viz/core/callbacks.py
+++ b/triton_viz/core/callbacks.py
@@ -8,3 +8,11 @@ class OpCallbacks:
     before_callback: Optional[Callable] = None
     after_callback: Optional[Callable] = None
     op_overrider: Optional[Callable] = None
+
+
+@dataclass
+class ForLoopCallbacks:
+    before_loop_callback: Optional[Callable] = None
+    loop_iter_overrider: Optional[Callable] = None
+    loop_iter_listener: Optional[Callable] = None
+    after_loop_callback: Optional[Callable] = None

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -13,7 +13,7 @@ from .patch import (
     op_list,
     patch_calls,
 )
-from .callbacks import OpCallbacks
+from .callbacks import OpCallbacks, ForLoopCallbacks
 from .patch import patch_lang, unpatch_lang
 
 
@@ -51,11 +51,7 @@ class Client(ABC):
         ...
 
     @abstractmethod
-    def register_for_loop_callback(
-        self,
-    ) -> tuple[
-        Optional[Callable], Optional[Callable], Optional[Callable], Optional[Callable]
-    ]:
+    def register_for_loop_callback(self) -> ForLoopCallbacks:
         ...
 
     @abstractmethod
@@ -93,18 +89,8 @@ class ClientManager:
                     patch_op(op, callbacks)
 
                 # patch for loops
-                (
-                    before_loop_callback,
-                    loop_iter_overrider,
-                    loop_iter_listener,
-                    after_loop_callback,
-                ) = client.register_for_loop_callback()
-                patch_for_loop(
-                    before_loop_callback,
-                    loop_iter_overrider,
-                    loop_iter_listener,
-                    after_loop_callback,
-                )
+                loop_callbacks = client.register_for_loop_callback()
+                patch_for_loop(loop_callbacks)
                 # Remaps core language functions to interpreted ones
                 patch_lang(fn)
             try:

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from tqdm import tqdm
 
 from . import config as cfg
-from .callbacks import OpCallbacks
+from .callbacks import OpCallbacks, ForLoopCallbacks
 from .data import (
     Op,
     RawLoad,
@@ -395,23 +395,18 @@ def _visit_For(self, node: ast.For):  # type: ignore[override]
     return ast.fix_missing_locations(new_for)
 
 
-def patch_for_loop(
-    before_loop_callback: Optional[Callable],
-    loop_iter_overrider: Optional[Callable],
-    loop_iter_listener: Optional[Callable],
-    after_loop_callback: Optional[Callable],
-):
+def patch_for_loop(loop_callbacks: ForLoopCallbacks):
     _loop_patcher.patch()
 
     # Registering hooks
-    if before_loop_callback is not None:
-        _loop_patcher.hooks.add_before(before_loop_callback)
-    if loop_iter_overrider is not None:
-        _loop_patcher.hooks.set_iter_overrider(loop_iter_overrider)
-    if loop_iter_listener is not None:
-        _loop_patcher.hooks.add_iter_listener(loop_iter_listener)
-    if after_loop_callback is not None:
-        _loop_patcher.hooks.add_after(after_loop_callback)
+    if loop_callbacks.before_loop_callback is not None:
+        _loop_patcher.hooks.add_before(loop_callbacks.before_loop_callback)
+    if loop_callbacks.loop_iter_overrider is not None:
+        _loop_patcher.hooks.set_iter_overrider(loop_callbacks.loop_iter_overrider)
+    if loop_callbacks.loop_iter_listener is not None:
+        _loop_patcher.hooks.add_iter_listener(loop_callbacks.loop_iter_listener)
+    if loop_callbacks.after_loop_callback is not None:
+        _loop_patcher.hooks.add_after(loop_callbacks.after_loop_callback)
 
 
 def unpatch_for_loop():


### PR DESCRIPTION
- Add ForLoopCallbacks dataclass in core/callbacks.py to encapsulate loop-related callbacks
- Update profiler, sanitizer, and tracer clients to return ForLoopCallbacks objects instead of tuples
- Refactor patch_for_loop() to accept ForLoopCallbacks object as single parameter
- Update Client abstract class to use ForLoopCallbacks return type
- Improve code consistency with OpCallbacks pattern