### PR TITLE
[DEV][PROFILER] Add CHECK_BUFFER_LOAD switch to Profiler for optional buffer_load checking

### DIFF
--- a/triton_viz/wrapper.py
+++ b/triton_viz/wrapper.py
@@ -24,7 +24,7 @@ def sanitizer_wrapper(kernel):
 
 
 def profiler_wrapper(kernel):
-    tracer = triton_viz.trace(clients=Profiler(CHECK_BUFFER_LOAD=True))
+    tracer = triton_viz.trace(clients=Profiler())
     return tracer(kernel)
 
 


### PR DESCRIPTION
Add configurable CHECK_BUFFER_LOAD parameter to control whether buffer_load instruction checking and 32-bit range validation are performed during profiling.