### PR TITLE
[FEAT][EVALUATION]Add configurable timing measurement for Triton kernel execution

### DIFF
--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -18,6 +18,9 @@ class Config:
         # --- Profiler disable flag ---
         self._disable_profiler = os.getenv("DISABLE_PROFILER", "0") == "1"
 
+        # --- Timing enable flag ---
+        self._enable_timing = os.getenv("ENABLE_TIMING", "0") == "1"
+
         # --- Grid execution progress flag ---
         self.report_grid_execution_progress = (
             os.getenv("REPORT_GRID_EXECUTION_PROGRESS", "0") == "1"
@@ -60,6 +63,26 @@ class Config:
             print("Triton Profiler disabled.")
         elif not value and previous:
             print("Triton Profiler enabled.")
+
+    # ---------- enable_timing ----------
+    @property
+    def enable_timing(self) -> bool:
+        return self._enable_timing
+
+    @enable_timing.setter
+    def enable_timing(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("enable_timing expects a bool.")
+        self._enable_timing = value
+
+        previous = getattr(self, "_enable_timing", None)
+        self._enable_timing = value
+
+        # User-friendly status messages
+        if value and not previous:
+            print("Triton timing enabled.")
+        elif not value and previous:
+            print("Triton timing disabled.")
 
     # ---------- report_grid_execution_progress ----------
     @property

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -536,7 +536,16 @@ def _grid_executor_call(self, *args_dev, **kwargs):
     grid = grid + (1,) * (3 - len(grid))
     interpreter_builder.set_grid_dim(*grid)
     client_manager.grid_callback(grid)
+    if cfg.enable_timing:
+        import time
+
+        start_time = time.time()
     run_grid_loops(grid)
+    if cfg.enable_timing:
+        end_time = time.time()
+        elapsed_time = end_time - start_time
+        name = self.fn.__name__
+        print(f"Triton-Viz: execution time for {name}: {elapsed_time * 1000:.3f} ms")
     # Copy arguments back to propagate side-effects
     self._restore_args_dev(args_dev, args_hst, kwargs, kwargs_hst)
 


### PR DESCRIPTION
- Add ENABLE_TIMING environment variable and config property to control timing
- Instrument grid executor to measure and report kernel execution time
- Display timing results in milliseconds with function name
- Default timing disabled (ENABLE_TIMING=0)