### PR TITLE
[DEV] Add support for `create_bitcast` operation in sanitizer

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -62,6 +62,7 @@ from ...core.data import (
     Umulhi,
     Trans,
     CumSum,
+    Bitcast,
 )
 from ..utils import (
     check_out_of_bounds_access,
@@ -705,7 +706,7 @@ class SymbolicExpr:
     SCAN_OPS = ("cumsum",)
     POINTER_OPS = ("make_block_ptr", "addptr", "advance")
     BROADCAST_OPS = ("splat", "expand_dims", "broadcast", "reshape")
-    CAST_OPS = ("cast_impl",)
+    CAST_OPS = ("cast_impl", "bitcast")
     SUPPORTED_OPS = (
         BASIC_OPS
         + INDIRECT_OPS
@@ -789,6 +790,7 @@ class SymbolicExpr:
         "reshape": Spec(req=("arg", "shape"), post=_broadcast_dtype),
         # Casting
         "cast_impl": Spec(req=("src", "dst_type"), post=_cast_impl_post),
+        "bitcast": Spec(req=("src", "dst_type"), post=_cast_impl_post),
         # Misc
         "advance": Spec(req=("ptr", "offsets")),
         "umulhi": Spec(req=("lhs", "rhs")),
@@ -1204,8 +1206,8 @@ class SymbolicExpr:
             else:
                 self._z3 = ptr_z3 + offset_z3 * element_bytewidth
 
-        if self.op == "cast_impl":
-            # Cast operation - pass through the source value
+        if self.op in ("cast_impl", "bitcast"):
+            # Cast/bitcast operation - pass through the source value
             self._z3, self._constraints = self.src._to_z3()
 
         if self.op == "advance":
@@ -1356,10 +1358,22 @@ class SymbolicExpr:
                 None,  # is_volatile
             )
         else:
-            concrete_args = [
-                SymbolicExpr.concretize(v) for k, v in obj.children.items()
-            ]
-            result = obj.concrete_fn(*concrete_args)
+            # Special handling for cast_impl and bitcast operations
+            if obj.op in ("cast_impl", "bitcast"):
+                from ...core.patch import original_ops
+                from ...core.data import CastImpl, Bitcast
+                src_concrete = obj.src.concretize()
+                # dst_type is stored as a SymbolicExpr const node, need to extract the value
+                dst_type_value = obj.dst_type.value if hasattr(obj.dst_type, 'value') else obj.dst_type
+                if obj.op == "cast_impl":
+                    result = original_ops[CastImpl](src_concrete, dst_type_value)
+                else:  # bitcast
+                    result = original_ops[Bitcast](src_concrete, dst_type_value)
+            else:
+                concrete_args = [
+                    SymbolicExpr.concretize(v) for k, v in obj.children.items()
+                ]
+                result = obj.concrete_fn(*concrete_args)
 
         return result
 
@@ -1896,6 +1910,12 @@ class SanitizerSymbolicExecution(Sanitizer):
                 "cumsum", SymbolicExpr.from_value(input), axis, reverse, dtype
             )
 
+        def op_bitcast_overrider(src, dst_type):
+            src_sym = SymbolicExpr.from_value(src)
+            result = SymbolicExpr("bitcast", src_sym, dst_type)
+            result.dtype_tt = dst_type
+            return result
+
         OP_TYPE_TO_OVERRIDER: dict[type[Op], Callable] = {
             ProgramId: op_program_id_overrider,
             RawLoad: op_raw_load_overrider,
@@ -1928,6 +1948,7 @@ class SanitizerSymbolicExecution(Sanitizer):
             Umulhi: op_umulhi_overrider,
             Trans: op_trans_overrider,
             CumSum: op_cumsum_overrider,
+            Bitcast: op_bitcast_overrider,
         }
 
         if op_type in OP_TYPE_TO_OVERRIDER:

--- a/triton_viz/core/data.py
+++ b/triton_viz/core/data.py
@@ -224,6 +224,11 @@ class CumSum(Op):
 
 
 @dataclass
+class Bitcast(Op):
+    name: ClassVar[str] = "bitcast"
+
+
+@dataclass
 class Tensor:
     ptr: int
     dtype: str

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -39,6 +39,7 @@ from .data import (
     Umulhi,
     Trans,
     CumSum,
+    Bitcast,
 )
 import inspect
 import ast
@@ -83,6 +84,7 @@ op_list = [
     Umulhi,
     Trans,
     CumSum,
+    Bitcast,
 ]
 
 # Hardcoded operation attribute names to avoid issues with lambda functions
@@ -114,6 +116,7 @@ _OP_ATTR_NAMES = {
     FpToFp: "create_fp_to_fp",
     Umulhi: "create_umulhi",
     Trans: "create_trans",
+    Bitcast: "create_bitcast",
 }
 
 original_ops = {
@@ -144,6 +147,7 @@ original_ops = {
     FpToFp: interpreter_builder.create_fp_to_fp,
     Umulhi: interpreter_builder.create_umulhi,
     Trans: interpreter_builder.create_trans,
+    Bitcast: interpreter_builder.create_bitcast,
 }
 reduce_map: dict[type[Op], Callable] = {
     ReduceMax: tl.max,


### PR DESCRIPTION
- Add Bitcast operation class to data.py
- Import and map create_bitcast in patch.py
- Implement op_bitcast_overrider in sanitizer.py
- Add bitcast to CAST_OPS and OP_SPEC
- Handle bitcast in concretize method for proper type extraction

Fixes #155.