### PR TITLE
[FIX] Patch libdevice stubs for interpreter/sanitizer mode

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -8,9 +8,11 @@ import triton.language.extra.libdevice as libdevice
 from triton.language.extra.libdevice import acos as _ld_acos
 from triton.language.extra.libdevice import asin as _ld_asin
 from triton.language.extra.libdevice import erf as _ld_erf
+from triton.language.extra.libdevice import rsqrt as _ld_rsqrt
 from triton.language.extra.libdevice import tanh as _ld_tanh
 
 import triton_viz
+from triton_viz.clients.tracer.tracer import Tracer
 from triton_viz.core.data import Load, RawLoad
 from triton_viz.clients.symbolic_engine import SymbolicExpr, Z3Expr, RangeWrapper
 from triton_viz.clients.sanitizer.sanitizer import (
@@ -983,6 +985,24 @@ def libdevice_acos_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
     tl.store(out_ptr + offs, y)
 
 
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_rsqrt_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = _ld_rsqrt(x)
+    tl.store(out_ptr + offs, y)
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_rsqrt_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = libdevice.rsqrt(x)
+    tl.store(out_ptr + offs, y)
+
+
 # -- Unsupported op kernel --
 
 
@@ -1002,10 +1022,34 @@ _LIBDEVICE_KERNELS = {
     ("asin", "module"): libdevice_asin_module_kernel,
     ("acos", "direct"): libdevice_acos_direct_kernel,
     ("acos", "module"): libdevice_acos_module_kernel,
+    ("rsqrt", "direct"): libdevice_rsqrt_direct_kernel,
+    ("rsqrt", "module"): libdevice_rsqrt_module_kernel,
+}
+
+_NUMPY_REFS = {
+    "tanh": np.tanh,
+    "asin": np.arcsin,
+    "acos": np.arccos,
+    "rsqrt": lambda x: 1.0 / np.sqrt(x),
+}
+
+_LIBDEVICE_INPUTS = {
+    "tanh": torch.tensor(
+        [0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32
+    ),
+    "asin": torch.tensor(
+        [0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32
+    ),
+    "acos": torch.tensor(
+        [0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32
+    ),
+    "rsqrt": torch.tensor(
+        [1.0, 4.0, 0.25, 9.0, 16.0, 0.01, 100.0, 0.5], dtype=torch.float32
+    ),
 }
 
 
-@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos"])
+@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "rsqrt"])
 @pytest.mark.parametrize("import_style", ["direct", "module"])
 def test_libdevice_op(op_name, import_style):
     """
@@ -1014,8 +1058,7 @@ def test_libdevice_op(op_name, import_style):
     """
     libdevice_sanitizer.records.clear()
 
-    # Values valid for asin/acos domain [-1, 1], padded to power-of-2 length
-    x = torch.tensor([0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32)
+    x = _LIBDEVICE_INPUTS[op_name].clone()
     out = torch.empty(8, dtype=torch.float32)
 
     kernel = _LIBDEVICE_KERNELS[(op_name, import_style)]
@@ -1036,6 +1079,63 @@ def test_libdevice_unsupported_op_raises():
 
     with pytest.raises(NotImplementedError, match=r"libdevice\.erf.*not supported"):
         libdevice_erf_direct_kernel[(1,)](x, out, N=8)
+
+
+# -- Numerical correctness kernels (no sanitizer override) --
+
+_correctness_tracer = Tracer()
+
+
+@triton_viz.trace(client=_correctness_tracer)
+@triton.jit
+def _ld_tanh_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, _ld_tanh(x))
+
+
+@triton_viz.trace(client=_correctness_tracer)
+@triton.jit
+def _ld_asin_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, _ld_asin(x))
+
+
+@triton_viz.trace(client=_correctness_tracer)
+@triton.jit
+def _ld_acos_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, _ld_acos(x))
+
+
+@triton_viz.trace(client=_correctness_tracer)
+@triton.jit
+def _ld_rsqrt_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, _ld_rsqrt(x))
+
+
+_CORRECTNESS_KERNELS = {
+    "tanh": _ld_tanh_kernel,
+    "asin": _ld_asin_kernel,
+    "acos": _ld_acos_kernel,
+    "rsqrt": _ld_rsqrt_kernel,
+}
+
+
+@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "rsqrt"])
+def test_libdevice_numerical_correctness(op_name):
+    """Libdevice ops produce numerically correct results in interpreter mode."""
+    x = _LIBDEVICE_INPUTS[op_name].clone()
+    out = torch.empty(8, dtype=torch.float32)
+
+    _CORRECTNESS_KERNELS[op_name][(1,)](x, out, N=8)
+
+    expected = _NUMPY_REFS[op_name](x.numpy())
+    np.testing.assert_allclose(out.numpy(), expected, rtol=1e-5, atol=1e-6)
 
 
 # ======== Fake Tensor (Virtual Memory) OOB Tests ===========

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -15,6 +15,7 @@ import triton_viz
 from triton_viz.clients.tracer.tracer import Tracer
 from triton_viz.core.data import Load, RawLoad
 from triton_viz.clients.symbolic_engine import SymbolicExpr, Z3Expr, RangeWrapper
+from triton_viz.core.libdevice_registry import _np_erf
 from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicSanitizer,
     _range_to_iterator_constraint,
@@ -1003,9 +1004,6 @@ def libdevice_rsqrt_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
     tl.store(out_ptr + offs, y)
 
 
-# -- Unsupported op kernel --
-
-
 @triton_viz.trace(client=libdevice_sanitizer)
 @triton.jit
 def libdevice_erf_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
@@ -1024,11 +1022,6 @@ def libdevice_erf_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
     tl.store(out_ptr + offs, y)
 
 
-_UNSUPPORTED_KERNELS = {
-    "direct": libdevice_erf_direct_kernel,
-    "module": libdevice_erf_module_kernel,
-}
-
 _LIBDEVICE_KERNELS = {
     ("tanh", "direct"): libdevice_tanh_direct_kernel,
     ("tanh", "module"): libdevice_tanh_module_kernel,
@@ -1036,6 +1029,8 @@ _LIBDEVICE_KERNELS = {
     ("asin", "module"): libdevice_asin_module_kernel,
     ("acos", "direct"): libdevice_acos_direct_kernel,
     ("acos", "module"): libdevice_acos_module_kernel,
+    ("erf", "direct"): libdevice_erf_direct_kernel,
+    ("erf", "module"): libdevice_erf_module_kernel,
     ("rsqrt", "direct"): libdevice_rsqrt_direct_kernel,
     ("rsqrt", "module"): libdevice_rsqrt_module_kernel,
 }
@@ -1044,6 +1039,7 @@ _NUMPY_REFS = {
     "tanh": np.tanh,
     "asin": np.arcsin,
     "acos": np.arccos,
+    "erf": _np_erf,
     "rsqrt": lambda x: 1.0 / np.sqrt(x),
 }
 
@@ -1057,13 +1053,16 @@ _LIBDEVICE_INPUTS = {
     "acos": torch.tensor(
         [0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32
     ),
+    "erf": torch.tensor(
+        [0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32
+    ),
     "rsqrt": torch.tensor(
         [1.0, 4.0, 0.25, 9.0, 16.0, 0.01, 100.0, 0.5], dtype=torch.float32
     ),
 }
 
 
-@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "rsqrt"])
+@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "erf", "rsqrt"])
 @pytest.mark.parametrize("import_style", ["direct", "module"])
 def test_libdevice_op(op_name, import_style):
     """
@@ -1082,19 +1081,6 @@ def test_libdevice_op(op_name, import_style):
         f"Expected no OOB records for {op_name}/{import_style}, "
         f"got {len(libdevice_sanitizer.records)}"
     )
-
-
-@pytest.mark.parametrize("import_style", ["direct", "module"])
-def test_libdevice_unsupported_op_raises(import_style):
-    """Unsupported libdevice ops raise NotImplementedError, not silent None."""
-    libdevice_sanitizer.records.clear()
-
-    x = torch.tensor([0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32)
-    out = torch.empty(8, dtype=torch.float32)
-
-    kernel = _UNSUPPORTED_KERNELS[import_style]
-    with pytest.raises(NotImplementedError, match=r"libdevice\.erf.*not supported"):
-        kernel[(1,)](x, out, N=8)
 
 
 # -- Numerical correctness kernels (no sanitizer override) --
@@ -1128,6 +1114,14 @@ def _ld_acos_kernel(x_ptr, out_ptr, N: tl.constexpr):
 
 @triton_viz.trace(client=_correctness_tracer)
 @triton.jit
+def _ld_erf_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    tl.store(out_ptr + offs, _ld_erf(x))
+
+
+@triton_viz.trace(client=_correctness_tracer)
+@triton.jit
 def _ld_rsqrt_kernel(x_ptr, out_ptr, N: tl.constexpr):
     offs = tl.arange(0, N)
     x = tl.load(x_ptr + offs)
@@ -1138,11 +1132,12 @@ _CORRECTNESS_KERNELS = {
     "tanh": _ld_tanh_kernel,
     "asin": _ld_asin_kernel,
     "acos": _ld_acos_kernel,
+    "erf": _ld_erf_kernel,
     "rsqrt": _ld_rsqrt_kernel,
 }
 
 
-@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "rsqrt"])
+@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos", "erf", "rsqrt"])
 def test_libdevice_numerical_correctness(op_name):
     """Libdevice ops produce numerically correct results in interpreter mode."""
     x = _LIBDEVICE_INPUTS[op_name].clone()

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -4,6 +4,11 @@ import numpy as np
 
 import triton
 import triton.language as tl
+import triton.language.extra.libdevice as libdevice
+from triton.language.extra.libdevice import acos as _ld_acos
+from triton.language.extra.libdevice import asin as _ld_asin
+from triton.language.extra.libdevice import erf as _ld_erf
+from triton.language.extra.libdevice import tanh as _ld_tanh
 
 import triton_viz
 from triton_viz.core.data import Load, RawLoad
@@ -915,39 +920,122 @@ def test_reduce_broadcast():
 
 # ======== Libdevice Tests ===========
 
-from triton.language.extra.libdevice import tanh
-
 libdevice_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+# -- Direct import kernels --
 
 
 @triton_viz.trace(client=libdevice_sanitizer)
 @triton.jit
-def libdevice_tanh_kernel(x_ptr, out_ptr, N: tl.constexpr):
+def libdevice_tanh_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
     offs = tl.arange(0, N)
     x = tl.load(x_ptr + offs)
-    y = tanh(x)
+    y = _ld_tanh(x)
     tl.store(out_ptr + offs, y)
 
 
-def test_libdevice_tanh():
-    """
-    Verify libdevice.tanh works under the sanitizer without raising
-    TypeError: cannot convert None of type <class 'NoneType'> to tensor.
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_asin_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = _ld_asin(x)
+    tl.store(out_ptr + offs, y)
 
