### PR TITLE
[FEATURE + REFACTOR] Reject nested triton_viz.trace calls with different clients

### DIFF
--- a/tests/nki/test_nki_tracer.py
+++ b/tests/nki/test_nki_tracer.py
@@ -136,7 +136,6 @@ def test_tracer_records_dot():
     TILE_K = 2
     TILE_N = 4
 
-    @triton_viz.trace(client=Tracer(), backend="nki")
     def matmul_kernel(lhs, rhs, result):
         """NKI matmul_kernel to compute a matrix multiplication operation in a tiled manner
 

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -1,21 +1,13 @@
-from contextlib import contextmanager, nullcontext
+from contextlib import nullcontext
 
 from abc import ABC, abstractmethod
 from typing import ClassVar, Optional, Any
 from collections.abc import Callable
 import threading
 
-from .data import Op, Launch
-from .patch import (
-    patch_op,
-    unpatch_op,
-    patch_for_loop,
-    unpatch_for_loop,
-    patch_calls,
-)
+from .data import Op
 from functools import wraps
 from .callbacks import OpCallbacks, ForLoopCallbacks
-from .patch import patch_lang, unpatch_lang, OPERATION_REGISTRY
 from .config import config as cfg
 
 
@@ -111,119 +103,3 @@ class Client(ABC):
     @grid_idx.setter
     def grid_idx(self, value: Optional[tuple[int, ...]]) -> None:
         self._set_thread_local("grid_idx", value)
-
-
-class ClientManager:
-    def __init__(self, clients: Optional[list[Client]] = None):
-        self.clients: dict[str, Client] = {}
-        if clients:
-            self.add_clients(clients)
-        self.launch = Launch()
-        self._lock = threading.Lock()
-
-    def _lock_context(self):
-        if cfg.num_sms > 1:
-            return self._lock
-        return nullcontext()
-
-    def get_client(self, name: str) -> Optional[Client]:
-        return self.clients.get(name)
-
-    def add_clients(self, new_clients_list: list[Client]) -> None:
-        for new_client in new_clients_list:
-            duplicate = any(
-                isinstance(existing_client, new_client.__class__)
-                for existing_client in self.clients.values()
-            )
-            if not duplicate:
-                self.clients[new_client.NAME] = new_client
-
-    @contextmanager
-    def patch_warmup(self, jit_fn):
-        if not hasattr(jit_fn, "warmup"):
-            yield
-            return
-
-        def patcher(fn):
-            @wraps(fn)
-            def wrapped(*args, **kwargs):
-                if all(
-                    not client.pre_warmup_callback(jit_fn, *args, **kwargs)
-                    for client in self.clients.values()
-                ):
-                    return None
-                kwargs.pop("warmup", None)
-                ret = fn(*args, **kwargs)
-                for client in self.clients.values():
-                    client.post_warmup_callback(jit_fn, ret)
-                return ret
-
-            return wrapped
-
-        jit_fn.warmup = patcher(jit_fn.warmup)
-        try:
-            yield
-        finally:
-            jit_fn.warmup = jit_fn.warmup.__wrapped__
-
-    @contextmanager
-    def patch_run(self, fn, backend: str):
-        namespaces = OPERATION_REGISTRY[backend].namespaces
-        with patch_calls(backend):
-            for client in self.clients.values():
-                for namespace, attrs in namespaces.items():  # patch ops
-                    for attr, op in attrs.items():
-                        callbacks = client.register_op_callback(op)
-                        patch_op(namespace, attr, callbacks, backend=backend)
-
-                # patch for loops
-                loop_callbacks = client.register_for_loop_callback()
-                patch_for_loop(loop_callbacks)
-            # Remaps core language functions to interpreted ones
-            patch_lang(fn, backend)
-            try:
-                yield
-            finally:
-                for namespace, attrs in namespaces.items():
-                    for attr, op in attrs.items():
-                        unpatch_op(namespace, attr, backend)
-                unpatch_for_loop()
-                unpatch_lang(backend)
-
-    def pre_run_callback(self, fn: Callable) -> bool:
-        with self._lock_context():
-            rets = []
-            for client in self.clients.values():
-                rets.append(client.pre_run_callback(fn))
-            return all(rets) if rets else True
-
-    def post_run_callback(self, fn: Callable) -> bool:
-        with self._lock_context():
-            rets = []
-            for client in self.clients.values():
-                rets.append(client.post_run_callback(fn))
-            return any(rets)
-
-    def finalize(self) -> None:
-        with self._lock_context():
-            self.launch.records = []
-            for client in self.clients.values():
-                self.launch.records += client.finalize()
-
-    def arg_callback(self, name, arg, arg_cvt):
-        with self._lock_context():
-            if hasattr(arg, "data_ptr"):
-                self.launch.tensors.add(arg)
-            for client in self.clients.values():
-                client.arg_callback(name, arg, arg_cvt)
-
-    def grid_callback(self, grid: tuple[int]):
-        with self._lock_context():
-            self.launch.grid = grid
-            for client in self.clients.values():
-                client.grid_callback(grid)
-
-    def grid_idx_callback(self, grid_idx: tuple[int, ...]):
-        with self._lock_context():
-            for client in self.clients.values():
-                client.grid_idx_callback(grid_idx)

--- a/triton_viz/core/flip_patch.py
+++ b/triton_viz/core/flip_patch.py
@@ -6,7 +6,7 @@ import triton.language as tl
 from .data import Flip
 
 
-def patch_flip(scope: Any, get_client_manager: Callable[[], Any]) -> None:
+def patch_flip(scope: Any, get_trace_runtime: Callable[[], Any]) -> None:
     # Wrap tl.flip to emit a Flip record after computing result.
     try:
         _orig_flip = getattr(tl, "flip", None)
@@ -49,8 +49,8 @@ def patch_flip(scope: Any, get_client_manager: Callable[[], Any]) -> None:
 
             # Emit a Flip record to the active tracer, if available
             try:
-                cm = get_client_manager()
-                if cm is not None and hasattr(cm, "clients"):
+                cm = get_trace_runtime()
+                if cm is not None and hasattr(cm, "get_client"):
                     tracer = cm.get_client("tracer")
                     if tracer is not None:
                         input_payload = None

--- a/triton_viz/core/flip_patch.py
+++ b/triton_viz/core/flip_patch.py
@@ -49,9 +49,9 @@ def patch_flip(scope: Any, get_trace_runtime: Callable[[], Any]) -> None:
 
             # Emit a Flip record to the active tracer, if available
             try:
-                cm = get_trace_runtime()
-                if cm is not None and hasattr(cm, "get_client"):
-                    tracer = cm.get_client("tracer")
+                trace_runtime = get_trace_runtime()
+                if hasattr(trace_runtime, "client"):
+                    tracer = trace_runtime.client
                     if tracer is not None:
                         input_payload = None
                         output_payload = None

--- a/triton_viz/core/nki.py
+++ b/triton_viz/core/nki.py
@@ -473,13 +473,13 @@ class NKIInterpretedFunction:
         nki_builder.fn = self.fn
 
         kwargs.pop("warmup", None)  # Remove warmup from kwargs if it exists
-        client_manager = kwargs.pop(
-            "client_manager", None
-        )  # Remove client_manager from kwargs if it exists
+        trace_runtime = kwargs.pop(
+            "trace_runtime", None
+        )  # Remove trace_runtime from kwargs if it exists
 
         # Call grid_callback once before grid execution (similar to Triton)
-        if client_manager is not None:
-            client_manager.grid_callback(grid_dims)
+        if trace_runtime is not None:
+            trace_runtime.grid_callback(grid_dims)
 
         # Apply AST transformers
         if hasattr(self.fn, "__code__"):
@@ -512,7 +512,7 @@ class NKIInterpretedFunction:
         for name, arg in name_args.items():
             call_args[name] = arg
             ret = arg
-            client_manager.arg_callback(name, arg, ret)
+            trace_runtime.arg_callback(name, arg, ret)
 
         for x in range(grid_dims[0]):
             for y in range(grid_dims[1]):
@@ -520,11 +520,11 @@ class NKIInterpretedFunction:
                     nki_builder.set_grid_idx(x, y, z)
 
                     # Call grid_idx_callback for each grid iteration (similar to Triton)
-                    if client_manager is not None:
-                        client_manager.grid_idx_callback((x, y, z))
+                    if trace_runtime is not None:
+                        trace_runtime.grid_idx_callback((x, y, z))
 
-                    if not client_manager.pre_run_callback(self.fn):
+                    if not trace_runtime.pre_run_callback(self.fn):
                         return
                     self.fn(*args, **kwargs)
-                    if not client_manager.post_run_callback(self.fn):
+                    if not trace_runtime.post_run_callback(self.fn):
                         return


### PR DESCRIPTION
handles [this](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/issues/137) issue. Since a trace (corresponds to one function) can only be attached to one client, the `ClientManager` class is unnecessary (it seems it was made to handle multiple clients per trace).

Instead, we can attach the client directly to the trace object. Previously, this was called `TraceInterface`, but moving `ClientManager`'s patching utilities to `TraceInterface` makes it not an interface (aside: was it ever an interface? It had an `__init__` function so arguably no). Since it's not an interface, I renamed `TraceInterface` to `TraceRuntime`.