### PR TITLE
[REFACTOR] Replace sanitizer backend config with disable flag

### DIFF
--- a/examples/ima_example.py
+++ b/examples/ima_example.py
@@ -4,10 +4,6 @@ import triton.language as tl
 
 import triton_viz
 from triton_viz.clients import Sanitizer
-from triton_viz import config as cfg
-
-
-cfg.sanitizer_backend = "symexec"
 
 
 @triton.jit

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -12,10 +12,6 @@ import triton.language as tl
 
 import triton_viz
 from triton_viz.clients import Sanitizer
-from triton_viz import config as cfg
-
-
-cfg.sanitizer_backend = "symexec"
 
 
 # ======== Trace Decorator Tests =========
@@ -30,9 +26,6 @@ def test_trace_decorator_add_clients():
     The final Trace object should contain exactly one instance each of
     Sanitizer, Profiler, and Tracer (total = 3 clients).
     """
-
-    # Make sure sanitizer is on.
-    cfg.sanitizer_backend = "symexec"
 
     @triton_viz.trace("sanitizer")
     @triton_viz.trace("profiler")
@@ -108,7 +101,6 @@ def test_cli_invocation():
         # load sitecustomize.py
         env = os.environ.copy()
         env["PYTHONPATH"] = str(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
-        env["TRITON_SANITIZER_BACKEND"] = "symexec"
         env["TRITON_INTERPRET"] = "1"
 
         # run the dummy program using triton-sanitizer
@@ -161,7 +153,6 @@ if torch.cuda.is_available():  # Only test if CUDA is available
         This test uses n_elements = 128, matching the size of the input tensors.
         It should NOT cause any out-of-bound access.
         """
-        cfg.sanitizer_backend = "symexec"
         x = torch.randn(128)
         y = torch.randn(128)
         out = torch.empty_like(x)
@@ -175,7 +166,6 @@ if torch.cuda.is_available():  # Only test if CUDA is available
         This test deliberately sets n_elements = 256, exceeding the actual buffer size (128).
         It will likely cause out-of-bound reads/writes, which may trigger errors or warnings.
         """
-        cfg.sanitizer_backend = "symexec"
         x = torch.randn(128)
         y = torch.randn(128)
         out = torch.empty_like(x)

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -1,6 +1,7 @@
 import pytest
 import torch
 import numpy as np
+from unittest.mock import patch
 
 import triton
 import triton.language as tl
@@ -13,29 +14,19 @@ from triton_viz.core.client import Client
 from triton_viz.clients import Sanitizer
 from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicExpr,
-    SanitizerBruteForce,
     NullSanitizer,
     SanitizerSymbolicExecution,
 )
 
-cfg.sanitizer_backend = "symexec"
-
 
 # ======== Init ===========
-def test_init_brute_force():
-    cfg.sanitizer_backend = "brute_force"
-    s1 = Sanitizer(abort_on_error=True)
-    assert isinstance(s1, SanitizerBruteForce) and s1.abort_on_error is True
-
-
 def test_init_null_sanitizer():
-    cfg.sanitizer_backend = "off"
-    s2 = Sanitizer(abort_on_error=True)
-    assert isinstance(s2, NullSanitizer)
+    with patch.object(cfg, "disable_sanitizer", True):
+        s2 = Sanitizer(abort_on_error=True)
+        assert isinstance(s2, NullSanitizer)
 
 
 def test_init_symbolic_execution():
-    cfg.sanitizer_backend = "symexec"
     s3 = Sanitizer(abort_on_error=True)
     assert isinstance(s3, SanitizerSymbolicExecution) and s3.abort_on_error is True
 
@@ -82,9 +73,9 @@ def null_sanitizer_kernel(idx_ptr):
 
 
 def test_null_sanitizer():
-    cfg.sanitizer_backend = "off"
-    idx = torch.arange(128, dtype=torch.int32)
-    null_sanitizer_kernel[(1,)](idx)
+    with patch.object(cfg, "disable_sanitizer", True):
+        idx = torch.arange(128, dtype=torch.int32)
+        null_sanitizer_kernel[(1,)](idx)
 
 
 # ======== Indirect Load/Store =========
@@ -191,7 +182,6 @@ def indirect_load_kernel(idx_ptr, src_ptr, dst_ptr, BLOCK_SIZE: tl.constexpr):
 
 
 def test_indirect_load():
-    cfg.sanitizer_backend = "symexec"
     idx = torch.arange(128, dtype=torch.int32)
     src = torch.rand(128)
     dst = torch.empty_like(src)
@@ -229,7 +219,6 @@ def triple_indirect_load_kernel(
 
 
 def test_triple_indirect_load(device):
-    cfg.sanitizer_backend = "symexec"
     N = 128
 
     src = torch.rand(N, device=device, dtype=torch.float32)
@@ -277,7 +266,6 @@ def dual_offset_load_kernel(
 
 
 def test_dual_offset_load(device):
-    cfg.sanitizer_backend = "symexec"
     N = 128
 
     src = torch.rand(N, device=device, dtype=torch.float32)
@@ -307,21 +295,21 @@ def test_dual_offset_load(device):
 # ======== Sanitizer Backend Tests =========
 def test_switch_backend():
     """Switch back and forth at runtime."""
-    original = cfg.sanitizer_backend
+    original = cfg.disable_sanitizer
 
-    cfg.sanitizer_backend = "symexec"
-    assert cfg.sanitizer_backend == "symexec"
+    cfg.disable_sanitizer = False  # Enable sanitizer
+    assert cfg.disable_sanitizer is False
 
-    cfg.sanitizer_backend = "off"
-    assert cfg.sanitizer_backend == "off"
+    cfg.disable_sanitizer = True  # Disable sanitizer
+    assert cfg.disable_sanitizer is True
 
-    cfg.sanitizer_backend = original
+    cfg.disable_sanitizer = original
 
 
 def test_invalid_backend_raises():
-    """Setting an unknown backend should raise ValueError."""
-    with pytest.raises(ValueError):
-        cfg.sanitizer_backend = "does_not_exist"
+    """Setting a non-boolean value should raise TypeError."""
+    with pytest.raises(TypeError):
+        cfg.disable_sanitizer = "not_a_bool"
 
 
 # ======== For-Loop Optimization Tests =========

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -442,7 +442,7 @@ class LoopContext:
 class Sanitizer(Client):
     """
     Factory class that returns the concrete sanitizer implementation
