### PR TITLE
[FEAT][RACE DETECTOR] Add effect-based race classification and concrete HB solver

### DIFF
--- a/tests/end_to_end/test_race_detector.py
+++ b/tests/end_to_end/test_race_detector.py
@@ -69,7 +69,7 @@ def test_raw_waw_histogram():
     assert len(races) > 0
     race_types = {r.race_type for r in races}
     assert RaceType.WAW in race_types
-    assert RaceType.RW in race_types
+    assert RaceType.RAW in race_types
 
 
 # ======== Correct vector_add (No Race) ========

--- a/tests/unit/test_race_detector_epoch.py
+++ b/tests/unit/test_race_detector_epoch.py
@@ -20,7 +20,11 @@ def _store_access(block_idx: int, offset: int, event_id: int) -> MemoryAccess:
 
 
 def _atomic_access(
-    block_idx: int, offset: int, event_id: int, atomic_op: str
+    block_idx: int,
+    offset: int,
+    event_id: int,
+    atomic_op: str,
+    atomic_scope: str | None = None,
 ) -> MemoryAccess:
     return MemoryAccess(
         access_type=AccessType.ATOMIC,
@@ -30,6 +34,7 @@ def _atomic_access(
         grid_idx=(block_idx, 0, 0),
         event_id=event_id,
         atomic_op=atomic_op,
+        atomic_scope=atomic_scope,
     )
 
 
@@ -282,3 +287,43 @@ def test_incomplete_second_barrier_does_not_globally_reach_epoch_two():
     ]
     assert phase2_stores
     assert all(acc.epoch == 1 for acc in phase2_stores)
+
+
+def test_cta_scope_atomics_not_detected_as_global_barrier():
+    """CTA-scoped add+cas at same addr from all blocks must NOT be treated as a barrier.
+
+    CTA scope is block-local and cannot synchronize across blocks.
+    Without this filter, the epoch system would split phases incorrectly.
+    """
+    n = 2
+    barrier_addr = 4096
+    accesses = []
+    for i in range(n):
+        # Phase 0 store
+        accesses.append(_store_access(block_idx=i, offset=i, event_id=i))
+        # CTA-scoped add + cas (should NOT be a barrier)
+        accesses.append(
+            _atomic_access(
+                i, barrier_addr, event_id=100 + i,
+                atomic_op="rmw:add", atomic_scope="cta",
+            )
+        )
+        accesses.append(
+            _atomic_access(
+                i, barrier_addr, event_id=200 + i,
+                atomic_op="cas", atomic_scope="cta",
+            )
+        )
+        # Phase 1 store at overlapping address
+        accesses.append(
+            _store_access(block_idx=i, offset=(i + 1) % n, event_id=300 + i)
+        )
+
+    barrier_addrs = _detect_global_barrier_addresses(accesses)
+    assert barrier_addrs == set()  # cta scope → no global barrier
+
+    _apply_epoch_annotations(accesses)
+    assert all(acc.epoch == 0 for acc in accesses)  # no epoch split
+
+    races = detect_races(accesses)
+    assert len(races) > 0  # WAW races reported (no barrier suppression)

