### PR TITLE
[FIX] Simplify idiv operator check in SymbolicExpr Z3 conversion

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -1118,7 +1118,7 @@ class SymbolicExpr:
                 self._z3 = lhs - rhs
             if self.op == "mul":
                 self._z3 = lhs * rhs
-            if self.op in ("idiv"):
+            if self.op == "idiv":
                 self._z3 = lhs / rhs
             if self.op == "mod":
                 self._z3 = lhs % rhs


### PR DESCRIPTION
Changed tuple check `if self.op in ("idiv")` to direct comparison `if self.op == "idiv"` for better readability and consistency with other operator checks.