-    Previously, the libdevice stub ``def tanh(arg0): ...`` returned None
-    in interpreter mode because Triton's _patch_lang does not patch the
-    libdevice module.
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_acos_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = _ld_acos(x)
+    tl.store(out_ptr + offs, y)
+
+
+# -- Module-style import kernels --
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_tanh_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = libdevice.tanh(x)
+    tl.store(out_ptr + offs, y)
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_asin_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = libdevice.asin(x)
+    tl.store(out_ptr + offs, y)
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_acos_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = libdevice.acos(x)
+    tl.store(out_ptr + offs, y)
+
+
+# -- Unsupported op kernel --
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_erf_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = _ld_erf(x)
+    tl.store(out_ptr + offs, y)
+
+
+_LIBDEVICE_KERNELS = {
+    ("tanh", "direct"): libdevice_tanh_direct_kernel,
+    ("tanh", "module"): libdevice_tanh_module_kernel,
+    ("asin", "direct"): libdevice_asin_direct_kernel,
+    ("asin", "module"): libdevice_asin_module_kernel,
+    ("acos", "direct"): libdevice_acos_direct_kernel,
+    ("acos", "module"): libdevice_acos_module_kernel,
+}
+
+
+@pytest.mark.parametrize("op_name", ["tanh", "asin", "acos"])
+@pytest.mark.parametrize("import_style", ["direct", "module"])
+def test_libdevice_op(op_name, import_style):
+    """
+    Verify libdevice ops work under the sanitizer without raising
+    TypeError: cannot convert None of type <class 'NoneType'> to tensor.
     """
     libdevice_sanitizer.records.clear()
 