--- a/tests/unit/test_race_detector_hb.py
+++ b/tests/unit/test_race_detector_hb.py
@@ -1,0 +1,269 @@
+import numpy as np
+
+from triton_viz.clients.race_detector.data import (
+    AccessType,
+    MemoryAccess,
+    RaceType,
+)
+from triton_viz.clients.race_detector.hb_solver import HBSolver
+from triton_viz.clients.race_detector.race_detector import (
+    _classify_race,
+    detect_races,
+)
+
+
+def _make_access(
+    access_type,
+    block_idx,
+    offset,
+    event_id,
+    atomic_op=None,
+    atomic_sem=None,
+    atomic_scope=None,
+    read_mask=None,
+    write_mask=None,
+    legacy_atomic=False,
+    atomic_old=None,
+    atomic_cmp=None,
+):
+    masks = np.array([True], dtype=np.bool_)
+    return MemoryAccess(
+        access_type=access_type,
+        ptr=0,
+        offsets=np.array([offset], dtype=np.int64),
+        masks=masks,
+        grid_idx=(block_idx, 0, 0),
+        event_id=event_id,
+        atomic_op=atomic_op,
+        atomic_sem=atomic_sem,
+        atomic_scope=atomic_scope,
+        read_mask=read_mask
+        if read_mask is not None
+        else (
+            masks.copy()
+            if access_type == AccessType.ATOMIC and not legacy_atomic
+            else None
+        ),
+        write_mask=write_mask
+        if write_mask is not None
+        else (
+            masks.copy()
+            if access_type == AccessType.ATOMIC and not legacy_atomic
+            else None
+        ),
+        legacy_atomic=legacy_atomic,
+        atomic_old=atomic_old,
+        atomic_cmp=atomic_cmp,
+    )
+
+
+def test_release_acquire_flag_handoff_no_race():
+    """Producer store data + release flag, consumer acquire flag + load data → no race."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    # Block 0 (producer): store data, then release-store flag
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+    )
+
+    # Block 1 (consumer): acquire-load flag, then load data
+    acquire_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+    )
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    # Check: store_data vs load_data should be ordered via
+    # store_data ->po-> release_flag ->sw-> acquire_flag ->po-> load_data
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_flag, acquire_flag])
+    assert not solver.check_race_possible()  # UNSAT → no race
+
+
+def test_relaxed_atomics_still_race():
+    """Same pattern but sem='relaxed' → no sw edge → race reported."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    relaxed_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+
+    relaxed_read = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([relaxed_flag, relaxed_read])
+    assert solver.check_race_possible()  # SAT → race exists
+
+
+def test_cta_scope_no_cross_block_suppression():
+    """scope='cta' on release/acquire → no cross-block sw → race reported."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="cta",
+    )
+
+    acquire_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="cta",
+    )
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_flag, acquire_flag])
+    assert solver.check_race_possible()  # SAT → race (cta can't cross blocks)
+
+
+def test_failed_cas_no_write_effect():
+    """Failed CAS at addr X vs plain load at addr X → no conflict (read-read)."""
+    ADDR = 100
+
+    # CAS that failed: read_mask=True, write_mask=False
+    failed_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=ADDR,
+        event_id=0,
+        atomic_op="cas",
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([False], dtype=np.bool_),
+    )
+    load = _make_access(AccessType.LOAD, block_idx=1, offset=ADDR, event_id=0)
+
+    race_type = _classify_race(failed_cas, load, ADDR)
+    assert race_type is None  # read-read → no race
+
+
+def test_successful_cas_write_effect():
+    """Successful CAS at addr X vs plain store at addr X → WAW."""
+    ADDR = 100
+
+    success_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=ADDR,
+        event_id=0,
+        atomic_op="cas",
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    store = _make_access(AccessType.STORE, block_idx=1, offset=ADDR, event_id=0)
+
+    race_type = _classify_race(success_cas, store, ADDR)
+    assert race_type == RaceType.WAW
+
+
+def test_atomic_atomic_still_suppressed():
+    """Two atomic_add at same addr → no race (preserved behavior)."""
+    ADDR = 100
+
+    add_a = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=ADDR,
+        event_id=0,
+        atomic_op="rmw:add",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+    add_b = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=ADDR,
+        event_id=0,
+        atomic_op="rmw:add",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+
+    race_type = _classify_race(add_a, add_b, ADDR)
+    assert race_type is None  # atomic-atomic → suppressed
+
+
+def test_legacy_atomic_skips_hb():
+    """legacy_atomic=True access → HB solver not invoked, conservative classify."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    # Even with release/acquire pattern, legacy atomics should not use HB
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        legacy_atomic=True,
+    )
+    acquire_flag = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        legacy_atomic=True,
+    )
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    # Build accesses list and run detect_races
+    all_accesses = [store_data, release_flag, acquire_flag, load_data]
+    races = detect_races(all_accesses)
+
+    # Should report race because legacy atomics prevent HB reasoning
+    assert len(races) > 0
+    assert races[0].race_type == RaceType.RAW

--- a/tests/unit/test_race_detector_hb.py
+++ b/tests/unit/test_race_detector_hb.py
@@ -62,7 +62,7 @@ def test_release_acquire_flag_handoff_no_race():
     DATA_ADDR = 100
     FLAG_ADDR = 200
 
-    # Block 0 (producer): store data, then release-store flag
+    # Block 0 (producer): store data, then release-store flag (writes 1)
     store_data = _make_access(
         AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
     )
@@ -74,9 +74,11 @@ def test_release_acquire_flag_handoff_no_race():
         atomic_op="rmw:xchg",
         atomic_sem="release",
         atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
     )
+    release_flag.atomic_val = np.array([1], dtype=np.int32)
 
-    # Block 1 (consumer): acquire-load flag, then load data
+    # Block 1 (consumer): acquire-load flag (reads old=1), then load data
     acquire_flag = _make_access(
         AccessType.ATOMIC,
         block_idx=1,
@@ -85,7 +87,9 @@ def test_release_acquire_flag_handoff_no_race():
         atomic_op="rmw:xchg",
         atomic_sem="acquire",
         atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
     )
+    acquire_flag.atomic_val = np.array([0], dtype=np.int32)
     load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
 
     # Check: store_data vs load_data should be ordered via
@@ -267,3 +271,182 @@ def test_legacy_atomic_skips_hb():
     # Should report race because legacy atomics prevent HB reasoning
     assert len(races) > 0
     assert races[0].race_type == RaceType.RAW
