### PR TITLE
[FEAT][RACE DETECTOR] Add atomic metadata plumbing and return value capture

### DIFF
--- a/tests/unit/test_race_detector_atomic_metadata.py
+++ b/tests/unit/test_race_detector_atomic_metadata.py
@@ -72,6 +72,48 @@ def test_effects_at_addr_rmw():
     assert effects_at_addr(acc, 100) == (True, True)
 
 
+def test_effects_at_addr_multi_lane_mixed_cas():
+    """2 lanes same addr, lane 0 CAS fail (write=False), lane 1 CAS success (write=True) → (True, True)."""
+    acc = MemoryAccess(
+        access_type=AccessType.ATOMIC,
+        ptr=0,
+        offsets=np.array([100, 100], dtype=np.int64),
+        masks=np.array([True, True], dtype=np.bool_),
+        grid_idx=(0, 0, 0),
+        read_mask=np.array([True, True], dtype=np.bool_),
+        write_mask=np.array([False, True], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, True)
+
+
+def test_effects_at_addr_multi_lane_all_cas_fail():
+    """3 lanes same addr, all CAS fail → (True, False)."""
+    acc = MemoryAccess(
+        access_type=AccessType.ATOMIC,
+        ptr=0,
+        offsets=np.array([100, 100, 100], dtype=np.int64),
+        masks=np.array([True, True, True], dtype=np.bool_),
+        grid_idx=(0, 0, 0),
+        read_mask=np.array([True, True, True], dtype=np.bool_),
+        write_mask=np.array([False, False, False], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, False)
+
+
+def test_effects_at_addr_first_lane_masked_off():
+    """2 lanes same addr, first masked off, second active → (True, True)."""
+    acc = MemoryAccess(
+        access_type=AccessType.ATOMIC,
+        ptr=0,
+        offsets=np.array([100, 100], dtype=np.int64),
+        masks=np.array([False, True], dtype=np.bool_),
+        grid_idx=(0, 0, 0),
+        read_mask=np.array([False, True], dtype=np.bool_),
+        write_mask=np.array([False, True], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, True)
+
+
 # ── Metadata round-trip tests ──
 
 

--- a/tests/unit/test_race_detector_atomic_metadata.py
+++ b/tests/unit/test_race_detector_atomic_metadata.py
@@ -1,0 +1,156 @@
+import numpy as np
+
+from triton_viz.clients.race_detector.data import (
+    AccessType,
+    MemoryAccess,
+    effects_at_addr,
+)
+from triton_viz.clients.race_detector.race_detector import _sem_to_str, _scope_to_str
+
+
+def _make_access(
+    access_type,
+    offset=100,
+    read_mask=None,
+    write_mask=None,
+    **kwargs,
+):
+    return MemoryAccess(
+        access_type=access_type,
+        ptr=0,
+        offsets=np.array([offset], dtype=np.int64),
+        masks=np.array([True], dtype=np.bool_),
+        grid_idx=(0, 0, 0),
+        read_mask=read_mask,
+        write_mask=write_mask,
+        **kwargs,
+    )
+
+
+# ── effects_at_addr tests ──
+
+
+def test_effects_at_addr_load():
+    acc = _make_access(AccessType.LOAD)
+    assert effects_at_addr(acc, 100) == (True, False)
+
+
+def test_effects_at_addr_store():
+    acc = _make_access(AccessType.STORE)
+    assert effects_at_addr(acc, 100) == (False, True)
+
+
+def test_effects_at_addr_atomic_legacy():
+    acc = _make_access(AccessType.ATOMIC)
+    assert effects_at_addr(acc, 100) == (True, True)
+
+
+def test_effects_at_addr_cas_success():
+    acc = _make_access(
+        AccessType.ATOMIC,
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, True)
+
+
+def test_effects_at_addr_cas_fail():
+    acc = _make_access(
+        AccessType.ATOMIC,
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([False], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, False)
+
+
+def test_effects_at_addr_rmw():
+    acc = _make_access(
+        AccessType.ATOMIC,
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    assert effects_at_addr(acc, 100) == (True, True)
+
+
+# ── Metadata round-trip tests ──
+
+
+def test_metadata_round_trip_cas():
+    cmp_val = np.array([42], dtype=np.int32)
+    val_val = np.array([99], dtype=np.int32)
+    old_val = np.array([42], dtype=np.int32)
+    acc = MemoryAccess(
+        access_type=AccessType.ATOMIC,
+        ptr=0,
+        offsets=np.array([100], dtype=np.int64),
+        masks=np.array([True], dtype=np.bool_),
+        grid_idx=(0, 0, 0),
+        atomic_op="cas",
+        atomic_sem="acq_rel",
+        atomic_scope="gpu",
+        atomic_cmp=cmp_val,
+        atomic_val=val_val,
+        atomic_old=old_val,
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    assert acc.atomic_sem == "acq_rel"
+    assert acc.atomic_scope == "gpu"
+    np.testing.assert_array_equal(acc.atomic_cmp, cmp_val)
+    np.testing.assert_array_equal(acc.atomic_val, val_val)
+    np.testing.assert_array_equal(acc.atomic_old, old_val)
+    np.testing.assert_array_equal(acc.read_mask, [True])
+    np.testing.assert_array_equal(acc.write_mask, [True])
+    assert acc.legacy_atomic is False
+
+
+def test_metadata_round_trip_rmw():
+    val_val = np.array([1], dtype=np.int32)
+    old_val = np.array([5], dtype=np.int32)
+    acc = MemoryAccess(
+        access_type=AccessType.ATOMIC,
+        ptr=0,
+        offsets=np.array([200], dtype=np.int64),
+        masks=np.array([True], dtype=np.bool_),
+        grid_idx=(1, 0, 0),
+        atomic_op="rmw:add",
+        atomic_sem="release",
+        atomic_scope="sys",
+        atomic_val=val_val,
+        atomic_old=old_val,
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    assert acc.atomic_sem == "release"
+    assert acc.atomic_scope == "sys"
+    np.testing.assert_array_equal(acc.atomic_val, val_val)
+    np.testing.assert_array_equal(acc.atomic_old, old_val)
+    assert acc.atomic_cmp is None
+
+
+# ── sem/scope conversion tests ──
+
+
+def test_sem_to_str_handles_string_and_enum():
+    assert _sem_to_str("acq_rel") == "acq_rel"
+    assert _sem_to_str("RELEASE") == "release"
+    assert _sem_to_str(None) is None
+
+    # Simulate enum-like object
+    class FakeEnum:
+        def __str__(self):
+            return "ATOMIC_ORDERING.ACQ_REL"
+
+    assert _sem_to_str(FakeEnum()) == "acq_rel"
+
+
+def test_scope_to_str_handles_string_and_enum():
+    assert _scope_to_str("gpu") == "gpu"
+    assert _scope_to_str("CTA") == "cta"
+    assert _scope_to_str(None) is None
+
+    class FakeEnum:
+        def __str__(self):
+            return "MEMORY_SCOPE.GPU"
+
+    assert _scope_to_str(FakeEnum()) == "gpu"

--- a/triton_viz/clients/race_detector/data.py
+++ b/triton_viz/clients/race_detector/data.py
@@ -91,7 +91,14 @@ def effects_at_addr(access: MemoryAccess, addr: int) -> tuple[bool, bool]:
     if len(lane_indices) == 0:
         return (False, False)
 
-    lane = lane_indices[0]
-    reads = access.read_mask[lane] if access.read_mask is not None else False
-    writes = access.write_mask[lane] if access.write_mask is not None else False
-    return (bool(reads), bool(writes))
+    if access.read_mask is not None:
+        reads = bool(np.any(access.read_mask[lane_indices]))
+    else:
+        reads = access.access_type in (AccessType.LOAD, AccessType.ATOMIC)
+
+    if access.write_mask is not None:
+        writes = bool(np.any(access.write_mask[lane_indices]))
+    else:
+        writes = access.access_type in (AccessType.STORE, AccessType.ATOMIC)
+
+    return (reads, writes)

--- a/triton_viz/clients/race_detector/data.py
+++ b/triton_viz/clients/race_detector/data.py
@@ -33,6 +33,14 @@ class MemoryAccess:
     epoch: int = 0
     event_id: int = 0
     atomic_op: str | None = None
+    atomic_sem: str | None = None
+    atomic_scope: str | None = None
+    atomic_cmp: npt.NDArray | None = None
+    atomic_val: npt.NDArray | None = None
+    atomic_old: npt.NDArray | None = None
+    read_mask: npt.NDArray[np.bool_] | None = None
+    write_mask: npt.NDArray[np.bool_] | None = None
+    legacy_atomic: bool = False
 
 
 @dataclass
@@ -47,6 +55,10 @@ class SymbolicMemoryAccess:
     epoch: int = 0
     event_id: int = 0
     atomic_op: str | None = None
+    atomic_sem: str | None = None
+    atomic_scope: str | None = None
+    atomic_cmp_expr: Any = None
+    atomic_val_expr: Any = None
 
 
 @dataclass
@@ -57,3 +69,30 @@ class RaceRecord:
     address_offset: int
     access_a: MemoryAccess
     access_b: MemoryAccess
+
+
+def effects_at_addr(access: MemoryAccess, addr: int) -> tuple[bool, bool]:
+    """Return (reads, writes) for a given access at a specific byte address.
+
+    For accesses without read_mask/write_mask (legacy), falls back to
+    AccessType-based classification:
+      LOAD -> (True, False), STORE -> (False, True), ATOMIC -> (True, True)
+    """
+    if access.read_mask is None and access.write_mask is None:
+        # Legacy fallback based on AccessType
+        if access.access_type == AccessType.LOAD:
+            return (True, False)
+        elif access.access_type == AccessType.STORE:
+            return (False, True)
+        else:  # ATOMIC
+            return (True, True)
+
+    # Find the lane index for this address
+    lane_indices = np.where(access.masks & (access.offsets == addr))[0]
+    if len(lane_indices) == 0:
+        return (False, False)
+
+    lane = lane_indices[0]
+    reads = access.read_mask[lane] if access.read_mask is not None else False
+    writes = access.write_mask[lane] if access.write_mask is not None else False
+    return (bool(reads), bool(writes))

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -1,6 +1,6 @@
 from collections.abc import Callable
 from typing import Any, Optional
-from collections import defaultdict
+from collections import defaultdict, deque
 
 import numpy as np
 from z3 import Solver, Int, And, Or, sat, substitute, is_bool
@@ -28,6 +28,22 @@ from .data import AccessType, MemoryAccess, SymbolicMemoryAccess, RaceRecord, Ra
 from ...utils.traceback_utils import extract_user_frames
 
 
+def _sem_to_str(sem) -> str | None:
+    if sem is None:
+        return None
+    if isinstance(sem, str):
+        return sem.lower()
+    return str(sem).rsplit(".", 1)[-1].lower()
+
+
+def _scope_to_str(scope) -> str | None:
+    if scope is None:
+        return None
+    if isinstance(scope, str):
+        return scope.lower()
+    return str(scope).rsplit(".", 1)[-1].lower()
+
+
 class RaceDetector(SymbolicClient):
     NAME = "race_detector"
 
@@ -42,6 +58,7 @@ class RaceDetector(SymbolicClient):
         self._op_callbacks: list[tuple[OpCallbacks, Callable]] = []
         self._races: list[RaceRecord] = []
         self._event_counter: int = 0
+        self._pending_atomics: dict[tuple[int, ...], deque[int]] = defaultdict(deque)
 
     # ── Client interface ─────────────────────────────────────────
 
@@ -80,6 +97,7 @@ class RaceDetector(SymbolicClient):
         self._concrete_accesses.clear()
         self._races.clear()
         self._event_counter = 0
+        self._pending_atomics.clear()
         # Re-enable overriders (may have been disabled by a previous concrete fallback)
         for cb, orig_overrider in self._op_callbacks:
             cb.op_overrider = orig_overrider
@@ -152,6 +170,10 @@ class RaceDetector(SymbolicClient):
             SymbolicExpr.from_value(ptr),
             None,
             atomic_op="cas",
+            atomic_sem=_sem_to_str(sem),
+            atomic_scope=_scope_to_str(scope),
+            atomic_cmp_expr=SymbolicExpr.from_value(cmp),
+            atomic_val_expr=SymbolicExpr.from_value(val),
         )
         return ret
 
@@ -162,6 +184,9 @@ class RaceDetector(SymbolicClient):
             SymbolicExpr.from_value(ptr),
             SymbolicExpr.from_value(mask),
             atomic_op=f"rmw:{str(rmwOp).lower()}",
+            atomic_sem=_sem_to_str(sem),
+            atomic_scope=_scope_to_str(scope),
+            atomic_val_expr=SymbolicExpr.from_value(val),
         )
         return ret
 
@@ -289,6 +314,7 @@ class RaceDetector(SymbolicClient):
                 else np.ones(offsets.shape, dtype=bool)
             )
             event_id = self._next_event_id()
+            idx = len(self._concrete_accesses)
             self._concrete_accesses.append(
                 MemoryAccess(
                     access_type=AccessType.ATOMIC,
@@ -299,8 +325,12 @@ class RaceDetector(SymbolicClient):
                     call_path=extract_user_frames(),
                     event_id=event_id,
                     atomic_op=f"rmw:{str(rmwOp).lower()}",
+                    atomic_sem=_sem_to_str(sem),
+                    atomic_scope=_scope_to_str(scope),
+                    atomic_val=val.data.flatten() if hasattr(val, "data") else None,
                 )
             )
+            self._pending_atomics[grid_idx].append(idx)
 
         @self.lock_fn
         def before_atomic_cas(ptr, cmp, val, sem, scope):
@@ -312,6 +342,7 @@ class RaceDetector(SymbolicClient):
             offsets = ptr.data.flatten().astype(np.int64)
             masks = np.ones(offsets.shape, dtype=bool)
             event_id = self._next_event_id()
+            idx = len(self._concrete_accesses)
             self._concrete_accesses.append(
                 MemoryAccess(
                     access_type=AccessType.ATOMIC,
@@ -322,8 +353,54 @@ class RaceDetector(SymbolicClient):
                     call_path=extract_user_frames(),
                     event_id=event_id,
                     atomic_op="cas",
+                    atomic_sem=_sem_to_str(sem),
+                    atomic_scope=_scope_to_str(scope),
+                    atomic_cmp=cmp.data.flatten() if hasattr(cmp, "data") else None,
+                    atomic_val=val.data.flatten() if hasattr(val, "data") else None,
                 )
             )
+            self._pending_atomics[grid_idx].append(idx)
+
+        @self.lock_fn
+        def after_atomic_rmw(ret, rmwOp, ptr, val, mask, sem, scope):
+            if self._phase != "concrete":
+                return
+            grid_idx = self.grid_idx
+            if grid_idx is None:
+                return
+            pending = self._pending_atomics.get(grid_idx)
+            if not pending:
+                return
+            idx = pending.popleft()
+            acc = self._concrete_accesses[idx]
+            old = ret.data.flatten() if hasattr(ret, "data") else None
+            acc.atomic_old = old
+            # For RMW, active_mask comes from the mask parameter
+            active_mask = acc.masks.copy()
+            acc.read_mask = active_mask
+            acc.write_mask = active_mask
+
+        @self.lock_fn
+        def after_atomic_cas(ret, ptr, cmp, val, sem, scope):
+            if self._phase != "concrete":
+                return
+            grid_idx = self.grid_idx
+            if grid_idx is None:
+                return
+            pending = self._pending_atomics.get(grid_idx)
+            if not pending:
+                return
+            idx = pending.popleft()
+            acc = self._concrete_accesses[idx]
+            old = ret.data.flatten() if hasattr(ret, "data") else None
+            acc.atomic_old = old
+            # CAS has no mask param, active_mask is always all-True
+            active_mask = acc.masks.copy()
+            acc.read_mask = active_mask
+            if old is not None and acc.atomic_cmp is not None:
+                acc.write_mask = active_mask & (old == acc.atomic_cmp)
+            else:
+                acc.write_mask = active_mask
 
         BEFORE_MAP: dict[type[Op], Callable] = {
             Load: before_load,
@@ -334,16 +411,30 @@ class RaceDetector(SymbolicClient):
             AtomicCas: before_atomic_cas,
         }
 
+        AFTER_MAP: dict[type[Op], Callable] = {
+            AtomicRMW: after_atomic_rmw,
+            AtomicCas: after_atomic_cas,
+        }
+
         overrider = overrider_map.get(op_type)
         before = BEFORE_MAP.get(op_type)
+        after = AFTER_MAP.get(op_type)
 
         if overrider is not None:
             locked_overrider = self.lock_fn(overrider)
             callbacks = OpCallbacks(
                 op_overrider=locked_overrider,
                 before_callback=before,
+                after_callback=after,
             )
             self._op_callbacks.append((callbacks, locked_overrider))
+            return callbacks
+
+        if before is not None or after is not None:
+            callbacks = OpCallbacks(
+                before_callback=before,
+                after_callback=after,
+            )
             return callbacks
 
         return OpCallbacks()
@@ -358,6 +449,7 @@ class RaceDetector(SymbolicClient):
         self._symbolic_accesses.clear()
         self._concrete_accesses.clear()
         self._races.clear()
+        self._pending_atomics.clear()
         self._phase = "init"
         self._event_counter = 0
         return races
@@ -370,6 +462,10 @@ class RaceDetector(SymbolicClient):
         ptr_expr: SymbolicExpr,
         mask_expr: Optional[SymbolicExpr],
         atomic_op: Optional[str] = None,
+        atomic_sem: Optional[str] = None,
+        atomic_scope: Optional[str] = None,
+        atomic_cmp_expr: Any = None,
+        atomic_val_expr: Any = None,
     ) -> None:
         is_data_dependent = ptr_expr.has_op("load")
         if mask_expr is not None and mask_expr.has_op("load"):
@@ -386,6 +482,10 @@ class RaceDetector(SymbolicClient):
                 call_path=extract_user_frames(),
                 event_id=event_id,
                 atomic_op=atomic_op,
+                atomic_sem=atomic_sem,
+                atomic_scope=atomic_scope,
+                atomic_cmp_expr=atomic_cmp_expr,
+                atomic_val_expr=atomic_val_expr,
             )
         )
 
@@ -413,6 +513,7 @@ class RaceDetector(SymbolicClient):
                 masks = mask_concrete.data.flatten().astype(bool)
             else:
                 masks = np.ones(offsets.shape, dtype=bool)
+            is_atomic = sym_access.access_type == AccessType.ATOMIC
             self._concrete_accesses.append(
                 MemoryAccess(
                     access_type=sym_access.access_type,
@@ -423,6 +524,9 @@ class RaceDetector(SymbolicClient):
                     call_path=sym_access.call_path,
                     event_id=sym_access.event_id,
                     atomic_op=sym_access.atomic_op,
+                    atomic_sem=sym_access.atomic_sem,
+                    atomic_scope=sym_access.atomic_scope,
+                    legacy_atomic=is_atomic,
                 )
             )
 


### PR DESCRIPTION
<git-pr-chain>


Add atomic metadata plumbing and return value capture for race detector

Capture sem, scope, cmp, val on atomic CAS/RMW operations in both symbolic
and concrete paths. Add after-callbacks with per-block pending queue to
populate atomic_old, read_mask, write_mask (CAS success/fail distinction).
Add effects_at_addr() helper for per-lane read/write classification.
Mark concretized block0 atomics as legacy_atomic for future HB exclusion.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. 👉 #344 👈 **YOU ARE HERE**
1. #345
1. #346
1. #347


</git-pr-chain>