-    x = torch.randn(8, dtype=torch.float32)
+    # Values valid for asin/acos domain [-1, 1], padded to power-of-2 length
+    x = torch.tensor([0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32)
     out = torch.empty(8, dtype=torch.float32)
 
-    libdevice_tanh_kernel[(1,)](x, out, N=8)
+    kernel = _LIBDEVICE_KERNELS[(op_name, import_style)]
+    kernel[(1,)](x, out, N=8)
 
     assert len(libdevice_sanitizer.records) == 0, (
-        f"Expected no OOB records, got {len(libdevice_sanitizer.records)}"
+        f"Expected no OOB records for {op_name}/{import_style}, "
+        f"got {len(libdevice_sanitizer.records)}"
     )
+
+
+def test_libdevice_unsupported_op_raises():
+    """Unsupported libdevice ops raise NotImplementedError, not silent None."""
+    libdevice_sanitizer.records.clear()
+
+    x = torch.tensor([0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32)
+    out = torch.empty(8, dtype=torch.float32)
+
+    with pytest.raises(NotImplementedError, match=r"libdevice\.erf.*not supported"):
+        libdevice_erf_direct_kernel[(1,)](x, out, N=8)
 
 
 # ======== Fake Tensor (Virtual Memory) OOB Tests ===========

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -844,3 +844,40 @@ def test_reduce_broadcast():
     assert (
         len(reduce_broadcast_sanitizer.records) == 0
     ), f"Expected no OOB records, got {len(reduce_broadcast_sanitizer.records)}"
+
+
+# ======== Libdevice Tests ===========
+
+from triton.language.extra.libdevice import tanh
+
+libdevice_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_tanh_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = tanh(x)
+    tl.store(out_ptr + offs, y)
+
+
+def test_libdevice_tanh():
+    """
+    Verify libdevice.tanh works under the sanitizer without raising
+    TypeError: cannot convert None of type <class 'NoneType'> to tensor.
+
+    Previously, the libdevice stub ``def tanh(arg0): ...`` returned None
+    in interpreter mode because Triton's _patch_lang does not patch the
+    libdevice module.
+    """
+    libdevice_sanitizer.records.clear()
+
+    x = torch.randn(8, dtype=torch.float32)
+    out = torch.empty(8, dtype=torch.float32)
+
+    libdevice_tanh_kernel[(1,)](x, out, N=8)
+
+    assert len(libdevice_sanitizer.records) == 0, (
+        f"Expected no OOB records, got {len(libdevice_sanitizer.records)}"
+    )

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1015,6 +1015,20 @@ def libdevice_erf_direct_kernel(x_ptr, out_ptr, N: tl.constexpr):
     tl.store(out_ptr + offs, y)
 
 
+@triton_viz.trace(client=libdevice_sanitizer)
+@triton.jit
+def libdevice_erf_module_kernel(x_ptr, out_ptr, N: tl.constexpr):
+    offs = tl.arange(0, N)
+    x = tl.load(x_ptr + offs)
+    y = libdevice.erf(x)
+    tl.store(out_ptr + offs, y)
+
+
+_UNSUPPORTED_KERNELS = {
+    "direct": libdevice_erf_direct_kernel,
+    "module": libdevice_erf_module_kernel,
+}
+
 _LIBDEVICE_KERNELS = {
     ("tanh", "direct"): libdevice_tanh_direct_kernel,
     ("tanh", "module"): libdevice_tanh_module_kernel,
@@ -1070,15 +1084,17 @@ def test_libdevice_op(op_name, import_style):
     )
 
 
-def test_libdevice_unsupported_op_raises():
+@pytest.mark.parametrize("import_style", ["direct", "module"])
+def test_libdevice_unsupported_op_raises(import_style):
     """Unsupported libdevice ops raise NotImplementedError, not silent None."""
     libdevice_sanitizer.records.clear()
 
     x = torch.tensor([0.0, 0.5, -0.5, 0.9, -0.9, 0.1, -0.1, 0.0], dtype=torch.float32)
     out = torch.empty(8, dtype=torch.float32)
 
+    kernel = _UNSUPPORTED_KERNELS[import_style]
     with pytest.raises(NotImplementedError, match=r"libdevice\.erf.*not supported"):
-        libdevice_erf_direct_kernel[(1,)](x, out, N=8)
+        kernel[(1,)](x, out, N=8)
 
 
 # -- Numerical correctness kernels (no sanitizer override) --

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -143,3 +143,24 @@ def test_libdevice_patch_and_restore():
     scope.restore()
     # Module attr is restored
     assert _ld.tanh is original_tanh
+
+
+def test_patch_libdevice_alias_restore():
+    """_patch_libdevice patches fn.__globals__ aliases; restore undoes them."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_tanh = _ld.tanh
+
+    def _kernel_with_alias():
+        pass
+
+    _kernel_with_alias.__globals__["my_tanh"] = original_tanh
+
+    scope = _LangPatchScope()
+    _patch_libdevice(_kernel_with_alias, scope)
+    assert _kernel_with_alias.__globals__["my_tanh"] is not original_tanh
+
+    scope.restore()
+    assert _kernel_with_alias.__globals__["my_tanh"] is original_tanh
+    del _kernel_with_alias.__globals__["my_tanh"]

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -1,6 +1,7 @@
 import pytest
 
 import triton.language as tl
+import triton.language.extra.libdevice as _ld_ref  # noqa: F401
 
 from triton_viz.core import patch as patch_mod
 from triton_viz.core.patch import _LangPatchScope, _triton_snapshot_scope
@@ -164,3 +165,71 @@ def test_patch_libdevice_alias_restore():
     scope.restore()
     assert _kernel_with_alias.__globals__["my_tanh"] is original_tanh
     del _kernel_with_alias.__globals__["my_tanh"]
+
+
+def test_patch_libdevice_multiple_aliases():
+    """Multiple globals aliasing different libdevice fns are all patched and restored."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_tanh = _ld.tanh
+    original_asin = _ld.asin
+
+    def _kernel():
+        pass
+
+    _kernel.__globals__["my_tanh"] = original_tanh
+    _kernel.__globals__["my_asin"] = original_asin
+
+    scope = _LangPatchScope()
+    _patch_libdevice(_kernel, scope)
+    assert _kernel.__globals__["my_tanh"] is not original_tanh
+    assert _kernel.__globals__["my_asin"] is not original_asin
+
+    scope.restore()
+    assert _kernel.__globals__["my_tanh"] is original_tanh
+    assert _kernel.__globals__["my_asin"] is original_asin
+    del _kernel.__globals__["my_tanh"]
+    del _kernel.__globals__["my_asin"]
+
+
+def test_patch_libdevice_unsupported_alias():
+    """A global aliasing an unregistered libdevice fn gets the unsupported stub."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_erf = _ld.erf
+
+    def _kernel():
+        pass
+
+    _kernel.__globals__["my_erf"] = original_erf
+
+    scope = _LangPatchScope()
+    _patch_libdevice(_kernel, scope)
+    with pytest.raises(NotImplementedError, match="libdevice.erf"):
+        _kernel.__globals__["my_erf"](None)
+
+    scope.restore()
+    assert _kernel.__globals__["my_erf"] is original_erf
+    del _kernel.__globals__["my_erf"]
+
+
+def test_patch_lang_rollback_on_libdevice_failure(monkeypatch):
+    """If _patch_libdevice throws, all triton lang state must be restored."""
+    from triton_viz.core import patch as patch_mod
+
+    original_arange = tl.arange
+
+    def _exploding_patch(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(patch_mod, "_patch_libdevice", _exploding_patch)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        patch_mod.patch_lang(_dummy_kernel, "triton")
+
+    # tl.arange must be restored to its original (not leaked as interpreter version)
+    assert tl.arange is original_arange
+    # scope must not have been pushed
+    assert len(patch_mod._LANG_PATCH_SCOPES["triton"]) == 0

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -3,7 +3,7 @@ import pytest
 import triton.language as tl
 
 from triton_viz.core import patch as patch_mod
-from triton_viz.core.patch import _triton_snapshot_scope
+from triton_viz.core.patch import _LangPatchScope, _triton_snapshot_scope
 
 
 def _dummy_kernel():
@@ -72,3 +72,54 @@ def test_scope_restores_tensor_descriptor_base_builtins(monkeypatch):
         scope.restore()
 
     assert getattr(descriptor, attr) is original
+
+
+# ======== set_item Tests ===========
+
+
+def test_scope_set_item_restores_original():
+    """set_item on existing key restores original value."""
+    scope = _LangPatchScope()
+    d = {"key": "original"}
+    scope.set_item(d, "key", "patched")
+    assert d["key"] == "patched"
+    scope.restore()
+    assert d["key"] == "original"
+
+
+def test_scope_set_item_removes_new_key():
+    """set_item on non-existent key removes it on restore."""
+    scope = _LangPatchScope()
+    d = {}
+    scope.set_item(d, "new_key", "value")
+    assert d["new_key"] == "value"
+    scope.restore()
+    assert "new_key" not in d
+
+
+def test_scope_interleaved_restore_order():
+    """Interleaved set_attr and set_item restore in LIFO order."""
+    scope = _LangPatchScope()
+
+    class Obj:
+        x = "orig_x"
+
+    d = {"k": "orig_k"}
+
+    scope.set_attr(Obj, "x", "patched_x")  # first
+    scope.set_item(d, "k", "patched_k")  # second
+    scope.set_attr(Obj, "x", "patched_x2")  # third
+
+    assert Obj.x == "patched_x2"
+    assert d["k"] == "patched_k"
+
+    scope.restore()
+
+    assert Obj.x == "orig_x"
+    assert d["k"] == "orig_k"
+
+
+def test_scope_restore_not_monkey_patched():
+    """After _patch_libdevice, scope.restore must be the original method, not a closure."""
+    scope = _LangPatchScope()
+    assert scope.restore.__func__ is _LangPatchScope.restore

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -193,26 +193,91 @@ def test_patch_libdevice_multiple_aliases():
     del _kernel.__globals__["my_asin"]
 
 
-def test_patch_libdevice_unsupported_alias():
-    """A global aliasing an unregistered libdevice fn gets the unsupported stub."""
+def test_patch_libdevice_unregistered_alias_unchanged():
+    """Unregistered libdevice aliases are left as-is (not blanket-replaced)."""
     import triton.language.extra.libdevice as _ld
     from triton_viz.core.patch import _patch_libdevice
+    from triton_viz.core.libdevice_registry import _REGISTERED_SPECS
 
-    original_erf = _ld.erf
+    # Find an unregistered public function on the libdevice module
+    import inspect
+
+    unregistered_name = None
+    for name in dir(_ld):
+        if name.startswith("_") or name in _REGISTERED_SPECS:
+            continue
+        member = getattr(_ld, name, None)
+        if (
+            inspect.isfunction(member)
+            and getattr(member, "__module__", None) == _ld.__name__
+        ):
+            unregistered_name = name
+            break
+    if unregistered_name is None:
+        pytest.skip("No unregistered libdevice functions found")
+
+    original = getattr(_ld, unregistered_name)
 
     def _kernel():
         pass
 
-    _kernel.__globals__["my_erf"] = original_erf
+    _kernel.__globals__["_unreg_alias"] = original
 
     scope = _LangPatchScope()
     _patch_libdevice(_kernel, scope)
-    with pytest.raises(NotImplementedError, match="libdevice.erf"):
-        _kernel.__globals__["my_erf"](None)
+    # Unregistered alias must NOT be modified
+    assert _kernel.__globals__["_unreg_alias"] is original
 
     scope.restore()
-    assert _kernel.__globals__["my_erf"] is original_erf
-    del _kernel.__globals__["my_erf"]
+    del _kernel.__globals__["_unreg_alias"]
+
+
+def test_patch_libdevice_helper_same_module_alias():
+    """Direct-import alias in a same-module helper is patched via shared globals."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_tanh = _ld.tanh
+
+    # Simulate: from triton.language.extra.libdevice import tanh as _tanh
+    # Both kernel and helper share __globals__ when in the same module.
+    def _kernel():
+        pass
+
+    _kernel.__globals__["_tanh"] = original_tanh
+
+    scope = _LangPatchScope()
+    _patch_libdevice(_kernel, scope)
+    # Alias must be patched (same-module helpers share the kernel's globals)
+    assert _kernel.__globals__["_tanh"] is not original_tanh
+
+    scope.restore()
+    assert _kernel.__globals__["_tanh"] is original_tanh
+    del _kernel.__globals__["_tanh"]
+
+
+def test_patch_libdevice_default_arg_not_patched():
+    """Default args capturing a libdevice fn are NOT patched (known limitation)."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_tanh = _ld.tanh
+
+    def helper(x, op=original_tanh):
+        return op(x)
+
+    def _kernel():
+        pass
+
+    _kernel.__globals__["helper"] = helper
+
+    scope = _LangPatchScope()
+    _patch_libdevice(_kernel, scope)
+    # The default arg is captured at definition time and NOT rewritten.
+    assert helper.__defaults__[0] is original_tanh
+
+    scope.restore()
+    del _kernel.__globals__["helper"]
 
 
 def test_patch_lang_rollback_on_libdevice_failure(monkeypatch):

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -120,6 +120,26 @@ def test_scope_interleaved_restore_order():
 
 
 def test_scope_restore_not_monkey_patched():
-    """After _patch_libdevice, scope.restore must be the original method, not a closure."""
+    """After _patch_libdevice, scope.restore is the original method, not a closure."""
+    from triton_viz.core.patch import _patch_libdevice
+
     scope = _LangPatchScope()
+    _patch_libdevice(_dummy_kernel, scope)
     assert scope.restore.__func__ is _LangPatchScope.restore
+    scope.restore()  # clean up
+
+
+def test_libdevice_patch_and_restore():
+    """_patch_libdevice patches module attrs + aliases; restore undoes both."""
+    import triton.language.extra.libdevice as _ld
+    from triton_viz.core.patch import _patch_libdevice
+
+    original_tanh = _ld.tanh
+    scope = _LangPatchScope()
+    _patch_libdevice(_dummy_kernel, scope)
+
+    # Module attr is now patched
+    assert _ld.tanh is not original_tanh
+    scope.restore()
+    # Module attr is restored
+    assert _ld.tanh is original_tanh

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -14,6 +14,7 @@ from triton_viz.clients.symbolic_engine import (
     LoadSymbolicExpr,
     StoreSymbolicExpr,
 )
+from triton_viz.core.libdevice_registry import _np_erf
 from triton_viz.clients.sanitizer.sanitizer import (
     NullSanitizer,
     SymbolicSanitizer,
@@ -567,6 +568,7 @@ def test_store_dtype_block_of_pointers():
         ("tanh", np.tanh, False),
         ("asin", np.arcsin, False),
         ("acos", np.arccos, False),
+        ("erf", _np_erf, False),
         ("rsqrt", None, True),
     ],
 )

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -599,7 +599,7 @@ def test_unary_concretize(op_name, expected_np_func, is_builder):
 
 def test_libdevice_registry_sym_op_consistency():
     """Every LibdeviceSpec must have matching entries in the symbolic engine."""
-    from triton_viz.core.patch import _LIBDEVICE_REGISTRY
+    from triton_viz.core.libdevice_registry import _LIBDEVICE_REGISTRY
     from triton_viz.clients.symbolic_engine import _UNARY_NUMPY_TO_SYM_OP
     from triton.runtime.interpreter import interpreter_builder
 
@@ -641,3 +641,61 @@ def test_unary_z3_opaque_fallback():
     # Arange constraints must propagate through
     assert constraints is not None
     assert "arange_0_8" in str(constraints)
+
+
+def test_unary_z3_opaque_range_constraints():
+    """Opaque symbols for bounded ops carry range constraints."""
+    # tanh: bounded to [-1, 1]
+    arg = SymbolicExpr.create("arange", tl.int32, 0, 8)
+    expr = SymbolicExpr.create("tanh", arg)
+    result, constraints = expr.eval(simplify_constraints=False)
+
+    s = Solver()
+    s.add(constraints)
+    s.add(result > 1)
+    assert s.check() != sat, "tanh result > 1 should be unsat"
+
+    s2 = Solver()
+    s2.add(constraints)
+    s2.add(result < -1)
+    assert s2.check() != sat, "tanh result < -1 should be unsat"
+
+    # exp: bounded to >= 0
+    arg2 = SymbolicExpr.create("arange", tl.int32, 0, 8)
+    expr2 = SymbolicExpr.create("exp", arg2)
+    result2, constraints2 = expr2.eval(simplify_constraints=False)
+
+    s3 = Solver()
+    s3.add(constraints2)
+    s3.add(result2 < 0)
+    assert s3.check() != sat, "exp result < 0 should be unsat"
+
+    # value within range must be satisfiable
+    s4 = Solver()
+    s4.add(constraints)
+    s4.add(result == 0)
+    assert s4.check() == sat, "tanh result == 0 should be sat"
+
+
+def test_addptr_through_bounded_unary():
+    """addptr with a tanh-bounded offset produces tighter pointer bounds."""
+    base = SymbolicExpr.create("const", 1000, tl.pointer_type(tl.int32))
+    idx = SymbolicExpr.create("arange", tl.int32, 0, 8)
+    tanh_idx = SymbolicExpr.create("tanh", idx)
+    ptr = SymbolicExpr.create("addptr", base, tanh_idx)
+    result, constraints = ptr.eval(simplify_constraints=False)
+
+    assert result is not None
+    assert constraints is not None
+
+    # ptr = 1000 + tanh * 4  (int32 is 4 bytes)
+    # tanh in [-1, 1] => ptr in [996, 1004]
+    s = Solver()
+    s.add(constraints)
+    s.add(result < 996)
+    assert s.check() != sat, "ptr < 996 should be unsat with tanh bounds"
+
+    s2 = Solver()
+    s2.add(constraints)
+    s2.add(result > 1004)
+    assert s2.check() != sat, "ptr > 1004 should be unsat with tanh bounds"

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -562,21 +562,63 @@ def test_store_dtype_block_of_pointers():
 
 
 @pytest.mark.parametrize(
-    "op_name,np_func",
+    "op_name,expected_np_func,is_builder",
     [
-        ("tanh", np.tanh),
-        ("asin", np.arcsin),
-        ("acos", np.arccos),
+        ("tanh", np.tanh, False),
+        ("asin", np.arcsin, False),
+        ("acos", np.arccos, False),
+        ("rsqrt", None, True),
     ],
 )
-def test_unary_concretize(op_name, np_func):
-    """UnarySymbolicExpr.concretize() delegates to concrete_fn with the right numpy op."""
-    from triton.runtime.interpreter import interpreter_builder
+def test_unary_concretize(op_name, expected_np_func, is_builder):
+    """concretize() must pass the correct numpy op to concrete_fn."""
+    captured = {}
 
     arg = ConstSymbolicExpr("const", value=0, dtype=tl.block_type(tl.float32, [4]))
     expr = UnarySymbolicExpr(op_name, arg)
-    expr.concrete_fn = interpreter_builder.unary_op
 
-    # concretize should not raise
-    result = expr.concretize()
-    assert result is not None
+    if is_builder:
+
+        def _mock_builder(arg_concrete):
+            captured["called"] = True
+            return arg_concrete
+
+        expr.concrete_fn = _mock_builder
+        expr.concretize()
+        assert captured["called"] is True
+    else:
+
+        def _mock_unary_op(arg_concrete, np_func):
+            captured["np_func"] = np_func
+            return arg_concrete
+
+        expr.concrete_fn = _mock_unary_op
+        expr.concretize()
+        assert captured["np_func"] is expected_np_func
+
+
+def test_libdevice_registry_sym_op_consistency():
+    """Every LibdeviceSpec must have matching entries in the symbolic engine."""
+    from triton_viz.core.patch import _LIBDEVICE_REGISTRY
+    from triton_viz.clients.symbolic_engine import _UNARY_NUMPY_TO_SYM_OP
+    from triton.runtime.interpreter import interpreter_builder
+
+    for spec in _LIBDEVICE_REGISTRY:
+        assert spec.sym_name in SymbolicExpr.UNARY_OPS, (
+            f"LibdeviceSpec {spec.name!r} has sym_name={spec.sym_name!r} "
+            f"not in UNARY_OPS"
+        )
+        if spec.np_func is not None:
+            assert (
+                spec.np_func in _UNARY_NUMPY_TO_SYM_OP
+            ), f"LibdeviceSpec {spec.name!r} np_func not in _UNARY_NUMPY_TO_SYM_OP"
+            assert _UNARY_NUMPY_TO_SYM_OP[spec.np_func] == spec.sym_name, (
+                f"LibdeviceSpec {spec.name!r} sym_name mismatch: "
+                f"registry says {spec.sym_name!r}, "
+                f"_UNARY_NUMPY_TO_SYM_OP says {_UNARY_NUMPY_TO_SYM_OP[spec.np_func]!r}"
+            )
+        if spec.builder_method is not None:
+            assert hasattr(interpreter_builder, spec.builder_method), (
+                f"LibdeviceSpec {spec.name!r} builder_method={spec.builder_method!r} "
+                f"not found on interpreter_builder"
+            )

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,6 +1,7 @@
 import pytest
 from typing import cast
 
+import numpy as np
 import triton.language as tl
 
 from triton_viz.core.config import config as cfg
@@ -8,6 +9,7 @@ from triton_viz.clients import Sanitizer
 from triton_viz.clients.symbolic_engine import (
     SymbolicExpr,
     ConstSymbolicExpr,
+    UnarySymbolicExpr,
     ReduceSymbolicExpr,
     LoadSymbolicExpr,
     StoreSymbolicExpr,
@@ -554,3 +556,27 @@ def test_store_dtype_block_of_pointers():
     )
     store = StoreSymbolicExpr("store", ptr, value)
     assert store.dtype is None, f"Expected None, got {store.dtype}"
+
+
+# ======== Unary Concretize Tests ===========
+
+
+@pytest.mark.parametrize(
+    "op_name,np_func",
+    [
+        ("tanh", np.tanh),
+        ("asin", np.arcsin),
+        ("acos", np.arccos),
+    ],
+)
+def test_unary_concretize(op_name, np_func):
+    """UnarySymbolicExpr.concretize() delegates to concrete_fn with the right numpy op."""
+    from triton.runtime.interpreter import interpreter_builder
+
+    arg = ConstSymbolicExpr("const", value=0, dtype=tl.block_type(tl.float32, [4]))
+    expr = UnarySymbolicExpr(op_name, arg)
+    expr.concrete_fn = interpreter_builder.unary_op
+
+    # concretize should not raise
+    result = expr.concretize()
+    assert result is not None

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -604,11 +604,17 @@ def test_libdevice_registry_sym_op_consistency():
     from triton.runtime.interpreter import interpreter_builder
 
     for spec in _LIBDEVICE_REGISTRY:
-        assert spec.sym_name in SymbolicExpr.UNARY_OPS, (
-            f"LibdeviceSpec {spec.name!r} has sym_name={spec.sym_name!r} "
-            f"not in UNARY_OPS"
-        )
-        if spec.np_func is not None:
+        if spec.arity == 1:
+            assert spec.sym_name in SymbolicExpr.UNARY_OPS, (
+                f"LibdeviceSpec {spec.name!r} has sym_name={spec.sym_name!r} "
+                f"not in UNARY_OPS"
+            )
+        else:
+            assert spec.sym_name not in SymbolicExpr.UNARY_OPS, (
+                f"LibdeviceSpec {spec.name!r} (arity={spec.arity}) "
+                f"should NOT be in UNARY_OPS"
+            )
+        if spec.np_func is not None and spec.arity == 1:
             assert (
                 spec.np_func in _UNARY_NUMPY_TO_SYM_OP
             ), f"LibdeviceSpec {spec.name!r} np_func not in _UNARY_NUMPY_TO_SYM_OP"
@@ -622,3 +628,16 @@ def test_libdevice_registry_sym_op_consistency():
                 f"LibdeviceSpec {spec.name!r} builder_method={spec.builder_method!r} "
                 f"not found on interpreter_builder"
             )
+
+
+def test_unary_z3_opaque_fallback():
+    """Unary ops without Z3 builders return an opaque symbol, not raise."""
+    arg = SymbolicExpr.create("arange", tl.int32, 0, 8)
+    expr = SymbolicExpr.create("tanh", arg)
+    result, constraints = expr.eval(simplify_constraints=False)
+    # Must return a Z3 expression, not raise
+    assert result is not None
+    assert "unary_tanh_" in str(result)
+    # Arange constraints must propagate through
+    assert constraints is not None
+    assert "arange_0_8" in str(constraints)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -228,6 +228,8 @@ class SymbolicExpr:
         "sin",
         "rsqrt",
         "tanh",
+        "asin",
+        "acos",
     )
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
@@ -847,6 +849,32 @@ class UnarySymbolicExpr(SymbolicExpr):
         "abs": _abs,
         "fabs": _abs,
     }
+
+    _NUMPY_OPS: ClassVar[dict[str, Callable]] = {
+        "cos": np.cos,
+        "exp": np.exp,
+        "exp2": np.exp2,
+        "abs": np.abs,
+        "fabs": np.fabs,
+        "floor": np.floor,
+        "ceil": np.ceil,
+        "log": np.log,
+        "log2": np.log2,
+        "sqrt": np.sqrt,
+        "sin": np.sin,
+        "tanh": np.tanh,
+        "asin": np.arcsin,
+        "acos": np.arccos,
+    }
+
+    def concretize(self) -> Any:
+        arg_concrete = self.arg.concretize()
+        np_op = self._NUMPY_OPS.get(self.op)
+        if np_op is None:
+            raise NotImplementedError(
+                f"Concretize for unary op {self.op} is not implemented"
+            )
+        return self.concrete_fn(arg_concrete, np_op)  # type: ignore
 
 
 class BinarySymbolicExpr(SymbolicExpr):
@@ -1708,6 +1736,8 @@ _UNARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {
     np.sqrt: "sqrt",
     np.sin: "sin",
     np.tanh: "tanh",
+    np.arcsin: "asin",
+    np.arccos: "acos",
 }
 
 _BINARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -216,7 +216,10 @@ class SymbolicExpr:
         "tensor_pointer_store",
     )
     UNARY_OPS: ClassVar[tuple[str, ...]] = tuple(
-        sorted({spec.sym_name for spec in _LIBDEVICE_REGISTRY} | {"fabs"})
+        sorted(
+            {spec.sym_name for spec in _LIBDEVICE_REGISTRY if spec.arity == 1}
+            | {"fabs"}
+        )
     )
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
@@ -824,9 +827,13 @@ class UnarySymbolicExpr(SymbolicExpr):
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         val, constraints = self.arg._to_z3()
         handler = self._Z3_BUILDERS.get(self.op)
-        if handler is None:
-            raise NotImplementedError(f"Unary op {self.op} is not implemented")
-        return handler(val), constraints
+        if handler is not None:
+            return handler(val), constraints
+        # Conservative fallback: fresh unconstrained symbol.
+        # Transcendental ops have no precise Z3 integer semantics.
+        # Argument constraints are preserved for downstream analysis.
+        opaque = Int(f"unary_{self.op}_{id(self)}")
+        return opaque, constraints
 
     @staticmethod
     def _abs(val) -> Z3Expr:
@@ -841,13 +848,15 @@ class UnarySymbolicExpr(SymbolicExpr):
         **{
             spec.sym_name: spec.np_func
             for spec in _LIBDEVICE_REGISTRY
-            if spec.np_func is not None
+            if spec.np_func is not None and spec.arity == 1
         },
         "fabs": np.fabs,
     }
 
     _BUILDER_OPS: ClassVar[frozenset[str]] = frozenset(
-        spec.sym_name for spec in _LIBDEVICE_REGISTRY if spec.builder_method is not None
+        spec.sym_name
+        for spec in _LIBDEVICE_REGISTRY
+        if spec.builder_method is not None and spec.arity == 1
     )
 
     def concretize(self) -> Any:
@@ -1712,7 +1721,7 @@ SymbolicExpr.register_op_class(
 _UNARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {
     spec.np_func: spec.sym_name
     for spec in _LIBDEVICE_REGISTRY
-    if spec.np_func is not None
+    if spec.np_func is not None and spec.arity == 1
 }
 
 _BINARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -33,7 +33,7 @@ from triton.runtime.interpreter import TensorHandle, _get_np_dtype
 
 from ..core.client import Client
 from ..core.callbacks import OpCallbacks, ForLoopCallbacks
-from ..core.patch import _LIBDEVICE_REGISTRY
+from ..core.libdevice_registry import _LIBDEVICE_REGISTRY
 from ..core.data import (
     Op,
     UnaryOp,
@@ -824,15 +824,37 @@ class UnarySymbolicExpr(SymbolicExpr):
         self.dtype = self.arg.dtype
         self.shape = self.arg.shape
 
+    # Range bounds for opaque Z3 fallback: (lower, upper) where None means unbounded.
+    _Z3_RANGE_BOUNDS: ClassVar[dict[str, tuple[int | None, int | None]]] = {
+        "tanh": (-1, 1),
+        "sin": (-1, 1),
+        "cos": (-1, 1),
+        "asin": (-2, 2),
+        "acos": (0, 4),
+        "exp": (0, None),
+        "exp2": (0, None),
+        "sqrt": (0, None),
+        "rsqrt": (0, None),
+    }
+
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         val, constraints = self.arg._to_z3()
         handler = self._Z3_BUILDERS.get(self.op)
         if handler is not None:
             return handler(val), constraints
-        # Conservative fallback: fresh unconstrained symbol.
-        # Transcendental ops have no precise Z3 integer semantics.
+        # Conservative fallback: fresh symbol with range bounds where known.
         # Argument constraints are preserved for downstream analysis.
         opaque = Int(f"unary_{self.op}_{id(self)}")
+        bounds = self._Z3_RANGE_BOUNDS.get(self.op)
+        if bounds is not None:
+            lo, hi = bounds
+            parts: list = []
+            if lo is not None:
+                parts.append(opaque >= lo)
+            if hi is not None:
+                parts.append(opaque <= hi)
+            if parts:
+                constraints = _and_constraints(constraints, *parts)
         return opaque, constraints
 
     @staticmethod

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -227,6 +227,7 @@ class SymbolicExpr:
         "sqrt",
         "sin",
         "rsqrt",
+        "tanh",
     )
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
@@ -1639,6 +1640,7 @@ _UNARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {
     np.log2: "log2",
     np.sqrt: "sqrt",
     np.sin: "sin",
+    np.tanh: "tanh",
 }
 
 _BINARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -33,6 +33,7 @@ from triton.runtime.interpreter import TensorHandle, _get_np_dtype
 
 from ..core.client import Client
 from ..core.callbacks import OpCallbacks, ForLoopCallbacks
+from ..core.patch import _LIBDEVICE_REGISTRY
 from ..core.data import (
     Op,
     UnaryOp,
@@ -214,22 +215,8 @@ class SymbolicExpr:
         "tensor_pointer_load",
         "tensor_pointer_store",
     )
-    UNARY_OPS: ClassVar[tuple[str, ...]] = (
-        "cos",
-        "exp",
-        "exp2",
-        "abs",
-        "fabs",
-        "floor",
-        "ceil",
-        "log",
-        "log2",
-        "sqrt",
-        "sin",
-        "rsqrt",
-        "tanh",
-        "asin",
-        "acos",
+    UNARY_OPS: ClassVar[tuple[str, ...]] = tuple(
+        sorted({spec.sym_name for spec in _LIBDEVICE_REGISTRY} | {"fabs"})
     )
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
@@ -851,24 +838,22 @@ class UnarySymbolicExpr(SymbolicExpr):
     }
 
     _NUMPY_OPS: ClassVar[dict[str, Callable]] = {
-        "cos": np.cos,
-        "exp": np.exp,
-        "exp2": np.exp2,
-        "abs": np.abs,
+        **{
+            spec.sym_name: spec.np_func
+            for spec in _LIBDEVICE_REGISTRY
+            if spec.np_func is not None
+        },
         "fabs": np.fabs,
-        "floor": np.floor,
-        "ceil": np.ceil,
-        "log": np.log,
-        "log2": np.log2,
-        "sqrt": np.sqrt,
-        "sin": np.sin,
-        "tanh": np.tanh,
-        "asin": np.arcsin,
-        "acos": np.arccos,
     }
+
+    _BUILDER_OPS: ClassVar[frozenset[str]] = frozenset(
+        spec.sym_name for spec in _LIBDEVICE_REGISTRY if spec.builder_method is not None
+    )
 
     def concretize(self) -> Any:
         arg_concrete = self.arg.concretize()
+        if self.op in self._BUILDER_OPS:
+            return self.concrete_fn(arg_concrete)  # type: ignore
         np_op = self._NUMPY_OPS.get(self.op)
         if np_op is None:
             raise NotImplementedError(
@@ -1725,19 +1710,9 @@ SymbolicExpr.register_op_class(
 # ── Shared constants and utilities for symbolic clients ──────────
 
 _UNARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {
-    np.cos: "cos",
-    np.exp: "exp",
-    np.exp2: "exp2",
-    np.abs: "abs",
-    np.floor: "floor",
-    np.ceil: "ceil",
-    np.log: "log",
-    np.log2: "log2",
-    np.sqrt: "sqrt",
-    np.sin: "sin",
-    np.tanh: "tanh",
-    np.arcsin: "asin",
-    np.arccos: "acos",
+    spec.np_func: spec.sym_name
+    for spec in _LIBDEVICE_REGISTRY
+    if spec.np_func is not None
 }
 
 _BINARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {

--- a/triton_viz/core/libdevice_registry.py
+++ b/triton_viz/core/libdevice_registry.py
@@ -6,10 +6,18 @@ Centralizes ``LibdeviceSpec`` definitions so that both ``core.patch`` and
 
 from __future__ import annotations
 
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 
 import numpy as np
+
+_vectorized_erf = np.vectorize(math.erf)
+
+
+def _np_erf(x: np.ndarray) -> np.ndarray:
+    """Vectorized erf that preserves input dtype."""
+    return _vectorized_erf(x).astype(x.dtype, copy=False)
 
 
 @dataclass(frozen=True)
@@ -36,6 +44,7 @@ _LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
     LibdeviceSpec("tanh", np.tanh, 1, "tanh"),
     LibdeviceSpec("asin", np.arcsin, 1, "asin"),
     LibdeviceSpec("acos", np.arccos, 1, "acos"),
+    LibdeviceSpec("erf", _np_erf, 1, "erf"),
     # Builder-backed ops (use interpreter_builder methods directly)
     LibdeviceSpec("rsqrt", None, 1, "rsqrt", builder_method="create_rsqrt"),
 ]

--- a/triton_viz/core/libdevice_registry.py
+++ b/triton_viz/core/libdevice_registry.py
@@ -1,0 +1,44 @@
+"""Libdevice function registry.
+
+Centralizes ``LibdeviceSpec`` definitions so that both ``core.patch`` and
+``clients.symbolic_engine`` can import them without a circular dependency.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class LibdeviceSpec:
+    name: str  # libdevice function name, e.g. "tanh"
+    np_func: Callable | None  # numpy equivalent (None for builder ops)
+    arity: int  # 1, 2, or 3
+    sym_name: str  # symbolic engine op name, e.g. "tanh"
+    builder_method: str | None = None  # interpreter_builder method name
+
+
+_LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
+    # Unary ops (numpy-backed)
+    LibdeviceSpec("abs", np.abs, 1, "abs"),
+    LibdeviceSpec("ceil", np.ceil, 1, "ceil"),
+    LibdeviceSpec("cos", np.cos, 1, "cos"),
+    LibdeviceSpec("exp", np.exp, 1, "exp"),
+    LibdeviceSpec("exp2", np.exp2, 1, "exp2"),
+    LibdeviceSpec("floor", np.floor, 1, "floor"),
+    LibdeviceSpec("log", np.log, 1, "log"),
+    LibdeviceSpec("log2", np.log2, 1, "log2"),
+    LibdeviceSpec("sin", np.sin, 1, "sin"),
+    LibdeviceSpec("sqrt", np.sqrt, 1, "sqrt"),
+    LibdeviceSpec("tanh", np.tanh, 1, "tanh"),
+    LibdeviceSpec("asin", np.arcsin, 1, "asin"),
+    LibdeviceSpec("acos", np.arccos, 1, "acos"),
+    # Builder-backed ops (use interpreter_builder methods directly)
+    LibdeviceSpec("rsqrt", None, 1, "rsqrt", builder_method="create_rsqrt"),
+]
+
+# Pre-built name → spec lookup
+_REGISTERED_SPECS: dict[str, LibdeviceSpec] = {s.name: s for s in _LIBDEVICE_REGISTRY}

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -39,23 +39,36 @@ _MISSING = object()
 
 
 class _LangPatchScope:
-    """Tracks patched attributes so they can be restored."""
+    """Tracks patched attributes and dict items so they can be restored."""
 
     def __init__(self) -> None:
-        self._changes: list[tuple[object, str, object]] = []
+        self._changes: list[tuple[Any, ...]] = []  # tagged entries
 
     def set_attr(self, obj: object, name: str, value: object) -> None:
         original = getattr(obj, name, _MISSING)
-        self._changes.append((obj, name, original))
+        self._changes.append(("attr", obj, name, original))
         setattr(obj, name, value)
+
+    def set_item(self, mapping: dict, key: str, value: object) -> None:
+        original = mapping.get(key, _MISSING)
+        self._changes.append(("item", mapping, key, original))
+        mapping[key] = value
 
     def restore(self) -> None:
         while self._changes:
-            obj, name, original = self._changes.pop()
-            if original is _MISSING:
-                delattr(obj, name)
-            else:
-                setattr(obj, name, original)
+            entry = self._changes.pop()
+            if entry[0] == "attr":
+                _, obj, name, original = entry
+                if original is _MISSING:
+                    delattr(obj, name)
+                else:
+                    setattr(obj, name, original)
+            elif entry[0] == "item":
+                _, mapping, key, original = entry
+                if original is _MISSING:
+                    mapping.pop(key, None)
+                else:
+                    mapping[key] = original
 
 
 _LANG_PATCH_SCOPES: dict[str, list[Any]] = {"triton": [], "nki": [], "nki_beta2": []}
@@ -326,59 +339,138 @@ def unpatch_for_loop():
 # Triton's _patch_lang does NOT patch triton.language.extra.libdevice,
 # so stub functions like ``def tanh(arg0): ...`` return None in
 # interpreter mode.  We replace them with numpy-backed implementations
-# that route through interpreter_builder.unary_op so the symbolic
-# engine can track them.
-
-_LIBDEVICE_NUMPY_MAP: dict[str, Callable] = {
-    "tanh": np.tanh,
-}
+# that route through interpreter_builder so the symbolic engine can
+# track them.  Unsupported ops raise NotImplementedError immediately
+# rather than silently returning None.
 
 
-def _make_libdevice_interpreter_fn(np_func: Callable) -> Callable:
-    """Return a replacement for a libdevice stub that computes via numpy."""
+@dataclass(frozen=True)
+class LibdeviceSpec:
+    name: str  # libdevice function name, e.g. "tanh"
+    np_func: Callable  # numpy equivalent, e.g. np.tanh
+    arity: int  # 1, 2, or 3
+    sym_name: str  # symbolic engine op name, e.g. "tanh"
 
-    def _replacement(arg0):
+
+_LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
+    # Unary ops
+    LibdeviceSpec("abs", np.abs, 1, "abs"),
+    LibdeviceSpec("ceil", np.ceil, 1, "ceil"),
+    LibdeviceSpec("cos", np.cos, 1, "cos"),
+    LibdeviceSpec("exp", np.exp, 1, "exp"),
+    LibdeviceSpec("exp2", np.exp2, 1, "exp2"),
+    LibdeviceSpec("floor", np.floor, 1, "floor"),
+    LibdeviceSpec("log", np.log, 1, "log"),
+    LibdeviceSpec("log2", np.log2, 1, "log2"),
+    LibdeviceSpec("sin", np.sin, 1, "sin"),
+    LibdeviceSpec("sqrt", np.sqrt, 1, "sqrt"),
+    LibdeviceSpec("tanh", np.tanh, 1, "tanh"),
+    LibdeviceSpec("asin", np.arcsin, 1, "asin"),
+    LibdeviceSpec("acos", np.arccos, 1, "acos"),
+]
+
+
+def _make_libdevice_unary(np_func: Callable) -> Callable:
+    def _fn(arg0: Any) -> Any:
         handle = interpreter_builder.unary_op(arg0.handle, np_func)
         return tl.core.tensor(handle, arg0.type)
 
