### PR TITLE
[REFACTOR][CONFIG] Replace dynamic config module with standard class instance

### DIFF
--- a/examples/load_store.py
+++ b/examples/load_store.py
@@ -3,7 +3,7 @@ import triton
 import triton.language as tl
 import triton_viz
 from triton_viz.clients import Tracer
-from triton_viz.core import config as cfg
+from triton_viz.core.config import config as cfg
 from triton_viz.core.trace import launches
 
 

--- a/tests/test_sanitizer.py
+++ b/tests/test_sanitizer.py
@@ -7,7 +7,7 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 import triton_viz
-from triton_viz import config as cfg
+from triton_viz.core.config import config as cfg
 from triton_viz.core.data import AddPtr, Load, RawLoad
 from triton_viz.core.client import Client
 from triton_viz.clients import Sanitizer

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -78,7 +78,7 @@ from .data import (
     OutOfBoundsRecordBruteForce,
     OutOfBoundsRecordZ3,
 )
-from ...core import config as cfg
+from ...core.config import config as cfg
 
 
 def print_oob_record(oob_record: OutOfBoundsRecord, max_display=10):

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -1,22 +1,8 @@
 import os
-import sys
-import types
-from typing import TYPE_CHECKING
 
 
-if TYPE_CHECKING:
-    verbose: bool
-    sanitizer_activated: bool
-    disable_sanitizer: bool
-    report_grid_execution_progress: bool
-
-    def reset() -> None:
-        ...
-
-
-class Config(types.ModuleType):
-    def __init__(self, name: str) -> None:
-        super().__init__(name)
+class Config:
+    def __init__(self) -> None:
         self.reset()
 
     def reset(self) -> None:
@@ -67,5 +53,4 @@ class Config(types.ModuleType):
             print("Grid-progress reporting is now ON.")
 
 
-# Replace the current module object with a live Config instance
-sys.modules[__name__] = Config(__name__)
+config = Config()

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from typing import Any, Optional
 from tqdm import tqdm
 
-from . import config as cfg
+from .config import config as cfg
 from .callbacks import OpCallbacks, ForLoopCallbacks
 from .data import (
     Op,

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -2,7 +2,7 @@ from triton.runtime import KernelInterface, Autotuner
 from triton.runtime.interpreter import InterpretedFunction
 from triton import JITFunction
 
-from . import config as cfg
+from .config import config as cfg
 from ..clients import Sanitizer, Profiler, Tracer
 from .client import ClientManager, Client
 from .data import Launch


### PR DESCRIPTION
- Remove sys.modules replacement pattern in config.py
- Change Config from types.ModuleType subclass to regular class
- Export config as a standard class instance
- Update all imports to use the new config module structure

This change improves code clarity and follows standard Python patterns for configuration management.