### PR TITLE
[PROFILER] Move disable_buffer_load_check to config with env var support

### DIFF
--- a/tests/test_profiler.py
+++ b/tests/test_profiler.py
@@ -70,9 +70,8 @@ def test_for_loop_statistics():
     # Create profiler in the test function
     # Disable block sampling to ensure all blocks are executed
     cfg._profiler_enable_block_sampling = False
-    loop_profiler = Profiler(
-        disable_buffer_load_check=True, disable_load_mask_percentage_check=True
-    )
+    cfg._profiler_disable_buffer_load_check = True
+    loop_profiler = Profiler(disable_load_mask_percentage_check=True)
     traced_kernel = triton_viz.trace(loop_profiler)(for_loop_test_kernel)
 
     # Run the kernel
@@ -179,7 +178,8 @@ def test_mask_percentage():
     # Create profiler in the test function
     # Disable block sampling to ensure all blocks are executed
     cfg._profiler_enable_block_sampling = False
-    mask_profiler = Profiler(disable_buffer_load_check=True)
+    cfg._profiler_disable_buffer_load_check = True
+    mask_profiler = Profiler()
     traced_kernel = triton_viz.trace(mask_profiler)(mask_percentage_test_kernel)
 
     # Run the kernel
@@ -305,11 +305,11 @@ def test_block_sampling(test_name, enable_sampling, k_value, expected_executions
     # Configure block sampling via config - must be done BEFORE creating Profiler
     # Set the private attribute directly to ensure it takes effect
     cfg._profiler_enable_block_sampling = enable_sampling
+    cfg._profiler_disable_buffer_load_check = True
 
     # Create profiler with k value
     profiler = Profiler(
         k=k_value,
-        disable_buffer_load_check=True,
         disable_load_mask_percentage_check=True,
     )
 
@@ -360,9 +360,10 @@ def test_load_store_skip_disabled():
     cfg._profiler_enable_load_store_skipping = False
     # Also disable block sampling to ensure all blocks are executed
     cfg._profiler_enable_block_sampling = False
+    cfg._profiler_disable_buffer_load_check = True
 
     # Create profiler and traced kernel
-    profiler = Profiler(disable_buffer_load_check=True)
+    profiler = Profiler()
     traced_kernel = triton_viz.trace(profiler)(simple_kernel)
 
     # Run kernel
@@ -388,9 +389,10 @@ def test_load_store_skip_enabled():
     cfg._profiler_enable_load_store_skipping = True
     # Also disable block sampling to ensure all blocks are executed
     cfg._profiler_enable_block_sampling = False
+    cfg._profiler_disable_buffer_load_check = True
 
     # Create profiler and traced kernel
-    profiler = Profiler(disable_buffer_load_check=True)
+    profiler = Profiler()
     traced_kernel = triton_viz.trace(profiler)(simple_kernel)
 
     # Run kernel

--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -43,7 +43,6 @@ class Profiler(Client):
     def __init__(
         self,
         callpath: bool = True,
-        disable_buffer_load_check: bool = False,
         disable_for_loop_unroll_check: bool = False,
         disable_load_mask_percentage_check: bool = False,
         k: int | None = None,
@@ -76,7 +75,7 @@ class Profiler(Client):
 
         # Case 4: Buffer Load Check
         self.has_buffer_load = False
-        self.disable_buffer_load_check = disable_buffer_load_check
+        self.disable_buffer_load_check = cfg.profiler_disable_buffer_load_check
         self.potential_buffer_load_issue_found = False
 
         # Block sampling

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -57,6 +57,12 @@ class Config:
             os.getenv("PROFILER_ENABLE_BLOCK_SAMPLING", "1") == "1"
         )
 
+        # --- Profiler Performance Issues Detection ---
+        # AMD Buffer Load Check: detects buffer_load instruction usage in kernel ASM
+        self._profiler_disable_buffer_load_check = (
+            os.getenv("PROFILER_DISABLE_BUFFER_LOAD_CHECK", "0") == "1"
+        )
+
     # ---------- disable_sanitizer ----------
     @property
     def disable_sanitizer(self) -> bool:
@@ -170,6 +176,25 @@ class Config:
     @property
     def virtual_memory(self) -> bool:
         return self._virtual_memory
+
+    # ---------- profiler_disable_buffer_load_check ----------
+    @property
+    def profiler_disable_buffer_load_check(self) -> bool:
+        return self._profiler_disable_buffer_load_check
+
+    @profiler_disable_buffer_load_check.setter
+    def profiler_disable_buffer_load_check(self, value: bool) -> None:
+        if not isinstance(value, bool):
+            raise TypeError("profiler_disable_buffer_load_check expects a bool.")
+
+        previous = getattr(self, "_profiler_disable_buffer_load_check", None)
+        self._profiler_disable_buffer_load_check = value
+
+        # User-friendly status messages
+        if value and not previous:
+            print("Profiler buffer load check disabled.")
+        elif not value and previous:
+            print("Profiler buffer load check enabled.")
 
 
 config = Config()


### PR DESCRIPTION
- Add PROFILER_DISABLE_BUFFER_LOAD_CHECK env var to config.py (default: False)
- Remove disable_buffer_load_check parameter from Profiler.__init__
- Read disable_buffer_load_check from cfg.profiler_disable_buffer_load_check
- Update test_profiler.py to set config before creating Profiler