+
+
+# ── Reads-from gated sw edge tests ──
+
+
+def test_sw_xchg_release_cas_acquire_matching_old():
+    """xchg(release) writes 1, CAS(acquire) reads old=1 → sw edge → suppress."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    acquire_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="cas",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+        atomic_cmp=np.array([1], dtype=np.int32),
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    acquire_cas.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, acquire_cas])
+    assert not solver.check_race_possible()  # sw edge → no race
+
+
+def test_sw_spinlock_unlock_lock_pattern():
+    """Spinlock: unlock xchg(0) + lock CAS(cmp=0) reads old=0 → suppress."""
+    DATA_ADDR = 100
+    LOCK_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    unlock = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=LOCK_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+    )
+    unlock.atomic_val = np.array([0], dtype=np.int32)
+
+    lock = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=LOCK_ADDR,
+        event_id=0,
+        atomic_op="cas",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+        atomic_cmp=np.array([0], dtype=np.int32),
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    lock.atomic_val = np.array([1], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([unlock, lock])
+    assert not solver.check_race_possible()  # sw edge → no race
+
+
+def test_sw_acquire_reads_wrong_value_no_suppress():
+    """CAS reads old=42 (not 1) → no reads-from → no sw → race reported."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    acquire_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="cas",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([42], dtype=np.int32),  # wrong value
+        atomic_cmp=np.array([1], dtype=np.int32),
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([False], dtype=np.bool_),
+    )
+    acquire_cas.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, acquire_cas])
+    assert solver.check_race_possible()  # no sw → race
+
+
+def test_sw_intermediate_write_breaks_chain():
+    """Intermediate relaxed xchg overwrites; acquire reads overwritten value → no sw with original release."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    # Block 0 release writes 1
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 2 (interloper): relaxed xchg overwrites flag to 99
+    interloper = _make_access(
+        AccessType.ATOMIC,
+        block_idx=2,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+    )
+    interloper.atomic_val = np.array([99], dtype=np.int32)
+
+    # Block 1 acquire reads old=99 (from interloper, not from release)
+    acquire_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([99], dtype=np.int32),
+    )
+    acquire_xchg.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, interloper, acquire_xchg])
+    assert solver.check_race_possible()  # no sw with release → race

--- a/tests/unit/test_race_detector_hb.py
+++ b/tests/unit/test_race_detector_hb.py
@@ -547,6 +547,105 @@ def test_add_written_value_not_operand():
     assert not solver.check_race_possible()  # sw edge → no race
 
 
+def test_hb_solver_ignores_reader_self_writeback_for_same_value_cas():
+    """CAS(1,1) reader writes back 1 — must not count as ambiguous third-party writer."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    # Block 0 release xchg writes 1
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 1 acquire cas(1,1): reads old=1, writes back 1
+    acquire_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="cas",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+        atomic_cmp=np.array([1], dtype=np.int32),
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    acquire_cas.atomic_val = np.array([1], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, acquire_cas])
+    assert not solver.check_race_possible()  # reader's writeback excluded → sw edge → no race
+
+
+def test_hb_solver_still_flags_third_party_same_value_writer_as_ambiguous():
+    """Third-party writer of same value 1 → ambiguous reads-from → race."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    # Block 0 release xchg writes 1
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 2 relaxed xchg also writes 1 (genuine third-party)
+    interloper = _make_access(
+        AccessType.ATOMIC,
+        block_idx=2,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    interloper.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 1 acquire cas(1,1): reads old=1, writes back 1
+    acquire_cas = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="cas",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+        atomic_cmp=np.array([1], dtype=np.int32),
+        read_mask=np.array([True], dtype=np.bool_),
+        write_mask=np.array([True], dtype=np.bool_),
+    )
+    acquire_cas.atomic_val = np.array([1], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, interloper, acquire_cas])
+    assert solver.check_race_possible()  # third-party same-value → ambiguous → race
+
+
 def test_add_operand_vs_written_value_mismatch():
     """add(5) with old=10 writes 15; acquire reads old=5 (operand) → no sw → race."""
     DATA_ADDR = 100

--- a/tests/unit/test_race_detector_hb.py
+++ b/tests/unit/test_race_detector_hb.py
@@ -450,3 +450,137 @@ def test_sw_intermediate_write_breaks_chain():
     solver = HBSolver(store_data, load_data)
     solver.add_sync_events([release_xchg, interloper, acquire_xchg])
     assert solver.check_race_possible()  # no sw with release → race
+
+
+# ── ABA / same-value uniqueness tests ──
+
+
+def test_aba_same_written_value_no_spurious_suppress():
+    """Two writers write same value 1 → ambiguous reads-from → race reported."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    # Block 0 release xchg writes 1
+    release_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:xchg",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    release_xchg.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 2 relaxed xchg also writes 1
+    interloper = _make_access(
+        AccessType.ATOMIC,
+        block_idx=2,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+        atomic_old=np.array([0], dtype=np.int32),
+    )
+    interloper.atomic_val = np.array([1], dtype=np.int32)
+
+    # Block 1 acquire reads old=1 → ambiguous (could be from either writer)
+    acquire_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([1], dtype=np.int32),
+    )
+    acquire_xchg.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_xchg, interloper, acquire_xchg])
+    assert solver.check_race_possible()  # ambiguous → race
+
+
+def test_add_written_value_not_operand():
+    """add(5) with old=10 writes 15; acquire reads old=15 → sw edge → no race."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_add = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:add",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([10], dtype=np.int32),
+    )
+    release_add.atomic_val = np.array([5], dtype=np.int32)
+
+    # Block 1 acquire reads old=15 (the written value, not operand)
+    acquire_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([15], dtype=np.int32),
+    )
+    acquire_xchg.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_add, acquire_xchg])
+    assert not solver.check_race_possible()  # sw edge → no race
+
+
+def test_add_operand_vs_written_value_mismatch():
+    """add(5) with old=10 writes 15; acquire reads old=5 (operand) → no sw → race."""
+    DATA_ADDR = 100
+    FLAG_ADDR = 200
+
+    store_data = _make_access(
+        AccessType.STORE, block_idx=0, offset=DATA_ADDR, event_id=0
+    )
+    release_add = _make_access(
+        AccessType.ATOMIC,
+        block_idx=0,
+        offset=FLAG_ADDR,
+        event_id=1,
+        atomic_op="rmw:add",
+        atomic_sem="release",
+        atomic_scope="gpu",
+        atomic_old=np.array([10], dtype=np.int32),
+    )
+    release_add.atomic_val = np.array([5], dtype=np.int32)
+
+    # Block 1 acquire reads old=5 (the operand, NOT the written value 15)
+    acquire_xchg = _make_access(
+        AccessType.ATOMIC,
+        block_idx=1,
+        offset=FLAG_ADDR,
+        event_id=0,
+        atomic_op="rmw:xchg",
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        atomic_old=np.array([5], dtype=np.int32),
+    )
+    acquire_xchg.atomic_val = np.array([0], dtype=np.int32)
+    load_data = _make_access(AccessType.LOAD, block_idx=1, offset=DATA_ADDR, event_id=1)
+
+    solver = HBSolver(store_data, load_data)
+    solver.add_sync_events([release_add, acquire_xchg])
+    assert solver.check_race_possible()  # no sw → race

--- a/triton_viz/clients/race_detector/data.py
+++ b/triton_viz/clients/race_detector/data.py
@@ -15,7 +15,8 @@ class AccessType(Enum):
 
 
 class RaceType(Enum):
-    RW = auto()  # Read-Write (load + store/atomic, or store/atomic + load)
+    RAW = auto()  # Read-After-Write
+    WAR = auto()  # Write-After-Read
     WAW = auto()  # Write-After-Write
 
 

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -108,6 +108,27 @@ def _reads_from(writer: MemoryAccess, reader: MemoryAccess, addr: int) -> bool:
     return False
 
 
+def _has_ambiguous_writer(
+    all_nodes, sync_indices, wi, ri, addr, written,
+):
+    """Check if another sync node visible to reader writes the same value."""
+    r = all_nodes[ri]
+    for oi in sync_indices:
+        if oi == wi or oi == ri:          # skip candidate writer AND reader itself
+            continue
+        o = all_nodes[oi]
+        if addr not in _active_addrs(o):
+            continue
+        ov = _written_value_at_addr(o, addr)
+        if ov != written:
+            continue
+        # o writes same value — skip if po-after r (invisible)
+        if o.grid_idx == r.grid_idx and o.event_id > r.event_id:
+            continue
+        return True
+    return False
+
+
 class HBSolver:
     """Local happens-before solver for a candidate race pair.
 