-    return _replacement
+    return _fn
+
+
+def _make_libdevice_binary(np_func: Callable) -> Callable:
+    def _fn(arg0: Any, arg1: Any) -> Any:
+        handle = interpreter_builder.binary_op(arg0.handle, arg1.handle, np_func)
+        return tl.core.tensor(handle, arg0.type)
+
+    return _fn
+
+
+def _make_libdevice_ternary(np_func: Callable) -> Callable:
+    def _fn(arg0: Any, arg1: Any, arg2: Any) -> Any:
+        handle = interpreter_builder.ternary_op(
+            arg0.handle, arg1.handle, arg2.handle, np_func
+        )
+        return tl.core.tensor(handle, arg0.type)
+
+    return _fn
+
+
+_ARITY_FACTORIES: dict[int, Callable[[Callable], Callable]] = {
+    1: _make_libdevice_unary,
+    2: _make_libdevice_binary,
+    3: _make_libdevice_ternary,
+}
+
+
+def _make_libdevice_interpreter_fn(spec: LibdeviceSpec) -> Callable:
+    """Return a replacement for a libdevice stub that computes via numpy."""
+    factory = _ARITY_FACTORIES.get(spec.arity)
+    if factory is None:
+        raise ValueError(f"Unsupported arity {spec.arity} for {spec.name}")
+    return factory(spec.np_func)
+
+
+def _make_unsupported_libdevice_fn(name: str) -> Callable:
+    def _unsupported(*args, **kwargs):
+        raise NotImplementedError(
+            f"libdevice.{name}() is not supported in interpreter/sanitizer mode. "
+            f"Add a LibdeviceSpec to _LIBDEVICE_REGISTRY to enable it."
+        )
+
+    _unsupported.__name__ = name
+    return _unsupported
+
+
+def _patch_libdevice_module(scope: _LangPatchScope) -> None:
+    """Patch the libdevice module itself (covers ``libdevice.tanh(x)``)."""
+    import triton.language.extra.libdevice as _ld
+
+    registered = {s.name: s for s in _LIBDEVICE_REGISTRY}
+
+    # Patch registered ops
+    for name, spec in registered.items():
+        if hasattr(_ld, name):
+            scope.set_attr(_ld, name, _make_libdevice_interpreter_fn(spec))
+
+    # Patch unregistered stubs with unsupported-op errors
+    for name in dir(_ld):
+        if name.startswith("_") or name in registered:
+            continue
+        member = getattr(_ld, name, None)
+        if (
+            inspect.isfunction(member)
+            and getattr(member, "__module__", None) == _ld.__name__
+        ):
+            scope.set_attr(_ld, name, _make_unsupported_libdevice_fn(name))
+
+
+def _patch_libdevice_aliases(fn: Callable, scope: _LangPatchScope) -> None:
+    """Patch fn.__globals__ for direct imports (``from ... import tanh``)."""
+    import triton.language.extra.libdevice as _ld
+
+    registered = {s.name: s for s in _LIBDEVICE_REGISTRY}
+    for gname, gvalue in list(fn.__globals__.items()):
+        if not callable(gvalue):
+            continue
+        if getattr(gvalue, "__module__", None) != _ld.__name__:
+            continue
+        orig_name = getattr(gvalue, "__name__", None)
+        if orig_name is None:
+            continue
+        spec = registered.get(orig_name)
+        if spec is not None:
+            scope.set_item(fn.__globals__, gname, _make_libdevice_interpreter_fn(spec))
+        else:
+            scope.set_item(
+                fn.__globals__, gname, _make_unsupported_libdevice_fn(orig_name)
+            )
 
 
 def _patch_libdevice(fn: Callable, scope: _LangPatchScope) -> None:
     """Patch libdevice stub functions for interpreter / sanitizer mode."""
