### PR TITLE
[FIX] Derive constexpr names from JITFunction to fix string annotations

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1043,3 +1043,35 @@ def test_reinterpret_tensor_wrapper():
     x = torch.ones(N, dtype=torch.float16, device="cpu")
     y = torch.empty(N, dtype=torch.float16, device="cpu")
     copy_kernel[(1,)](triton.reinterpret(x, tl.float16), y, N, BLOCK=64)
+
+
+# ======== Constexpr Positional Argument Tests ===========
+
+constexpr_positional_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=constexpr_positional_sanitizer)
+@triton.jit
+def constexpr_positional_kernel(X, Out, N, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < N
+    x = tl.load(X + offs, mask=mask)
+    tl.store(Out + offs, x + 1.0, mask=mask)
+
+
+def test_constexpr_positional_arg():
+    """Passing a tl.constexpr param as a positional arg must not raise ValueError."""
+    constexpr_positional_sanitizer.records.clear()
+
+    N = 16
+    BLOCK_SIZE = 4
+    x = torch.arange(N, dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    # BLOCK_SIZE passed as positional arg, not keyword → must still be treated as constexpr
+    constexpr_positional_kernel[(N // BLOCK_SIZE,)](x, out, N, BLOCK_SIZE)
+
+    assert (
+        len(constexpr_positional_sanitizer.records) == 0
+    ), f"Expected no OOB records, got {len(constexpr_positional_sanitizer.records)}"

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1047,12 +1047,12 @@ def test_reinterpret_tensor_wrapper():
 
 # ======== Constexpr Positional Argument Tests ===========
 
-constexpr_positional_sanitizer = SymbolicSanitizer(abort_on_error=False)
+constexpr_str_annotation_sanitizer = SymbolicSanitizer(abort_on_error=False)
 
 
-@triton_viz.trace(client=constexpr_positional_sanitizer)
+@triton_viz.trace(client=constexpr_str_annotation_sanitizer)
 @triton.jit
-def constexpr_positional_kernel(X, Out, N, BLOCK_SIZE: tl.constexpr):
+def constexpr_str_annotation_kernel(X, Out, N, BLOCK_SIZE: "tl.constexpr"):
     pid = tl.program_id(0)
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offs < N
@@ -1060,18 +1060,24 @@ def constexpr_positional_kernel(X, Out, N, BLOCK_SIZE: tl.constexpr):
     tl.store(Out + offs, x + 1.0, mask=mask)
 
 
-def test_constexpr_positional_arg():
-    """Passing a tl.constexpr param as a positional arg must not raise ValueError."""
-    constexpr_positional_sanitizer.records.clear()
+def test_constexpr_string_annotation_positional_arg():
+    """String-annotated tl.constexpr passed positionally must not raise ValueError.
+
+    On Python 3.14+ the AST rewriter double-quotes string annotations,
+    so the rewritten function's __annotations__ contains "'tl.constexpr'"
+    instead of "tl.constexpr", making GridExecutor.constexprs empty.
+    The fix derives constexpr names from the original JITFunction.params.
+    """
+    constexpr_str_annotation_sanitizer.records.clear()
 
     N = 16
     BLOCK_SIZE = 4
     x = torch.arange(N, dtype=torch.float32)
     out = torch.empty_like(x)
 
-    # BLOCK_SIZE passed as positional arg, not keyword → must still be treated as constexpr
-    constexpr_positional_kernel[(N // BLOCK_SIZE,)](x, out, N, BLOCK_SIZE)
+    # BLOCK_SIZE passed as positional arg with string annotation
+    constexpr_str_annotation_kernel[(N // BLOCK_SIZE,)](x, out, N, BLOCK_SIZE)
 
     assert (
-        len(constexpr_positional_sanitizer.records) == 0
-    ), f"Expected no OOB records, got {len(constexpr_positional_sanitizer.records)}"
+        len(constexpr_str_annotation_sanitizer.records) == 0
+    ), f"Expected no OOB records, got {len(constexpr_str_annotation_sanitizer.records)}"

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -445,12 +445,9 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
 
     # Derive constexpr names from the original JIT function, which has
     # reliable annotation info.  The rewritten function's __annotations__
-    # can be corrupted on Python 3.14+ (string annotations get
-    # double-quoted), making self.constexprs unreliable.
-    if jit_fn is not None and hasattr(jit_fn, "params"):
-        constexpr_names = {p.name for p in jit_fn.params if p.is_constexpr}
-    else:
-        constexpr_names = set(self.constexprs)
+    # can be corrupted (string annotations get double-quoted), making
+    # self.constexprs unreliable.
+    constexpr_names = {p.name for p in jit_fn.params if p.is_constexpr}
 
     # Prepare call arguments
     args = inspect.getcallargs(self.fn, *args_hst, **kwargs_hst)

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -437,17 +437,26 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
     # Expose client_manager to tl.flip wrapper via a module-global
     global _current_client_manager
     _current_client_manager = client_manager
-    kwargs.pop("jit_fn")
+    jit_fn = kwargs.pop("jit_fn")
     if cfg.virtual_memory:
         args_hst, kwargs_hst = _init_args_hst(args_dev, kwargs)
     else:
         args_hst, kwargs_hst = self._init_args_hst(args_dev, kwargs)
 
+    # Derive constexpr names from the original JIT function, which has
+    # reliable annotation info.  The rewritten function's __annotations__
+    # can be corrupted on Python 3.14+ (string annotations get
+    # double-quoted), making self.constexprs unreliable.
+    if jit_fn is not None and hasattr(jit_fn, "params"):
+        constexpr_names = {p.name for p in jit_fn.params if p.is_constexpr}
+    else:
+        constexpr_names = set(self.constexprs)
+
     # Prepare call arguments
     args = inspect.getcallargs(self.fn, *args_hst, **kwargs_hst)
     call_args = {}
     for name, arg in args.items():
-        if name in self.constexprs:
+        if name in constexpr_names:
             call_args[name] = arg
             ret = arg
         else:

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -447,7 +447,11 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
     # reliable annotation info.  The rewritten function's __annotations__
     # can be corrupted (string annotations get double-quoted), making
     # self.constexprs unreliable.
-    constexpr_names = {p.name for p in jit_fn.params if p.is_constexpr}
+    # jit_fn is None for nested JIT calls and some Autotune paths.
+    if jit_fn is not None:
+        constexpr_names = {p.name for p in jit_fn.params if p.is_constexpr}
+    else:
+        constexpr_names = set(self.constexprs)
 
     # Prepare call arguments
     args = inspect.getcallargs(self.fn, *args_hst, **kwargs_hst)


### PR DESCRIPTION
## Summary
- On Python 3.14+ the AST rewriter double-quotes string annotations (e.g. `'tl.constexpr'` becomes `"'tl.constexpr'"`), causing `GridExecutor.constexprs` to be empty. This makes constexpr parameters go through `_implicit_cvt`, turning them into tensors, which then causes `tl.arange` to raise `ValueError: arange's arguments must be of type tl.constexpr`.
- Fix: derive constexpr names from the original `JITFunction.params` (passed via `jit_fn` kwarg) instead of relying on `self.constexprs` from the rewritten function.
- Add e2e test with string-annotated `"tl.constexpr"` passed as a positional argument.

## Test plan
- [x] `test_constexpr_string_annotation_positional_arg` passes with fix, fails without
- [x] All 29 existing sanitizer e2e tests pass