@@ -181,24 +202,11 @@ class HBSolver:
                         written = _written_value_at_addr(w, addr)
                         if written is None:
                             continue
-                        # ABA check: verify no other sync node visible to r
-                        # writes the same value (would make reads-from ambiguous)
-                        ambiguous = False
-                        for oi in sync_indices:
-                            if oi == wi:
-                                continue
-                            o = all_nodes[oi]
-                            if addr not in _active_addrs(o):
-                                continue
-                            ov = _written_value_at_addr(o, addr)
-                            if ov != written:
-                                continue
-                            # o writes same value — skip if po-after r (invisible)
-                            if o.grid_idx == r.grid_idx and o.event_id > r.event_id:
-                                continue
-                            ambiguous = True
-                            break
-                        if not ambiguous and _reads_from(w, r, addr):
+                        if not _reads_from(w, r, addr):
+                            continue
+                        if not _has_ambiguous_writer(
+                            all_nodes, sync_indices, wi, ri, addr, written,
+                        ):
                             adj[wi].add(ri)
                             break
 

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -4,17 +4,15 @@ Uses graph reachability over po (program order) and sw (synchronizes-with)
 edges to determine whether a candidate race pair (a, b) must be ordered
 in all valid executions.
 
-v1 uses a conservative model: any structurally valid release/acquire pair
-on the same sync address with compatible scope unconditionally creates a
-sw edge. This is sound in the "fewer false positives" direction — it may
-suppress races that could theoretically occur if the acquire doesn't
-actually read from the release, but in practice synchronization patterns
-are designed so that the acquire does see the release's write.
+sw edges are gated on reads-from: an acquire must observe the value
+written by the release (via atomic_old matching) to establish ordering.
 """
 
 from __future__ import annotations
 
 from collections import defaultdict, deque
+
+import numpy as np
 
 from .data import MemoryAccess
 
@@ -38,6 +36,39 @@ def _scope_ok(w_scope: str | None, r_scope: str | None) -> bool:
 
 def _active_addrs(acc: MemoryAccess) -> set[int]:
     return {int(o) for o, m in zip(acc.offsets, acc.masks) if m}
+
+
+def _written_value_at_addr(acc: MemoryAccess, addr: int) -> object | None:
+    """Return the value written by a sync op at addr, or None if no write."""
+    lane_indices = np.where(acc.masks & (acc.offsets == addr))[0]
+    if len(lane_indices) == 0 or acc.atomic_val is None:
+        return None
+
+    if acc.atomic_op == "cas":
+        # CAS only writes on success (write_mask=True for that lane)
+        for lane in lane_indices:
+            if acc.write_mask is not None and acc.write_mask[lane]:
+                return acc.atomic_val[lane]
+        return None  # all CAS attempts failed
+    else:
+        # xchg / rmw:add etc. always write
+        return acc.atomic_val[lane_indices[0]]
+
+
+def _reads_from(writer: MemoryAccess, reader: MemoryAccess, addr: int) -> bool:
+    """Return True if reader observed the value written by writer at addr."""
+    written = _written_value_at_addr(writer, addr)
+    if written is None:
+        return False
+
+    if reader.atomic_old is None:
+        return False
+
+    lane_indices = np.where(reader.masks & (reader.offsets == addr))[0]
+    for lane in lane_indices:
+        if reader.atomic_old[lane] == written:
+            return True
+    return False
 
 
 class HBSolver:
@@ -88,7 +119,7 @@ class HBSolver:
                 adj[sorted_indices[k]].add(sorted_indices[k + 1])
 
         # ─── Synchronizes-with (sw) edges ───
-        # For v1: unconditional sw for any qualifying release/acquire pair
+        # sw requires reads-from proof: acquire must observe release's write
         sync_indices = [node_ids[id(e)] for e in sync]
 
         for wi in sync_indices:
@@ -107,8 +138,12 @@ class HBSolver:
                 if not _scope_ok(w.atomic_scope, r.atomic_scope):
                     continue
                 r_addrs = _active_addrs(r)
-                if w_addrs & r_addrs:
-                    adj[wi].add(ri)
+                common_addrs = w_addrs & r_addrs
+                if common_addrs:
+                    for addr in common_addrs:
+                        if _reads_from(w, r, addr):
+                            adj[wi].add(ri)
+                            break
 
         # ─── Reachability check ───
         ai = node_ids[id(a)]

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -1,0 +1,136 @@
+"""Local happens-before solver for race detection.
+
+Uses graph reachability over po (program order) and sw (synchronizes-with)
+edges to determine whether a candidate race pair (a, b) must be ordered
+in all valid executions.
+
+v1 uses a conservative model: any structurally valid release/acquire pair
+on the same sync address with compatible scope unconditionally creates a
+sw edge. This is sound in the "fewer false positives" direction — it may
+suppress races that could theoretically occur if the acquire doesn't
+actually read from the release, but in practice synchronization patterns
+are designed so that the acquire does see the release's write.
+"""
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+
+from .data import MemoryAccess
+
+
+def _release_like(sem: str | None) -> bool:
+    return sem in ("release", "acq_rel")
+
+
+def _acquire_like(sem: str | None) -> bool:
+    return sem in ("acquire", "acq_rel")
+
+
+def _scope_ok(w_scope: str | None, r_scope: str | None) -> bool:
+    """Check if scopes are compatible for cross-block synchronization.
+
+    Only gpu or sys scopes can form cross-block sw edges.
+    cta scope is thread-block local and cannot synchronize across blocks.
+    """
+    return (w_scope in ("gpu", "sys")) and (r_scope in ("gpu", "sys"))
+
+
+def _active_addrs(acc: MemoryAccess) -> set[int]:
+    return {int(o) for o, m in zip(acc.offsets, acc.masks) if m}
+
+
+class HBSolver:
+    """Local happens-before solver for a candidate race pair.
+
+    acc_a and acc_b are always included as nodes in the HB graph
+    (they are the po endpoints that need ordering). Sync events are
+    the atomic accesses that may create sw edges between blocks.
+    """
+
+    def __init__(self, acc_a: MemoryAccess, acc_b: MemoryAccess):
+        self._acc_a = acc_a
+        self._acc_b = acc_b
+        self._sync_events: list[MemoryAccess] = []
+
+    def add_sync_events(self, events: list[MemoryAccess]) -> None:
+        """Add atomic events from same epoch, all blocks, per sync address.
+
+        Must NOT include legacy_atomic accesses.
+        """
+        self._sync_events = [e for e in events if not e.legacy_atomic]
+
+    def check_race_possible(self) -> bool:
+        """Return True if a race is possible (a and b unordered).
+
+        False means all valid executions order a and b (suppress race).
+        """
+        a = self._acc_a
+        b = self._acc_b
+        sync = self._sync_events
+
+        # Build graph: nodes are all accesses (a, b, + sync events)
+        all_nodes = [a, b] + sync
+        node_ids = {id(n): i for i, n in enumerate(all_nodes)}
+
+        # Adjacency list for HB edges
+        adj: dict[int, set[int]] = defaultdict(set)
+
+        # ─── Program order (po) edges ───
+        by_block: dict[tuple[int, ...], list[int]] = defaultdict(list)
+        for node in all_nodes:
+            idx = node_ids[id(node)]
+            by_block[node.grid_idx].append(idx)
+
+        for grid_idx, indices in by_block.items():
+            sorted_indices = sorted(indices, key=lambda i: all_nodes[i].event_id)
+            for k in range(len(sorted_indices) - 1):
+                adj[sorted_indices[k]].add(sorted_indices[k + 1])
+
+        # ─── Synchronizes-with (sw) edges ───
+        # For v1: unconditional sw for any qualifying release/acquire pair
+        sync_indices = [node_ids[id(e)] for e in sync]
+
+        for wi in sync_indices:
+            w = all_nodes[wi]
+            if not _release_like(w.atomic_sem):
+                continue
+            w_addrs = _active_addrs(w)
+            for ri in sync_indices:
+                if wi == ri:
+                    continue
+                r = all_nodes[ri]
+                if w.grid_idx == r.grid_idx:
+                    continue  # sw is cross-block only
+                if not _acquire_like(r.atomic_sem):
+                    continue
+                if not _scope_ok(w.atomic_scope, r.atomic_scope):
+                    continue
+                r_addrs = _active_addrs(r)
+                if w_addrs & r_addrs:
+                    adj[wi].add(ri)
+
+        # ─── Reachability check ───
+        ai = node_ids[id(a)]
+        bi = node_ids[id(b)]
+
+        if _reachable(adj, ai, bi) or _reachable(adj, bi, ai):
+            return False  # ordered → no race possible
+
+        return True  # unordered → race possible
+
+
+def _reachable(adj: dict[int, set[int]], src: int, dst: int) -> bool:
+    """BFS reachability check."""
+    visited: set[int] = set()
+    queue: deque[int] = deque([src])
+    visited.add(src)
+    while queue:
+        node = queue.popleft()
+        if node == dst:
+            return True
+        for neighbor in adj.get(node, ()):
+            if neighbor not in visited:
+                visited.add(neighbor)
+                queue.append(neighbor)
+    return False

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -38,6 +38,35 @@ def _active_addrs(acc: MemoryAccess) -> set[int]:
     return {int(o) for o, m in zip(acc.offsets, acc.masks) if m}
 
 
+def _rmw_op_suffix(atomic_op: str) -> str:
+    """Extract op suffix from 'rmw:add' or 'rmw:atomic_op.add' format."""
+    for sep in (".", ":"):
+        if sep in atomic_op:
+            atomic_op = atomic_op.rsplit(sep, 1)[-1]
+    return atomic_op
+
+
+def _compute_rmw_written(op_suffix: str, old, val):
+    """Compute value written by an RMW op. Returns None for unknown ops."""
+    if op_suffix == "xchg":
+        return val
+    elif op_suffix in ("add", "fadd"):
+        return old + val
+    elif op_suffix == "sub":
+        return old - val
+    elif op_suffix == "and":
+        return old & val
+    elif op_suffix == "or":
+        return old | val
+    elif op_suffix == "xor":
+        return old ^ val
+    elif op_suffix in ("max", "umax"):
+        return max(old, val)
+    elif op_suffix in ("min", "umin"):
+        return min(old, val)
+    return None
+
+
 def _written_value_at_addr(acc: MemoryAccess, addr: int) -> object | None:
     """Return the value written by a sync op at addr, or None if no write."""
     lane_indices = np.where(acc.masks & (acc.offsets == addr))[0]
@@ -52,7 +81,15 @@ def _written_value_at_addr(acc: MemoryAccess, addr: int) -> object | None:
         return None  # all CAS attempts failed
     else:
         # xchg / rmw:add etc. always write
-        return acc.atomic_val[lane_indices[0]]
+        lane = lane_indices[0]
+        if acc.atomic_op is None:
+            return None
+        op_suffix = _rmw_op_suffix(acc.atomic_op)
+        if op_suffix == "xchg":
+            return acc.atomic_val[lane]
+        if acc.atomic_old is None:
+            return None
+        return _compute_rmw_written(op_suffix, acc.atomic_old[lane], acc.atomic_val[lane])
 
 
 def _reads_from(writer: MemoryAccess, reader: MemoryAccess, addr: int) -> bool:
@@ -141,7 +178,27 @@ class HBSolver:
                 common_addrs = w_addrs & r_addrs
                 if common_addrs:
                     for addr in common_addrs:
-                        if _reads_from(w, r, addr):
+                        written = _written_value_at_addr(w, addr)
+                        if written is None:
+                            continue
+                        # ABA check: verify no other sync node visible to r
+                        # writes the same value (would make reads-from ambiguous)
+                        ambiguous = False
+                        for oi in sync_indices:
+                            if oi == wi:
+                                continue
+                            o = all_nodes[oi]
+                            if addr not in _active_addrs(o):
+                                continue
+                            ov = _written_value_at_addr(o, addr)
+                            if ov != written:
+                                continue
+                            # o writes same value — skip if po-after r (invisible)
+                            if o.grid_idx == r.grid_idx and o.event_id > r.event_id:
+                                continue
+                            ambiguous = True
+                            break
+                        if not ambiguous and _reads_from(w, r, addr):
                             adj[wi].add(ri)
                             break
 

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -855,7 +855,7 @@ def _classify_race_type(
     is_write_b = tb in (AccessType.STORE, AccessType.ATOMIC)
     if is_write_a and is_write_b:
         return RaceType.WAW
-    return RaceType.RW
+    return RaceType.RAW
 
 
 def _active_offsets(access: MemoryAccess) -> np.ndarray:
@@ -1149,4 +1149,4 @@ def _classify_race(
     is_write_b = tb in (AccessType.STORE, AccessType.ATOMIC)
     if is_write_a and is_write_b:
         return RaceType.WAW
-    return RaceType.RW
+    return RaceType.RAW

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -571,6 +571,8 @@ class RaceDetector(SymbolicClient):
         for acc in accesses:
             if acc.access_type != AccessType.ATOMIC:
                 continue
+            if acc.atomic_scope not in ("gpu", "sys", None):
+                continue  # cta scope cannot synchronize across blocks
             atomic_op = (acc.atomic_op or "").lower()
             is_add = "add" in atomic_op
             is_cas = "cas" in atomic_op
@@ -873,6 +875,8 @@ def _touches_address(access: MemoryAccess, addr_set: set[int]) -> bool:
 def _is_barrier_atomic(access: MemoryAccess, barrier_addrs: set[int]) -> bool:
     if access.access_type != AccessType.ATOMIC:
         return False
+    if access.atomic_scope not in ("gpu", "sys", None):
+        return False  # cta scope cannot form cross-block barriers
     if not _touches_address(access, barrier_addrs):
         return False
     atomic_op = (access.atomic_op or "").lower()
@@ -891,6 +895,8 @@ def _detect_global_barrier_addresses(accesses: list[MemoryAccess]) -> set[int]:
     for acc in accesses:
         if acc.access_type != AccessType.ATOMIC:
             continue
+        if acc.atomic_scope not in ("gpu", "sys", None):
+            continue  # cta scope cannot synchronize across blocks
         atomic_op = (acc.atomic_op or "").lower()
         is_add = "add" in atomic_op
         is_cas = "cas" in atomic_op

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -24,7 +24,14 @@ from ..symbolic_engine import (
     SymbolicExpr,
     SymbolicClient,
 )
-from .data import AccessType, MemoryAccess, SymbolicMemoryAccess, RaceRecord, RaceType
+from .data import (
+    AccessType,
+    MemoryAccess,
+    SymbolicMemoryAccess,
+    RaceRecord,
+    RaceType,
+    effects_at_addr,
+)
 from ...utils.traceback_utils import extract_user_frames
 
 
@@ -962,6 +969,33 @@ def _apply_epoch_annotations(accesses: list[MemoryAccess]) -> None:
             acc.epoch = globally_completed_rounds
 
 
+def _has_sync_metadata(accesses: list[MemoryAccess], epoch: int) -> bool:
+    """Check if any atomic access in the given epoch has sync metadata."""
+    for acc in accesses:
+        if acc.epoch != epoch:
+            continue
+        if acc.access_type != AccessType.ATOMIC:
+            continue
+        if acc.legacy_atomic:
+            continue
+        if acc.atomic_sem is not None:
+            return True
+    return False
+
+
+def _collect_sync_events(
+    accesses: list[MemoryAccess], epoch: int
+) -> list[MemoryAccess]:
+    """Collect all non-legacy atomic accesses in the given epoch."""
+    return [
+        acc
+        for acc in accesses
+        if acc.epoch == epoch
+        and acc.access_type == AccessType.ATOMIC
+        and not acc.legacy_atomic
+    ]
+
+
 def detect_races(accesses: list[MemoryAccess]) -> list[RaceRecord]:
     """Detect data races using an inverted index on byte addresses.
 