-    import triton.language.extra.libdevice as _ld
-
-    # Collect original stubs by identity so we can detect direct imports.
-    stubs: dict[int, Callable] = {}
-    for name, np_func in _LIBDEVICE_NUMPY_MAP.items():
-        stub = getattr(_ld, name, None)
-        if stub is not None:
-            stubs[id(stub)] = np_func
-
-    # Patch module-level attributes (covers ``libdevice.tanh(x)`` usage).
-    for name, np_func in _LIBDEVICE_NUMPY_MAP.items():
-        if hasattr(_ld, name):
-            scope.set_attr(_ld, name, _make_libdevice_interpreter_fn(np_func))
-
-    # Patch fn.__globals__ for direct imports
-    # (covers ``from triton.language.extra.libdevice import tanh``).
-    globals_saved: dict[str, Any] = {}
-    for gname, gvalue in list(fn.__globals__.items()):
-        if callable(gvalue) and id(gvalue) in stubs:
-            globals_saved[gname] = gvalue
-            fn.__globals__[gname] = _make_libdevice_interpreter_fn(
-                stubs[id(gvalue)]
-            )
-
-    if globals_saved:
-        _original_restore = scope.restore
-
-        def _extended_restore() -> None:
-            for gname, original in globals_saved.items():
-                fn.__globals__[gname] = original
-            _original_restore()
-
-        scope.restore = _extended_restore  # type: ignore[assignment]
+    _patch_libdevice_module(scope)
+    _patch_libdevice_aliases(fn, scope)
 
 
 def patch_lang(fn, backend, client_manager=None):

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -7,11 +7,15 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import SimpleQueue, Empty
 import threading
 import time
