### PR TITLE
[FIX][Sanitizer] Fix Z3 parser error for list operands and float values

### DIFF
--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -1156,19 +1156,21 @@ class SymbolicExpr:
             self._constraints.extend(constraints_rhs)
 
             # Helper function to apply binary operation element-wise when operands are lists
-            def _apply_binop(op_func, l, r):
-                lhs_is_list = isinstance(l, list)
-                rhs_is_list = isinstance(r, list)
+            def _apply_binop(op_func, left, right):
+                lhs_is_list = isinstance(left, list)
+                rhs_is_list = isinstance(right, list)
                 if lhs_is_list and rhs_is_list:
-                    if len(l) != len(r):
-                        raise ValueError(f"List operands must have same length: {len(l)} vs {len(r)}")
-                    return [op_func(li, ri) for li, ri in zip(l, r)]
+                    if len(left) != len(right):
+                        raise ValueError(
+                            f"List operands must have same length: {len(left)} vs {len(right)}"
+                        )
+                    return [op_func(li, ri) for li, ri in zip(left, right)]
                 elif lhs_is_list:
-                    return [op_func(li, r) for li in l]
+                    return [op_func(li, right) for li in left]
                 elif rhs_is_list:
-                    return [op_func(l, ri) for ri in r]
+                    return [op_func(left, ri) for ri in right]
                 else:
-                    return op_func(l, r)
+                    return op_func(left, right)
 
             if self.op == "add":
                 self._z3 = _apply_binop(lambda a, b: a + b, lhs, rhs)


### PR DESCRIPTION
Fix Z3Exception "parser error" that occurred when evaluating symbolic expressions containing numpy arrays or float constants.

Changes:
- Add element-wise binary operation support via _apply_binop() helper when one or both operands are lists (from numpy arrays)
- Fix const handling to properly convert float values to int before passing to Z3 IntVal (Z3 cannot parse float strings like "3.5")
- Add proper handling for tuple and None values in const expressions
- Remove incorrect .as_long() call in eval() that failed on symbolic expressions containing variables like PID0 or arange_0