### PR TITLE
[FIX] Add missing tl.int1 to triton_scala_dtypes in sanitizer

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -983,6 +983,7 @@ class SymbolicExpr:
         return SymbolicExprDataWrapper(self.__str__(), self)
 
     triton_scala_dtypes = (
+        tl.int1,
         tl.int8,
         tl.int16,
         tl.int32,


### PR DESCRIPTION
Added tl.int1 (boolean type) to the triton_scala_dtypes tuple to ensure proper handling of boolean scalar types in the sanitizer.