-from functools import partialmethod
-import numpy as np
+from functools import cache, partialmethod
 
 from .config import config as cfg
 from .callbacks import OpCallbacks
+from .libdevice_registry import (
+    LibdeviceSpec,
+    _LIBDEVICE_REGISTRY,
+    _REGISTERED_SPECS,
+)
 
 from .data import (
     Op,
@@ -344,35 +348,6 @@ def unpatch_for_loop():
 # rather than silently returning None.
 
 
-@dataclass(frozen=True)
-class LibdeviceSpec:
-    name: str  # libdevice function name, e.g. "tanh"
-    np_func: Callable | None  # numpy equivalent (None for builder ops)
-    arity: int  # 1, 2, or 3
-    sym_name: str  # symbolic engine op name, e.g. "tanh"
-    builder_method: str | None = None  # interpreter_builder method name
-
-
-_LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
-    # Unary ops (numpy-backed)
-    LibdeviceSpec("abs", np.abs, 1, "abs"),
-    LibdeviceSpec("ceil", np.ceil, 1, "ceil"),
-    LibdeviceSpec("cos", np.cos, 1, "cos"),
-    LibdeviceSpec("exp", np.exp, 1, "exp"),
-    LibdeviceSpec("exp2", np.exp2, 1, "exp2"),
-    LibdeviceSpec("floor", np.floor, 1, "floor"),
-    LibdeviceSpec("log", np.log, 1, "log"),
-    LibdeviceSpec("log2", np.log2, 1, "log2"),
-    LibdeviceSpec("sin", np.sin, 1, "sin"),
-    LibdeviceSpec("sqrt", np.sqrt, 1, "sqrt"),
-    LibdeviceSpec("tanh", np.tanh, 1, "tanh"),
-    LibdeviceSpec("asin", np.arcsin, 1, "asin"),
-    LibdeviceSpec("acos", np.arccos, 1, "acos"),
-    # Builder-backed ops (use interpreter_builder methods directly)
-    LibdeviceSpec("rsqrt", None, 1, "rsqrt", builder_method="create_rsqrt"),
-]
-
-
 def _make_libdevice_unary(np_func: Callable) -> Callable:
     def _fn(arg0: Any) -> Any:
         handle = interpreter_builder.unary_op(arg0.handle, np_func)
