### PR TITLE
[DEV][PROFILER] Add load/store overriders to skip memory operations

### DIFF
--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -15,6 +15,7 @@ class Profiler(Client):
         callpath: bool = True,
         disable_buffer_load_check: bool = False,
         disable_load_mask_percentage_check: bool = False,
+        disable_load_store_skipping: bool = False,
         block_sampling: bool = False,
         k: int | None = None,
     ):
@@ -26,6 +27,7 @@ class Profiler(Client):
         self.has_buffer_load = False
         self.disable_buffer_load_check = disable_buffer_load_check
         self.disable_load_mask_percentage_check = disable_load_mask_percentage_check
+        self.disable_load_store_skipping = disable_load_store_skipping
         self.block_sampling = block_sampling
         self.k = k
 
@@ -200,13 +202,19 @@ class Profiler(Client):
                 self._check_32bit_range(byte_offset, element_bytewidth, offset_data)
 
         if op_type is Load:
-            return OpCallbacks(
-                before_callback=pre_load_callback, op_overrider=load_overrider
-            )
+            if self.disable_load_store_skipping:
+                return OpCallbacks(before_callback=pre_load_callback)
+            else:
+                return OpCallbacks(
+                    before_callback=pre_load_callback, op_overrider=load_overrider
+                )
         elif op_type is Store:
-            return OpCallbacks(
-                before_callback=pre_store_callback, op_overrider=store_overrider
-            )
+            if self.disable_load_store_skipping:
+                return OpCallbacks(before_callback=pre_store_callback)
+            else:
+                return OpCallbacks(
+                    before_callback=pre_store_callback, op_overrider=store_overrider
+                )
         elif op_type is AddPtr:
             return OpCallbacks(before_callback=pre_addptr_callback)
 


### PR DESCRIPTION
- Add load_overrider that returns zeros instead of performing actual loads
- Add store_overrider that skips actual store operations
- Integrate overriders into Load and Store operation callbacks
- Improves profiler performance by avoiding unnecessary memory access