### PR TITLE
[FIX] Preserve block_type in CastSymbolicExpr and _resolve_element_dtype

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -301,7 +301,7 @@ def test_loop_deferred_checks_simplify():
 
 
 # Dedicated sanitizer for nested loop regression test
-nested_loop_checker = SymbolicSanitizer()
+nested_loop_checker = SymbolicSanitizer(abort_on_error=False)
 
 
 @triton_viz.trace(client=nested_loop_checker)
@@ -329,7 +329,7 @@ def test_nested_loop_no_false_positive():
 
 
 # Create a dedicated sanitizer for line number tests
-line_number_checker: SymbolicSanitizer = SymbolicSanitizer()
+line_number_checker: SymbolicSanitizer = SymbolicSanitizer(abort_on_error=False)
 
 
 @triton_viz.trace(client=line_number_checker)
@@ -452,7 +452,7 @@ def test_gemm_oob_call_stack():
 # ======== Block Tensor (Block Pointer) Tests ===========
 
 
-block_sanitizer = SymbolicSanitizer()
+block_sanitizer = SymbolicSanitizer(abort_on_error=False)
 
 
 @triton_viz.trace(client=block_sanitizer)
@@ -813,7 +813,7 @@ def test_cli_code_context_points_to_kernel():
 
 # ======== Reduce + Broadcast Tests ===========
 
-reduce_broadcast_sanitizer = SymbolicSanitizer()
+reduce_broadcast_sanitizer = SymbolicSanitizer(abort_on_error=False)
 
 
 @triton_viz.trace(client=reduce_broadcast_sanitizer)

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -301,7 +301,7 @@ def test_loop_deferred_checks_simplify():
 
 
 # Dedicated sanitizer for nested loop regression test
-nested_loop_checker = SymbolicSanitizer(abort_on_error=False)
+nested_loop_checker = SymbolicSanitizer()
 
 
 @triton_viz.trace(client=nested_loop_checker)
@@ -329,7 +329,7 @@ def test_nested_loop_no_false_positive():
 
 
 # Create a dedicated sanitizer for line number tests
-line_number_checker: SymbolicSanitizer = SymbolicSanitizer(abort_on_error=False)
+line_number_checker: SymbolicSanitizer = SymbolicSanitizer()
 
 
 @triton_viz.trace(client=line_number_checker)
@@ -452,7 +452,7 @@ def test_gemm_oob_call_stack():
 # ======== Block Tensor (Block Pointer) Tests ===========
 
 
-block_sanitizer = SymbolicSanitizer(abort_on_error=False)
+block_sanitizer = SymbolicSanitizer()
 
 
 @triton_viz.trace(client=block_sanitizer)
@@ -813,7 +813,7 @@ def test_cli_code_context_points_to_kernel():
 
 # ======== Reduce + Broadcast Tests ===========
 
-reduce_broadcast_sanitizer = SymbolicSanitizer(abort_on_error=False)
+reduce_broadcast_sanitizer = SymbolicSanitizer()
 
 
 @triton_viz.trace(client=reduce_broadcast_sanitizer)
@@ -873,3 +873,31 @@ def test_oob_with_fake_tensor():
             fake_tensor_oob_kernel[(1,)](x, out, N=8)
     finally:
         config.virtual_memory = old_virtual_memory
+
+
+@triton_viz.trace(client=SymbolicSanitizer())
+@triton.jit
+def block_ptr_sum_kernel(
+    s_ptr,
+    z_ptr,
+    T: tl.constexpr,
+    S: tl.constexpr,
+    BT: tl.constexpr,
+    BS: tl.constexpr,
+):
+    o_i = tl.arange(0, BT)
+    m = tl.where(o_i[:, None] <= o_i[None, :], 1.0, 0.0)
+    b_z = tl.zeros([BS], dtype=tl.float32)
+    p_s = tl.make_block_ptr(s_ptr, (T, S), (S, 1), (0, 0), (BT, BS), (1, 0))
+    p_z = tl.make_block_ptr(z_ptr, (T, S), (S, 1), (0, 0), (BT, BS), (1, 0))
+    b_s = tl.load(p_s, boundary_check=(0, 1)).to(tl.float32)
+    b_c = b_z[None, :] + tl.dot(m, b_s, allow_tf32=False)
+    tl.store(p_z, b_c.to(p_z.dtype.element_ty), boundary_check=(0, 1))
+    b_z += tl.sum(b_s, 0)
+
+
+def test_reduce_symbolic_core_dtype():
+    """tl.sum on cast block_ptr data must preserve block_type dtype."""
+    s = torch.randn(16, 16, device="cpu")
+    z = torch.empty_like(s)
+    block_ptr_sum_kernel[(1,)](s, z, T=16, S=16, BT=16, BS=16)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -1303,6 +1303,7 @@ class AdvanceSymbolicExpr(SymbolicExpr):
             self.add_child(dk, offset_list[i])
             self.delta_keys.append(dk)
         self.dtype = ptr.dtype
+        self.block_shape_values = getattr(ptr, "block_shape_values", None)
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         raise NotImplementedError(
@@ -1432,7 +1433,12 @@ class CastSymbolicExpr(SymbolicExpr):
         super().__init__(op)
         self.add_child("src", src)
         self.add_child("dst_type", dst_type)
-        self.dtype = self.dst_type.to_py()
+        dst = self.dst_type.to_py()
+        src_dtype = self.src.dtype
+        if isinstance(src_dtype, tl.block_type) and not isinstance(dst, tl.block_type):
+            self.dtype = tl.block_type(dst, src_dtype.shape)
+        else:
+            self.dtype = dst
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         return self.src._to_z3()
@@ -1503,9 +1509,11 @@ class TensorPointerSymbolicExpr(SymbolicExpr):
         dt = ptr.dtype
         if dt is None:
             return None
-        if isinstance(dt, tl.pointer_type):
-            return dt.element_ty
-        return dt
+        scalar_ty = dt.element_ty if isinstance(dt, tl.pointer_type) else dt
+        block_shape = getattr(ptr, "block_shape_values", None)
+        if block_shape is not None:
+            return tl.block_type(scalar_ty, block_shape)
+        return scalar_ty
 
     def _resolve_block_ptr_components(
         self, ptr: SymbolicExpr


### PR DESCRIPTION
## Summary
- `CastSymbolicExpr` set `self.dtype = self.dst_type.to_py()` which returns a scalar dtype, losing `block_type` shape info
- `_resolve_element_dtype` didn't reconstruct `block_type` from block shape
- Three coupled fixes: preserve block_type in cast, propagate `block_shape_values` through advance, reconstruct in resolve

## Test plan
- [x] `test_reduce_symbolic_core_dtype` — `.to(tl.float32)` on block_ptr data then `tl.sum()`