### PR TITLE
[DEV] Add support for `create_atomic_cas` operation in sanitizer

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -63,6 +63,7 @@ from ...core.data import (
     Trans,
     CumSum,
     Bitcast,
+    AtomicCas,
 )
 from ..utils import (
     check_out_of_bounds_access,
@@ -707,6 +708,7 @@ class SymbolicExpr:
     POINTER_OPS = ("make_block_ptr", "addptr", "advance")
     BROADCAST_OPS = ("splat", "expand_dims", "broadcast", "reshape")
     CAST_OPS = ("cast_impl", "bitcast")
+    ATOMIC_OPS = ("atomic_cas",)
     SUPPORTED_OPS = (
         BASIC_OPS
         + INDIRECT_OPS
@@ -718,6 +720,7 @@ class SymbolicExpr:
         + BROADCAST_OPS
         + CAST_OPS
         + SCAN_OPS
+        + ATOMIC_OPS
     )
 
     OP_SPEC = {
@@ -791,6 +794,8 @@ class SymbolicExpr:
         # Casting
         "cast_impl": Spec(req=("src", "dst_type"), post=_cast_impl_post),
         "bitcast": Spec(req=("src", "dst_type"), post=_cast_impl_post),
+        # Atomic operations
+        "atomic_cas": Spec(req=("ptr", "cmp", "val")),
         # Misc
         "advance": Spec(req=("ptr", "offsets")),
         "umulhi": Spec(req=("lhs", "rhs")),
@@ -1209,6 +1214,9 @@ class SymbolicExpr:
         if self.op in ("cast_impl", "bitcast"):
             # Cast/bitcast operation - pass through the source value
             self._z3, self._constraints = self.src._to_z3()
+
+        if self.op == "atomic_cas":
+            raise NotImplementedError("atomic_cas operation is not implemented yet")
 
         if self.op == "advance":
             raise NotImplementedError("Advance operation is not implemented yet")
@@ -1921,6 +1929,15 @@ class SanitizerSymbolicExecution(Sanitizer):
             result.dtype_tt = dst_type
             return result
 
+        def op_atomic_cas_overrider(ptr, cmp, val, sem, scope):
+            ptr_sym = SymbolicExpr.from_value(ptr)
+            cmp_sym = SymbolicExpr.from_value(cmp)
+            val_sym = SymbolicExpr.from_value(val)
+            # sem is a MEM_SEMANTIC enum, not a regular value, so we pass it directly
+            result = SymbolicExpr("atomic_cas", ptr_sym, cmp_sym, val_sym)
+            result.sem = sem  # Store sem as an attribute
+            return result
+
         OP_TYPE_TO_OVERRIDER: dict[type[Op], Callable] = {
             ProgramId: op_program_id_overrider,
             RawLoad: op_raw_load_overrider,
@@ -1954,6 +1971,7 @@ class SanitizerSymbolicExecution(Sanitizer):
             Trans: op_trans_overrider,
             CumSum: op_cumsum_overrider,
             Bitcast: op_bitcast_overrider,
+            AtomicCas: op_atomic_cas_overrider,
         }
 
         if op_type in OP_TYPE_TO_OVERRIDER:

--- a/triton_viz/core/data.py
+++ b/triton_viz/core/data.py
@@ -229,6 +229,11 @@ class Bitcast(Op):
 
 
 @dataclass
+class AtomicCas(Op):
+    name: ClassVar[str] = "atomic_cas"
+
+
+@dataclass
 class Tensor:
     ptr: int
     dtype: str

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -40,6 +40,7 @@ from .data import (
     Trans,
     CumSum,
     Bitcast,
+    AtomicCas,
 )
 import inspect
 import ast
@@ -85,6 +86,7 @@ op_list = [
     Trans,
     CumSum,
     Bitcast,
+    AtomicCas,
 ]
 
 # Hardcoded operation attribute names to avoid issues with lambda functions
@@ -117,6 +119,7 @@ _OP_ATTR_NAMES = {
     Umulhi: "create_umulhi",
     Trans: "create_trans",
     Bitcast: "create_bitcast",
+    AtomicCas: "create_atomic_cas",
 }
 
 original_ops = {
@@ -148,6 +151,7 @@ original_ops = {
     Umulhi: interpreter_builder.create_umulhi,
     Trans: interpreter_builder.create_trans,
     Bitcast: interpreter_builder.create_bitcast,
+    AtomicCas: interpreter_builder.create_atomic_cas,
 }
 reduce_map: dict[type[Op], Callable] = {
     ReduceMax: tl.max,


### PR DESCRIPTION
Following the pattern from create_bitcast (commit ebaf133), this commit adds support for the atomic_cas operation:
- Added AtomicCas class to data.py
- Registered AtomicCas in patch.py op_list and mappings
- Added atomic_cas support in sanitizer with special handling for MEM_SEMANTIC parameter
- Raises NotImplementedError in Z3 conversion as atomic operations require synchronization semantics

Fixes #165.