@@ -430,6 +405,7 @@ def _make_libdevice_interpreter_fn(spec: LibdeviceSpec) -> Callable:
     return factory(spec.np_func)
 
 
+@cache
 def _make_unsupported_libdevice_fn(name: str) -> Callable:
     def _unsupported(*args, **kwargs):
         raise NotImplementedError(
@@ -440,20 +416,24 @@ def _make_unsupported_libdevice_fn(name: str) -> Callable:
     return _unsupported
 
 
+# Pre-built interpreter wrappers: reused across patch calls.
+_INTERPRETER_FNS: dict[str, Callable] = {
+    spec.name: _make_libdevice_interpreter_fn(spec) for spec in _LIBDEVICE_REGISTRY
+}
+
+
 def _patch_libdevice_module(scope: _LangPatchScope) -> None:
     """Patch the libdevice module itself (covers ``libdevice.tanh(x)``)."""
     import triton.language.extra.libdevice as _ld
 
-    registered = {s.name: s for s in _LIBDEVICE_REGISTRY}
-
     # Patch registered ops
-    for name, spec in registered.items():
+    for name, fn in _INTERPRETER_FNS.items():
         if hasattr(_ld, name):
-            scope.set_attr(_ld, name, _make_libdevice_interpreter_fn(spec))
+            scope.set_attr(_ld, name, fn)
 
     # Patch unregistered stubs with unsupported-op errors
     for name in dir(_ld):
-        if name.startswith("_") or name in registered:
+        if name.startswith("_") or name in _REGISTERED_SPECS:
             continue
         member = getattr(_ld, name, None)
         if (
@@ -467,7 +447,6 @@ def _patch_libdevice_aliases(fn: Callable, scope: _LangPatchScope) -> None:
     """Patch fn.__globals__ for direct imports (``from ... import tanh``)."""
     import triton.language.extra.libdevice as _ld
 
-    registered = {s.name: s for s in _LIBDEVICE_REGISTRY}
     for gname, gvalue in list(fn.__globals__.items()):
         if not callable(gvalue):
             continue
@@ -476,17 +455,31 @@ def _patch_libdevice_aliases(fn: Callable, scope: _LangPatchScope) -> None:
         orig_name = getattr(gvalue, "__name__", None)
         if orig_name is None:
             continue
-        spec = registered.get(orig_name)
-        if spec is not None:
-            scope.set_item(fn.__globals__, gname, _make_libdevice_interpreter_fn(spec))
+        interp_fn = _INTERPRETER_FNS.get(orig_name)
+        if interp_fn is not None:
+            scope.set_item(fn.__globals__, gname, interp_fn)
         else:
             scope.set_item(
                 fn.__globals__, gname, _make_unsupported_libdevice_fn(orig_name)
             )
 
 
+def _kernel_references_libdevice(fn: Callable) -> bool:
+    """Check if the kernel's globals reference the libdevice module or its functions."""
+    import triton.language.extra.libdevice as _ld
+
+    for gvalue in fn.__globals__.values():
+        if gvalue is _ld:
+            return True
+        if callable(gvalue) and getattr(gvalue, "__module__", None) == _ld.__name__:
+            return True
+    return False
+
+
 def _patch_libdevice(fn: Callable, scope: _LangPatchScope) -> None:
     """Patch libdevice stub functions for interpreter / sanitizer mode."""
+    if not _kernel_references_libdevice(fn):
+        return
     _patch_libdevice_module(scope)
     _patch_libdevice_aliases(fn, scope)
 
@@ -494,8 +487,12 @@ def _patch_libdevice(fn: Callable, scope: _LangPatchScope) -> None:
 def patch_lang(fn, backend, client_manager=None):
     if backend == "triton":
         scope = _triton_snapshot_scope(fn)
-        triton_patch_lang(fn)
-        _patch_libdevice(fn, scope)
+        try:
+            triton_patch_lang(fn)
+            _patch_libdevice(fn, scope)
+        except Exception:
+            scope.restore()
+            raise
     elif backend == "nki":
         from triton_viz.core.nki import nki_patch_lang
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -347,13 +347,14 @@ def unpatch_for_loop():
 @dataclass(frozen=True)
 class LibdeviceSpec:
     name: str  # libdevice function name, e.g. "tanh"
-    np_func: Callable  # numpy equivalent, e.g. np.tanh
+    np_func: Callable | None  # numpy equivalent (None for builder ops)
     arity: int  # 1, 2, or 3
     sym_name: str  # symbolic engine op name, e.g. "tanh"
+    builder_method: str | None = None  # interpreter_builder method name
 
 
 _LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
-    # Unary ops
+    # Unary ops (numpy-backed)
     LibdeviceSpec("abs", np.abs, 1, "abs"),
     LibdeviceSpec("ceil", np.ceil, 1, "ceil"),
     LibdeviceSpec("cos", np.cos, 1, "cos"),
@@ -367,6 +368,8 @@ _LIBDEVICE_REGISTRY: list[LibdeviceSpec] = [
     LibdeviceSpec("tanh", np.tanh, 1, "tanh"),
     LibdeviceSpec("asin", np.arcsin, 1, "asin"),
     LibdeviceSpec("acos", np.arccos, 1, "acos"),
+    # Builder-backed ops (use interpreter_builder methods directly)
+    LibdeviceSpec("rsqrt", None, 1, "rsqrt", builder_method="create_rsqrt"),
 ]
 
 
@@ -403,8 +406,24 @@ _ARITY_FACTORIES: dict[int, Callable[[Callable], Callable]] = {
 }
 
 
+def _make_libdevice_builder_fn(method_name: str) -> Callable:
+    """Return a replacement that delegates to an interpreter_builder method."""
+
+    def _fn(arg0: Any) -> Any:
+        handle = getattr(interpreter_builder, method_name)(arg0.handle)
+        return tl.core.tensor(handle, arg0.type)
+
+    return _fn
+
+
 def _make_libdevice_interpreter_fn(spec: LibdeviceSpec) -> Callable:
-    """Return a replacement for a libdevice stub that computes via numpy."""
+    """Return a replacement for a libdevice stub that computes via numpy or builder."""
+    if spec.builder_method is not None:
+        return _make_libdevice_builder_fn(spec.builder_method)
+    if spec.np_func is None:
+        raise ValueError(
+            f"LibdeviceSpec {spec.name!r} has no np_func or builder_method"
+        )
     factory = _ARITY_FACTORIES.get(spec.arity)
     if factory is None:
         raise ValueError(f"Unsupported arity {spec.arity} for {spec.name}")
@@ -414,8 +433,7 @@ def _make_libdevice_interpreter_fn(spec: LibdeviceSpec) -> Callable:
 def _make_unsupported_libdevice_fn(name: str) -> Callable:
     def _unsupported(*args, **kwargs):
         raise NotImplementedError(
-            f"libdevice.{name}() is not supported in interpreter/sanitizer mode. "
-            f"Add a LibdeviceSpec to _LIBDEVICE_REGISTRY to enable it."
+            f"libdevice.{name}() is not supported in interpreter/sanitizer mode."
         )
 
     _unsupported.__name__ = name

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -8,6 +8,7 @@ from queue import SimpleQueue, Empty
 import threading
 import time
 from functools import partialmethod
+import numpy as np
 
 from .config import config as cfg
 from .callbacks import OpCallbacks, ForLoopCallbacks
@@ -416,10 +417,70 @@ def unpatch_for_loop():
     _loop_patcher.unpatch()
 
 
+# ── Libdevice stub patching ─────────────────────────────────────
+# Triton's _patch_lang does NOT patch triton.language.extra.libdevice,
+# so stub functions like ``def tanh(arg0): ...`` return None in
+# interpreter mode.  We replace them with numpy-backed implementations
+# that route through interpreter_builder.unary_op so the symbolic
+# engine can track them.
+
+_LIBDEVICE_NUMPY_MAP: dict[str, Callable] = {
+    "tanh": np.tanh,
+}
+
+
+def _make_libdevice_interpreter_fn(np_func: Callable) -> Callable:
+    """Return a replacement for a libdevice stub that computes via numpy."""
+
+    def _replacement(arg0):
+        handle = interpreter_builder.unary_op(arg0.handle, np_func)
+        return tl.core.tensor(handle, arg0.type)
+
+    return _replacement
+
+
+def _patch_libdevice(fn: Callable, scope: _LangPatchScope) -> None:
+    """Patch libdevice stub functions for interpreter / sanitizer mode."""
+    import triton.language.extra.libdevice as _ld
+
+    # Collect original stubs by identity so we can detect direct imports.
+    stubs: dict[int, Callable] = {}
+    for name, np_func in _LIBDEVICE_NUMPY_MAP.items():
+        stub = getattr(_ld, name, None)
+        if stub is not None:
+            stubs[id(stub)] = np_func
+
+    # Patch module-level attributes (covers ``libdevice.tanh(x)`` usage).
+    for name, np_func in _LIBDEVICE_NUMPY_MAP.items():
+        if hasattr(_ld, name):
+            scope.set_attr(_ld, name, _make_libdevice_interpreter_fn(np_func))
+
+    # Patch fn.__globals__ for direct imports
+    # (covers ``from triton.language.extra.libdevice import tanh``).
+    globals_saved: dict[str, Any] = {}
+    for gname, gvalue in list(fn.__globals__.items()):
+        if callable(gvalue) and id(gvalue) in stubs:
+            globals_saved[gname] = gvalue
+            fn.__globals__[gname] = _make_libdevice_interpreter_fn(
+                stubs[id(gvalue)]
+            )
+
+    if globals_saved:
+        _original_restore = scope.restore
+
+        def _extended_restore() -> None:
+            for gname, original in globals_saved.items():
+                fn.__globals__[gname] = original
+            _original_restore()
+
+        scope.restore = _extended_restore  # type: ignore[assignment]
+
+
 def patch_lang(fn, backend):
     if backend == "triton":
         scope = _triton_snapshot_scope(fn)
         triton_patch_lang(fn)
+        _patch_libdevice(fn, scope)
     elif backend == "nki":
         from triton_viz.core.nki import nki_patch_lang
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -7,14 +7,13 @@ from concurrent.futures import ThreadPoolExecutor
 from queue import SimpleQueue, Empty
 import threading
 import time
-from functools import cache, partialmethod
+from functools import partialmethod
 
 from .config import config as cfg
 from .callbacks import OpCallbacks
 from .libdevice_registry import (
     LibdeviceSpec,
     _LIBDEVICE_REGISTRY,
-    _REGISTERED_SPECS,
 )
 
 from .data import (
@@ -342,10 +341,10 @@ def unpatch_for_loop():
 # ── Libdevice stub patching ─────────────────────────────────────
 # Triton's _patch_lang does NOT patch triton.language.extra.libdevice,
 # so stub functions like ``def tanh(arg0): ...`` return None in
-# interpreter mode.  We replace them with numpy-backed implementations
-# that route through interpreter_builder so the symbolic engine can
-# track them.  Unsupported ops raise NotImplementedError immediately
-# rather than silently returning None.
+# interpreter mode.  We replace registered stubs with numpy-backed or
+# builder-backed implementations that route through interpreter_builder
+# so the symbolic engine can track them.  Unregistered stubs are left
+# as-is — only the symbols the kernel actually uses are patched.
 
 
 def _make_libdevice_unary(np_func: Callable) -> Callable:
@@ -405,17 +404,6 @@ def _make_libdevice_interpreter_fn(spec: LibdeviceSpec) -> Callable:
     return factory(spec.np_func)
 
 
-@cache
-def _make_unsupported_libdevice_fn(name: str) -> Callable:
-    def _unsupported(*args, **kwargs):
-        raise NotImplementedError(
-            f"libdevice.{name}() is not supported in interpreter/sanitizer mode."
-        )
-
-    _unsupported.__name__ = name
-    return _unsupported
-
-
 # Pre-built interpreter wrappers: reused across patch calls.
 _INTERPRETER_FNS: dict[str, Callable] = {
     spec.name: _make_libdevice_interpreter_fn(spec) for spec in _LIBDEVICE_REGISTRY
@@ -426,21 +414,9 @@ def _patch_libdevice_module(scope: _LangPatchScope) -> None:
     """Patch the libdevice module itself (covers ``libdevice.tanh(x)``)."""
     import triton.language.extra.libdevice as _ld
 
-    # Patch registered ops
     for name, fn in _INTERPRETER_FNS.items():
         if hasattr(_ld, name):
             scope.set_attr(_ld, name, fn)
-
-    # Patch unregistered stubs with unsupported-op errors
-    for name in dir(_ld):
-        if name.startswith("_") or name in _REGISTERED_SPECS:
-            continue
-        member = getattr(_ld, name, None)
-        if (
-            inspect.isfunction(member)
-            and getattr(member, "__module__", None) == _ld.__name__
-        ):
-            scope.set_attr(_ld, name, _make_unsupported_libdevice_fn(name))
 
 
 def _patch_libdevice_aliases(fn: Callable, scope: _LangPatchScope) -> None:
@@ -458,10 +434,6 @@ def _patch_libdevice_aliases(fn: Callable, scope: _LangPatchScope) -> None:
         interp_fn = _INTERPRETER_FNS.get(orig_name)
         if interp_fn is not None:
             scope.set_item(fn.__globals__, gname, interp_fn)
-        else:
-            scope.set_item(
-                fn.__globals__, gname, _make_unsupported_libdevice_fn(orig_name)
-            )
 
 
 def _kernel_references_libdevice(fn: Callable) -> bool:


### PR DESCRIPTION
## Summary
- Libdevice stub functions (e.g. `tanh`) return `None` in interpreter/sanitizer mode because Triton's `_patch_lang` does not patch the `triton.language.extra.libdevice` module, causing `TypeError: cannot convert None of type <class 'NoneType'> to tensor` when the result is passed to `tl.store`
- Replace libdevice stubs with numpy-backed implementations that route through `interpreter_builder.unary_op`, handling both module attribute access (`libdevice.tanh(x)`) and direct imports (`from ... import tanh`)
- Register `tanh` as a symbolic unary operation (`UNARY_OPS` + `_UNARY_NUMPY_TO_SYM_OP`) so the sanitizer can track it

## Test plan
- [x] Added `test_libdevice_tanh` end-to-end test that exercises the exact reproducer pattern (load → tanh → store)
- [x] All 21 existing sanitizer tests continue to pass