-    based on the value of ``cfg.sanitizer_backend``.
+    based on the value of ``cfg.disable_sanitizer``.
     """
 
     NAME = "sanitizer"
@@ -453,18 +453,11 @@ class Sanitizer(Client):
 
         cfg.sanitizer_activated = True
 
-        backend = cfg.sanitizer_backend
-
-        if backend == "brute_force":
-            return object.__new__(SanitizerBruteForce)
-
-        if backend == "symexec":
-            return object.__new__(SanitizerSymbolicExecution)
-
-        if backend == "off":
+        if cfg.disable_sanitizer:
             return object.__new__(NullSanitizer)
-
-        raise ValueError(f"Invalid TRITON_SANITIZER_BACKEND: {backend!r} ")
+        else:
+            # When sanitizer is enabled, use symexec backend by default
+            return object.__new__(SanitizerSymbolicExecution)
 
     def pre_run_callback(self, fn: Callable) -> bool:
         return True

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -91,8 +91,8 @@ def trace(clients: Union[str, Client, None] = None):
         raise TypeError(f"Expected str or Client, got {type(clients)}")
 
     def decorator(kernel) -> Trace:
-        # When sanitizer is off, skip tracing and return the original kernel unchanged
-        if cfg.sanitizer_backend == "off":
+        # When sanitizer is disabled, skip tracing and return the original kernel unchanged
+        if cfg.disable_sanitizer:
             return kernel
 
         # First-time wrapping

--- a/triton_viz/wrapper.py
+++ b/triton_viz/wrapper.py
@@ -3,7 +3,6 @@ import sys
 import triton
 import triton_viz
 from triton_viz.clients import Sanitizer
-from triton_viz import config as cfg
 
 
 # store the original triton.jit
@@ -72,8 +71,6 @@ def apply():
 
 
 def enable_sanitizer():
-    cfg.sanitizer_backend = "symexec"
-
     triton.jit = _patched_jit
     triton.language.jit = _patched_jit
     import triton.runtime.interpreter as _interp


### PR DESCRIPTION
Simplified sanitizer configuration by replacing the backend selection mechanism with a simple disable_sanitizer boolean flag. The symbolic execution backend is now the default when sanitizer is enabled. See #109.