@@ -970,6 +1004,8 @@ def detect_races(accesses: list[MemoryAccess]) -> list[RaceRecord]:
     2. At least one access is a write (Store)
     3. The accesses are not both atomic
     """
+    from .hb_solver import HBSolver
+
     _apply_epoch_annotations(accesses)
 
     addr_to_accesses: dict[int, list[MemoryAccess]] = defaultdict(list)
@@ -978,6 +1014,10 @@ def detect_races(accesses: list[MemoryAccess]) -> list[RaceRecord]:
         unique_offsets = _active_offsets(access)
         for off in unique_offsets:
             addr_to_accesses[int(off)].append(access)
+
+    # Cache sync metadata check and sync events per epoch
+    _sync_meta_cache: dict[int, bool] = {}
+    _sync_events_cache: dict[int, list[MemoryAccess]] = {}
 
     races: list[RaceRecord] = []
     seen_pairs: set[tuple[tuple[int, ...], tuple[int, ...], RaceType, int, int]] = set()
@@ -1012,19 +1052,43 @@ def detect_races(accesses: list[MemoryAccess]) -> list[RaceRecord]:
                     for acc_b in accesses_b:
                         if acc_a.epoch != acc_b.epoch:
                             continue
+
+                        # Atomic-atomic: suppress (preserved)
                         if (
                             acc_a.access_type == AccessType.ATOMIC
                             and acc_b.access_type == AccessType.ATOMIC
                         ):
                             continue
+
+                        # Load-load: no race
                         if (
                             acc_a.access_type == AccessType.LOAD
                             and acc_b.access_type == AccessType.LOAD
                         ):
                             continue
-                        race_type = _classify_race(acc_a, acc_b)
+
+                        # Effect-based classification
+                        race_type = _classify_race(acc_a, acc_b, addr)
                         if race_type is None:
                             continue
+
+                        # HB check: only if no legacy_atomic involved
+                        if not (acc_a.legacy_atomic or acc_b.legacy_atomic):
+                            epoch = acc_a.epoch
+                            if epoch not in _sync_meta_cache:
+                                _sync_meta_cache[epoch] = _has_sync_metadata(
+                                    accesses, epoch
+                                )
+                            if _sync_meta_cache[epoch]:
+                                if epoch not in _sync_events_cache:
+                                    _sync_events_cache[epoch] = _collect_sync_events(
+                                        accesses, epoch
+                                    )
+                                solver = HBSolver(acc_a, acc_b)
+                                solver.add_sync_events(_sync_events_cache[epoch])
+                                if not solver.check_race_possible():
+                                    continue  # UNSAT → proven ordered, suppress
+
                         dedup_key = (
                             pair_key[0],
                             pair_key[1],
@@ -1047,14 +1111,40 @@ def detect_races(accesses: list[MemoryAccess]) -> list[RaceRecord]:
     return races
 
 
-def _classify_race(a: MemoryAccess, b: MemoryAccess) -> Optional[RaceType]:
-    """Classify the race type between two accesses from different blocks."""
+def _classify_race(
+    a: MemoryAccess, b: MemoryAccess, addr: int | None = None
+) -> Optional[RaceType]:
+    """Classify the race type between two accesses from different blocks.
+
+    When addr is provided, uses effects_at_addr for precise per-lane
+    classification (e.g., failed CAS = read-only). When addr is None,
+    falls back to AccessType-based classification.
+    """
     ta = a.access_type
     tb = b.access_type
+
+    # Rule 1: Load-Load → no race
     if ta == AccessType.LOAD and tb == AccessType.LOAD:
         return None
+
+    # Rule 2: Atomic-Atomic → suppress (preserved for v1)
     if ta == AccessType.ATOMIC and tb == AccessType.ATOMIC:
         return None
+
+    # Rule 3: Use effects_at_addr for precision when addr is available
+    if addr is not None:
+        a_reads, a_writes = effects_at_addr(a, addr)
+        b_reads, b_writes = effects_at_addr(b, addr)
+
+        if not (a_writes or b_writes):
+            return None  # e.g., failed CAS (read-only) vs load → no race
+        if a_writes and b_writes:
+            return RaceType.WAW
+        if (a_writes and b_reads) or (a_reads and b_writes):
+            return RaceType.RAW
+        return None
+
+    # Fallback: AccessType-based classification
     is_write_a = ta in (AccessType.STORE, AccessType.ATOMIC)
     is_write_b = tb in (AccessType.STORE, AccessType.ATOMIC)
     if is_write_a and is_write_b:


### PR DESCRIPTION
<git-pr-chain>


Add effect-based race classification and concrete HB solver

Replace hard-coded _classify_race with effects_at_addr for mixed
atomic/plain pairs (e.g. failed CAS = read-only). Add HBSolver using
graph reachability over po+sw edges to suppress races proven ordered
by release/acquire synchronization. Integrate into detect_races with
caching and legacy_atomic exclusion.


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #344
1. 👉 #345 👈 **YOU ARE HERE**
1. #346
1. #347

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>
