### PR TITLE
[PROFILER][FIX] Skip warmup when buffer load check is disabled

### DIFF
--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -99,8 +99,8 @@ class Profiler(Client):
         return True
 
     def pre_warmup_callback(self, jit_fn, *args, **kwargs) -> bool:
-        # TODO: optionally proceed the warmup. For now, always proceed.
-        return True
+        # Skip warmup if buffer load check is disabled
+        return not self.disable_buffer_load_check
 
     def post_warmup_callback(self, jit_fn, ret) -> None:
         if not ret:


### PR DESCRIPTION
When disable_buffer_load_check=True, there's no need to run warmup since the ASM analysis for buffer_load detection is not required. This avoids unnecessary compilation overhead.