### PR TITLE
Pr/llm kernel assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,5 @@ benchmarks/*.json
 triton_viz/version.py
 .subagents/
 subagent*.txt
+triton_viz/visualizer/llm_config.local.json
+triton_viz/visualizer/llm_chat_debug.jsonl

--- a/examples/LLMtest/README.md
+++ b/examples/LLMtest/README.md
@@ -1,6 +1,6 @@
 # LLM test
 
-Intentionally buggy Triton kernels for trying the visualizer’s LLM assistant.
+Intentionally buggy Triton kernels for trying the visualizer's LLM assistant.
 
 ## Run
 

--- a/examples/LLMtest/README.md
+++ b/examples/LLMtest/README.md
@@ -1,24 +1,26 @@
 # LLM test
 
-This folder contains intentionally buggy Triton kernels for evaluating
-LLM-based trace analysis in Triton-Viz.
+Intentionally buggy Triton kernels for trying the visualizer’s LLM assistant.
 
-## How to run
+## Run
 
 From repo root:
 
-- `python "examples/LLM test/buggy_vector_add_shift.py"`
-- `python "examples/LLM test/buggy_matmul_missing_k.py"`
-- `python "examples/LLM test/buggy_softmax_no_stability.py"`
+```bash
+python examples/LLMtest/buggy_vector_add_shift.py
+python examples/LLMtest/buggy_matmul_missing_k.py
+python examples/LLMtest/buggy_softmax_no_stability.py
+```
 
-Each script:
+Each script has two optional constants at the top:
 
-- runs a buggy kernel with `@triton_viz.trace(client=Tracer())`
-- prints a quick numerical mismatch signal
-- launches Triton-Viz (`triton_viz.launch(share=True)`)
+- `_LL_CONFIG_PATH` — path to a JSON file (same keys as `triton_viz/visualizer/llm_config.example.json`)
+- `_LL_API_KEY` — API key string if it is not in that file
 
-## Intended bug patterns
+Fill either or both, then run. If both are empty, LLM still follows `llm_config.local.json` / env vars / defaults like the rest of the app.
+
+## Bug patterns
 
 - `buggy_vector_add_shift.py`: wrong load index for `y` (`offset + 1`)
 - `buggy_matmul_missing_k.py`: missing last K tile accumulation
-- `buggy_softmax_no_stability.py`: skips max-subtraction, prone to overflow
+- `buggy_softmax_no_stability.py`: no max-subtraction, prone to overflow

--- a/examples/LLMtest/README.md
+++ b/examples/LLMtest/README.md
@@ -1,0 +1,24 @@
+# LLM test
+
+This folder contains intentionally buggy Triton kernels for evaluating
+LLM-based trace analysis in Triton-Viz.
+
+## How to run
+
+From repo root:
+
+- `python "examples/LLM test/buggy_vector_add_shift.py"`
+- `python "examples/LLM test/buggy_matmul_missing_k.py"`
+- `python "examples/LLM test/buggy_softmax_no_stability.py"`
+
+Each script:
+
+- runs a buggy kernel with `@triton_viz.trace(client=Tracer())`
+- prints a quick numerical mismatch signal
+- launches Triton-Viz (`triton_viz.launch(share=True)`)
+
+## Intended bug patterns
+
+- `buggy_vector_add_shift.py`: wrong load index for `y` (`offset + 1`)
+- `buggy_matmul_missing_k.py`: missing last K tile accumulation
+- `buggy_softmax_no_stability.py`: skips max-subtraction, prone to overflow

--- a/examples/LLMtest/buggy_matmul_missing_k.py
+++ b/examples/LLMtest/buggy_matmul_missing_k.py
@@ -1,0 +1,90 @@
+import torch
+import triton
+import triton.language as tl
+
+import triton_viz
+from triton_viz.clients import Tracer
+
+
+@triton_viz.trace(client=Tracer())
+@triton.jit
+def matmul_missing_k_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    # Bug: skip the last K tile on purpose (range ends at K - BLOCK_K).
+    for _k in range(0, K - BLOCK_K, BLOCK_K):
+        a = tl.load(
+            a_ptrs, mask=(offs_m[:, None] < M) & (_k + offs_k[None, :] < K), other=0.0
+        )
+        b = tl.load(
+            b_ptrs, mask=(_k + offs_k[:, None] < K) & (offs_n[None, :] < N), other=0.0
+        )
+        acc += tl.dot(a, b)
+        a_ptrs += BLOCK_K * stride_ak
+        b_ptrs += BLOCK_K * stride_bk
+
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc, mask=(offs_m[:, None] < M) & (offs_n[None, :] < N))
+
+
+def run_demo():
+    torch.manual_seed(0)
+    M, N, K = 64, 64, 64
+    a = torch.randn((M, K), dtype=torch.float32)
+    b = torch.randn((K, N), dtype=torch.float32)
+    c = torch.empty((M, N), dtype=torch.float32)
+
+    BLOCK_M, BLOCK_N, BLOCK_K = 32, 32, 16
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N))
+    matmul_missing_k_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        BLOCK_K=BLOCK_K,
+    )
+
+    ref = a @ b
+    max_diff = (c - ref).abs().max().item()
+    print(f"[buggy_matmul_missing_k] max diff: {max_diff:.6f}")
+
+    triton_viz.launch(share=True)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/LLMtest/buggy_matmul_missing_k.py
+++ b/examples/LLMtest/buggy_matmul_missing_k.py
@@ -5,6 +5,10 @@ import triton.language as tl
 import triton_viz
 from triton_viz.clients import Tracer
 
+# Optional: visualizer LLM — set one or both before running.
+_LL_CONFIG_PATH = ""
+_LL_API_KEY = ""
+
 
 @triton_viz.trace(client=Tracer())
 @triton.jit
@@ -83,6 +87,10 @@ def run_demo():
     max_diff = (c - ref).abs().max().item()
     print(f"[buggy_matmul_missing_k] max diff: {max_diff:.6f}")
 
+    if _LL_CONFIG_PATH:
+        triton_viz.setup_llm(config_path=_LL_CONFIG_PATH)
+    if _LL_API_KEY:
+        triton_viz.setup_llm(api_key=_LL_API_KEY)
     triton_viz.launch(share=True)
 
 

--- a/examples/LLMtest/buggy_softmax_no_stability.py
+++ b/examples/LLMtest/buggy_softmax_no_stability.py
@@ -1,0 +1,68 @@
+import torch
+import triton
+import triton.language as tl
+
+import triton_viz
+from triton_viz.clients import Tracer
+
+
+@triton_viz.trace(client=Tracer())
+@triton.jit
+def softmax_no_stability_kernel(
+    x_ptr,
+    y_ptr,
+    stride_xm,
+    stride_xn,
+    stride_ym,
+    stride_yn,
+    n_cols,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    row_start_x = x_ptr + pid * stride_xm
+    row_start_y = y_ptr + pid * stride_ym
+
+    offs = tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_cols
+    x = tl.load(row_start_x + offs * stride_xn, mask=mask, other=-float("inf"))
+
+    # Bug: missing numerical stabilization (x - max(x)).
+    ex = tl.exp(x)
+    ex = tl.where(mask, ex, 0.0)
+    denom = tl.sum(ex, axis=0)
+    out = ex / denom
+    tl.store(row_start_y + offs * stride_yn, out, mask=mask)
+
+
+def run_demo():
+    torch.manual_seed(0)
+    rows, cols = 8, 64
+    # Large positive values make overflow likely without max-subtraction.
+    x = torch.randn((rows, cols), dtype=torch.float32) * 20.0 + 50.0
+    y = torch.empty_like(x)
+
+    grid = (rows,)
+    block = 64
+    softmax_no_stability_kernel[grid](
+        x,
+        y,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        cols,
+        BLOCK_SIZE=block,
+    )
+
+    ref = torch.softmax(x, dim=1)
+    finite_ratio = torch.isfinite(y).float().mean().item()
+    max_diff = (torch.nan_to_num(y) - ref).abs().max().item()
+    print(
+        f"[buggy_softmax_no_stability] finite ratio: {finite_ratio:.3f}, max diff: {max_diff:.6f}"
+    )
+
+    triton_viz.launch(share=True)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/LLMtest/buggy_softmax_no_stability.py
+++ b/examples/LLMtest/buggy_softmax_no_stability.py
@@ -5,6 +5,10 @@ import triton.language as tl
 import triton_viz
 from triton_viz.clients import Tracer
 
+# Optional: visualizer LLM — set one or both before running.
+_LL_CONFIG_PATH = ""
+_LL_API_KEY = ""
+
 
 @triton_viz.trace(client=Tracer())
 @triton.jit
@@ -61,6 +65,10 @@ def run_demo():
         f"[buggy_softmax_no_stability] finite ratio: {finite_ratio:.3f}, max diff: {max_diff:.6f}"
     )
 
+    if _LL_CONFIG_PATH:
+        triton_viz.setup_llm(config_path=_LL_CONFIG_PATH)
+    if _LL_API_KEY:
+        triton_viz.setup_llm(api_key=_LL_API_KEY)
     triton_viz.launch(share=True)
 
 

--- a/examples/LLMtest/buggy_vector_add_shift.py
+++ b/examples/LLMtest/buggy_vector_add_shift.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+import triton_viz
+from triton_viz.clients import Tracer
+
+
+@triton_viz.trace(client=Tracer())
+@triton.jit
+def add_shift_bug_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    # Bug: y uses shifted index (+1), which misaligns all pairs.
+    y = tl.load(y_ptr + offsets + 1, mask=(offsets + 1) < n_elements, other=0.0)
+    out = x + y
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def run_demo():
+    torch.manual_seed(0)
+    n = 256
+    x = torch.randn((n,), dtype=torch.float32)
+    y = torch.randn((n,), dtype=torch.float32)
+    out = torch.empty_like(x)
+
+    block = 64
+    grid = (triton.cdiv(n, block),)
+    add_shift_bug_kernel[grid](x, y, out, n, BLOCK_SIZE=block)
+
+    ref = x + y
+    max_diff = (out - ref).abs().max().item()
+    print(f"[buggy_vector_add_shift] max diff: {max_diff:.6f}")
+
+    triton_viz.launch(share=True)
+
+
+if __name__ == "__main__":
+    run_demo()

--- a/examples/LLMtest/buggy_vector_add_shift.py
+++ b/examples/LLMtest/buggy_vector_add_shift.py
@@ -5,6 +5,10 @@ import triton.language as tl
 import triton_viz
 from triton_viz.clients import Tracer
 
+# Optional: visualizer LLM — set one or both before running.
+_LL_CONFIG_PATH = "/home/jgu7/work/triton-viz/triton_viz/visualizer/llm_config.local.json"  # e.g. "/path/to/llm.json" (same shape as llm_config.example.json)
+_LL_API_KEY = ""  # e.g. "sk-..." if the key is not in that file
+
 
 @triton_viz.trace(client=Tracer())
 @triton.jit
@@ -36,6 +40,10 @@ def run_demo():
     max_diff = (out - ref).abs().max().item()
     print(f"[buggy_vector_add_shift] max diff: {max_diff:.6f}")
 
+    if _LL_CONFIG_PATH:
+        triton_viz.setup_llm(config_path=_LL_CONFIG_PATH)
+    if _LL_API_KEY:
+        triton_viz.setup_llm(api_key=_LL_API_KEY)
     triton_viz.launch(share=True)
 
 

--- a/triton_viz/__init__.py
+++ b/triton_viz/__init__.py
@@ -3,6 +3,12 @@ from .core.trace_io import save, load
 from .core.config import config
 from .version import __version__, git_version
 from .visualizer import launch
+from .visualizer.llm_utils import (
+    LLM_SETUP_KEYS,
+    clear_llm_setup,
+    setup_llm,
+    setup_llm_from_file,
+)
 
 __all__ = [
     "trace",
@@ -11,6 +17,10 @@ __all__ = [
     "load",
     "config",
     "launch",
+    "LLM_SETUP_KEYS",
+    "setup_llm",
+    "setup_llm_from_file",
+    "clear_llm_setup",
     "__version__",
     "git_version",
 ]

--- a/triton_viz/templates/index.html
+++ b/triton_viz/templates/index.html
@@ -313,8 +313,19 @@
                 root.style.display = visible ? 'flex' : 'none';
             }
 
+            function isChatPanelOpen() {
+                return window.getComputedStyle(root).display !== 'none';
+            }
+
+            function selectedOpUuidForLlm() {
+                const block = window.__tritonVizActiveBlock;
+                const fromBlock =
+                    block && block.blockData && block.blockData[0] && block.blockData[0].uuid;
+                return window.current_op_uuid || window.__tritonVizCurrentOp || fromBlock || null;
+            }
+
             toggle.addEventListener('click', function () {
-                const isOpen = root.style.display !== 'none';
+                const isOpen = isChatPanelOpen();
                 setChatVisible(!isOpen);
                 if (!isOpen) input.focus();
             });
@@ -414,7 +425,7 @@
                 addMsg('user', text);
                 setLoading(true, 'Thinking, please wait...');
                 try {
-                    const currentUuid = window.__tritonVizCurrentOp || null;
+                    const currentUuid = selectedOpUuidForLlm();
                     const resp = await fetch('/api/llm/chat', {
                         method: 'POST',
                         headers: { 'Content-Type': 'application/json' },
@@ -470,10 +481,8 @@
                 const opTab = el.closest('.detail-tab');
                 if (opTab) {
                     try {
-                        const active = window.__tritonVizActiveBlock;
-                        if (active && active.activeOpUuid) {
-                            window.__tritonVizCurrentOp = active.activeOpUuid;
-                        }
+                        const uuid = selectedOpUuidForLlm();
+                        if (uuid) window.__tritonVizCurrentOp = uuid;
                     } catch (_) {}
                 }
             });

--- a/triton_viz/templates/index.html
+++ b/triton_viz/templates/index.html
@@ -5,6 +5,226 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Triton Kernel Visualization</title>
     <link rel="stylesheet" href="/static/visualizer.css">
+    <style>
+        #llm-chat {
+            position: fixed;
+            right: 24px;
+            bottom: 24px;
+            z-index: 4000;
+            width: 400px;
+            height: 480px;
+            min-width: 320px;
+            min-height: 340px;
+            max-width: min(92vw, 760px);
+            max-height: 82vh;
+            display: none;
+            flex-direction: column;
+            overflow: hidden;
+            resize: both;
+            border-radius: 14px;
+            border: 1px solid rgba(255, 255, 255, 0.12);
+            background: linear-gradient(180deg, rgba(18, 20, 30, 0.97), rgba(16, 18, 28, 0.97));
+            color: #edf1ff;
+            box-shadow: 0 20px 48px rgba(0, 0, 0, 0.42);
+            backdrop-filter: blur(8px);
+            font-family: Inter, "SF Pro Text", "Segoe UI", Roboto, "PingFang SC", "Microsoft YaHei", sans-serif;
+        }
+
+        #llm-chat-header {
+            padding: 10px 12px;
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 10px;
+            border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.04);
+            cursor: move;
+            user-select: none;
+        }
+
+        #llm-title {
+            font-size: 13px;
+            font-weight: 650;
+            letter-spacing: 0.2px;
+            color: #e9eeff;
+        }
+
+        #llm-chat-actions {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+        }
+
+        .llm-btn {
+            border: 1px solid rgba(255, 255, 255, 0.16);
+            border-radius: 8px;
+            background: rgba(255, 255, 255, 0.06);
+            color: #e8ecff;
+            cursor: pointer;
+            font-size: 12px;
+            line-height: 1;
+            transition: all 0.15s ease;
+        }
+
+        .llm-btn:hover:not(:disabled) {
+            background: rgba(255, 255, 255, 0.14);
+            border-color: rgba(255, 255, 255, 0.28);
+        }
+
+        .llm-btn:disabled {
+            opacity: 0.55;
+            cursor: not-allowed;
+        }
+
+        #llm-analyze {
+            padding: 6px 10px;
+            background: linear-gradient(180deg, rgba(66, 103, 237, 0.45), rgba(41, 80, 221, 0.35));
+            border-color: rgba(112, 145, 255, 0.45);
+        }
+
+        #llm-close {
+            width: 28px;
+            height: 28px;
+            padding: 0;
+            font-size: 15px;
+            background: transparent;
+            border-color: transparent;
+        }
+
+        #llm-messages {
+            flex: 1;
+            overflow: auto;
+            padding: 12px;
+            display: flex;
+            flex-direction: column;
+            gap: 8px;
+            font-size: 12px;
+            line-height: 1.5;
+        }
+
+        .llm-row {
+            display: flex;
+        }
+
+        .llm-row.user {
+            justify-content: flex-end;
+        }
+
+        .llm-row.assistant,
+        .llm-row.system {
+            justify-content: flex-start;
+        }
+
+        .llm-bubble {
+            max-width: 92%;
+            padding: 8px 10px;
+            border-radius: 10px;
+            border: 1px solid transparent;
+            white-space: pre-wrap;
+            word-break: break-word;
+        }
+
+        .llm-row.user .llm-bubble {
+            background: linear-gradient(180deg, rgba(67, 113, 255, 0.9), rgba(54, 95, 236, 0.84));
+            color: #f8faff;
+            border-color: rgba(137, 167, 255, 0.38);
+        }
+
+        .llm-row.assistant .llm-bubble {
+            background: rgba(255, 255, 255, 0.08);
+            color: #e8ecff;
+            border-color: rgba(255, 255, 255, 0.12);
+        }
+
+        .llm-row.system .llm-bubble {
+            background: rgba(255, 255, 255, 0.04);
+            color: #c9d3ff;
+            border-style: dashed;
+            border-color: rgba(255, 255, 255, 0.16);
+        }
+
+        .llm-role {
+            opacity: 0.72;
+            font-size: 11px;
+            margin-bottom: 2px;
+        }
+
+        #llm-input-wrap {
+            display: flex;
+            gap: 8px;
+            padding: 10px 12px;
+            border-top: 1px solid rgba(255, 255, 255, 0.1);
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        #llm-input {
+            flex: 1;
+            min-width: 0;
+            padding: 8px 10px;
+            border-radius: 9px;
+            border: 1px solid rgba(255, 255, 255, 0.16);
+            background: rgba(7, 9, 15, 0.68);
+            color: #f2f5ff;
+            outline: none;
+            font-size: 12px;
+        }
+
+        #llm-input:focus {
+            border-color: rgba(126, 154, 255, 0.9);
+            box-shadow: 0 0 0 2px rgba(107, 141, 255, 0.22);
+        }
+
+        #llm-send {
+            padding: 8px 14px;
+            border: 1px solid rgba(137, 167, 255, 0.5);
+            border-radius: 9px;
+            background: linear-gradient(180deg, rgba(73, 122, 255, 0.95), rgba(62, 104, 236, 0.95));
+            color: #fff;
+            cursor: pointer;
+            font-size: 12px;
+            font-weight: 600;
+            transition: all 0.15s ease;
+        }
+
+        #llm-send:hover:not(:disabled) {
+            filter: brightness(1.06);
+        }
+
+        #llm-send:disabled {
+            opacity: 0.58;
+            cursor: not-allowed;
+        }
+
+        .llm-loading {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            min-height: 20px;
+        }
+
+        .llm-spinner {
+            width: 12px;
+            height: 12px;
+            border-radius: 999px;
+            border: 2px solid rgba(160, 180, 255, 0.35);
+            border-top-color: rgba(160, 180, 255, 0.95);
+            animation: llm-spin 0.9s linear infinite;
+            flex: 0 0 auto;
+        }
+
+        .llm-loading-text {
+            white-space: nowrap;
+        }
+
+        @keyframes llm-spin {
+            from {
+                transform: rotate(0deg);
+            }
+            to {
+                transform: rotate(360deg);
+            }
+        }
+    </style>
 </head>
 <body>
     <div class="viz-app" data-component="app">
@@ -39,6 +259,7 @@
                     <button id="btn-op-histogram" class="viz-button ghost" type="button" disabled>Value Histogram</button>
                     <button id="btn-op-download" class="viz-button ghost" type="button" disabled>Download Tensor</button>
                     <button id="btn-op-edit-tensor-view" class="viz-button ghost" type="button" disabled>Edit Tensor View: OFF</button>
+                    <button id="llm-toggle" class="viz-button ghost" type="button">AI Assistant</button>
                 </div>
             </section>
 
@@ -51,6 +272,212 @@
         </main>
     </div>
 
+    <div id="llm-chat">
+        <div id="llm-chat-header">
+            <span id="llm-title">AI Kernel Debug Assistant</span>
+            <div id="llm-chat-actions">
+                <button id="llm-analyze" class="llm-btn" type="button">开始分析</button>
+                <button id="llm-close" class="llm-btn" type="button" aria-label="Close chat">✕</button>
+            </div>
+        </div>
+        <div id="llm-messages">
+            <div class="llm-row system">
+                <div class="llm-bubble">
+                    <div class="llm-role">系统</div>
+                    你好，先点击“开始分析”让我先读一遍 Trace，随后你再继续追问。
+                </div>
+            </div>
+        </div>
+        <div id="llm-input-wrap">
+            <input id="llm-input" type="text" placeholder="问点什么，比如：这个 kernel 哪一段可能有索引 bug？">
+            <button id="llm-send" type="button">发送</button>
+        </div>
+    </div>
+
     <script type="module" src="/static/main.js"></script>
+    <script>
+        (function () {
+            const root = document.getElementById('llm-chat');
+            const header = document.getElementById('llm-chat-header');
+            const msgs = document.getElementById('llm-messages');
+            const input = document.getElementById('llm-input');
+            const send = document.getElementById('llm-send');
+            const toggle = document.getElementById('llm-toggle');
+            const close = document.getElementById('llm-close');
+            const analyze = document.getElementById('llm-analyze');
+            if (!root || !header || !msgs || !input || !send || !toggle || !close || !analyze) return;
+            let analysisReady = false;
+            let loadingNode = null;
+
+            function setChatVisible(visible) {
+                root.style.display = visible ? 'flex' : 'none';
+            }
+
+            toggle.addEventListener('click', function () {
+                const isOpen = root.style.display !== 'none';
+                setChatVisible(!isOpen);
+                if (!isOpen) input.focus();
+            });
+
+            close.addEventListener('click', function () {
+                setChatVisible(false);
+            });
+
+            function addMsg(role, text) {
+                const row = document.createElement('div');
+                row.className = 'llm-row ' + (role === 'user' ? 'user' : 'assistant');
+                const bubble = document.createElement('div');
+                bubble.className = 'llm-bubble';
+                const roleTag = document.createElement('div');
+                roleTag.className = 'llm-role';
+                roleTag.textContent = role === 'user' ? '你' : 'AI';
+                const content = document.createElement('div');
+                content.textContent = String(text || '');
+                bubble.appendChild(roleTag);
+                bubble.appendChild(content);
+                row.appendChild(bubble);
+                msgs.appendChild(row);
+                msgs.scrollTop = msgs.scrollHeight;
+            }
+
+            function setLoading(loading, text) {
+                send.disabled = !!loading;
+                analyze.disabled = !!loading;
+                if (loading) {
+                    if (!loadingNode) {
+                        loadingNode = document.createElement('div');
+                        loadingNode.className = 'llm-row assistant';
+                        const bubble = document.createElement('div');
+                        bubble.className = 'llm-bubble';
+                        const roleTag = document.createElement('div');
+                        roleTag.className = 'llm-role';
+                        roleTag.textContent = 'AI';
+                        const loading = document.createElement('div');
+                        loading.className = 'llm-loading';
+                        const spinner = document.createElement('span');
+                        spinner.className = 'llm-spinner';
+                        const textNode = document.createElement('span');
+                        textNode.className = 'llm-loading-text';
+                        textNode.textContent = '处理中';
+                        loading.appendChild(spinner);
+                        loading.appendChild(textNode);
+                        bubble.appendChild(roleTag);
+                        bubble.appendChild(loading);
+                        loadingNode.appendChild(bubble);
+                        msgs.appendChild(loadingNode);
+                    }
+                    const content = loadingNode.querySelector('.llm-loading-text');
+                    if (content) {
+                        content.textContent = String(text || '处理中');
+                    }
+                    msgs.scrollTop = msgs.scrollHeight;
+                    return;
+                }
+                if (loadingNode && loadingNode.parentNode) {
+                    loadingNode.parentNode.removeChild(loadingNode);
+                }
+                loadingNode = null;
+            }
+
+            let dragging = false;
+            let dragOffsetX = 0;
+            let dragOffsetY = 0;
+
+            header.addEventListener('mousedown', function (e) {
+                dragging = true;
+                const rect = root.getBoundingClientRect();
+                dragOffsetX = e.clientX - rect.left;
+                dragOffsetY = e.clientY - rect.top;
+                root.style.right = 'auto';
+                root.style.bottom = 'auto';
+                e.preventDefault();
+            });
+
+            document.addEventListener('mousemove', function (e) {
+                if (!dragging) return;
+                root.style.left = Math.max(8, e.clientX - dragOffsetX) + 'px';
+                root.style.top = Math.max(8, e.clientY - dragOffsetY) + 'px';
+            });
+
+            document.addEventListener('mouseup', function () {
+                dragging = false;
+            });
+
+            async function sendMsg() {
+                const text = input.value.trim();
+                if (!text) return;
+                if (!analysisReady) {
+                    addMsg('assistant', '请先点击“开始分析”，我需要先完成一次 Trace 总结。');
+                    return;
+                }
+                input.value = '';
+                addMsg('user', text);
+                setLoading(true, '正在思考，请稍候...');
+                try {
+                    const currentUuid = window.__tritonVizCurrentOp || null;
+                    const resp = await fetch('/api/llm/chat', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({ message: text, uuid: currentUuid }),
+                    });
+                    const data = await resp.json();
+                    if (!resp.ok) {
+                        addMsg('assistant', data.error || '请求失败');
+                    } else {
+                        addMsg('assistant', data.answer || '(空回复)');
+                    }
+                } catch (err) {
+                    addMsg('assistant', '网络错误: ' + err);
+                } finally {
+                    setLoading(false);
+                }
+            }
+
+            async function runAnalyze() {
+                setLoading(true, '正在分析 Trace，这可能需要几秒...');
+                try {
+                    const resp = await fetch('/api/llm/analyze', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/json' },
+                        body: JSON.stringify({}),
+                    });
+                    const data = await resp.json();
+                    if (!resp.ok) {
+                        analysisReady = false;
+                        addMsg('assistant', data.error || '初步分析失败');
+                        return;
+                    }
+                    analysisReady = !!data.analysis_ready;
+                    addMsg('assistant', data.summary || '初步分析完成，但没有可展示内容。');
+                    addMsg('assistant', '初步分析已完成。你可以继续给我下达排查指令。');
+                } catch (err) {
+                    analysisReady = false;
+                    addMsg('assistant', '网络错误: ' + err);
+                } finally {
+                    setLoading(false);
+                }
+            }
+
+            send.addEventListener('click', sendMsg);
+            analyze.addEventListener('click', runAnalyze);
+            input.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') sendMsg();
+            });
+
+            document.addEventListener('click', function (e) {
+                const el = e.target;
+                if (!el || !el.closest) return;
+                const opTab = el.closest('.detail-tab');
+                if (opTab) {
+                    try {
+                        const active = window.__tritonVizActiveBlock;
+                        if (active && active.activeOpUuid) {
+                            window.__tritonVizCurrentOp = active.activeOpUuid;
+                        }
+                    } catch (_) {}
+                }
+            });
+        })();
+    </script>
 </body>
 </html>

--- a/triton_viz/templates/index.html
+++ b/triton_viz/templates/index.html
@@ -276,21 +276,21 @@
         <div id="llm-chat-header">
             <span id="llm-title">AI Kernel Debug Assistant</span>
             <div id="llm-chat-actions">
-                <button id="llm-analyze" class="llm-btn" type="button">开始分析</button>
+                <button id="llm-analyze" class="llm-btn" type="button">Start analysis</button>
                 <button id="llm-close" class="llm-btn" type="button" aria-label="Close chat">✕</button>
             </div>
         </div>
         <div id="llm-messages">
             <div class="llm-row system">
                 <div class="llm-bubble">
-                    <div class="llm-role">系统</div>
-                    你好，先点击“开始分析”让我先读一遍 Trace，随后你再继续追问。
+                    <div class="llm-role">System</div>
+                    Hi — click &quot;Start analysis&quot; first so I can read the trace; then you can ask follow-ups.
                 </div>
             </div>
         </div>
         <div id="llm-input-wrap">
-            <input id="llm-input" type="text" placeholder="问点什么，比如：这个 kernel 哪一段可能有索引 bug？">
-            <button id="llm-send" type="button">发送</button>
+            <input id="llm-input" type="text" placeholder="Ask something, e.g. which part of this kernel might have an indexing bug?">
+            <button id="llm-send" type="button">Send</button>
         </div>
     </div>
 
@@ -330,7 +330,7 @@
                 bubble.className = 'llm-bubble';
                 const roleTag = document.createElement('div');
                 roleTag.className = 'llm-role';
-                roleTag.textContent = role === 'user' ? '你' : 'AI';
+                roleTag.textContent = role === 'user' ? 'You' : 'AI';
                 const content = document.createElement('div');
                 content.textContent = String(text || '');
                 bubble.appendChild(roleTag);
@@ -358,7 +358,7 @@
                         spinner.className = 'llm-spinner';
                         const textNode = document.createElement('span');
                         textNode.className = 'llm-loading-text';
-                        textNode.textContent = '处理中';
+                        textNode.textContent = 'Processing';
                         loading.appendChild(spinner);
                         loading.appendChild(textNode);
                         bubble.appendChild(roleTag);
@@ -368,7 +368,7 @@
                     }
                     const content = loadingNode.querySelector('.llm-loading-text');
                     if (content) {
-                        content.textContent = String(text || '处理中');
+                        content.textContent = String(text || 'Processing');
                     }
                     msgs.scrollTop = msgs.scrollHeight;
                     return;
@@ -407,12 +407,12 @@
                 const text = input.value.trim();
                 if (!text) return;
                 if (!analysisReady) {
-                    addMsg('assistant', '请先点击“开始分析”，我需要先完成一次 Trace 总结。');
+                    addMsg('assistant', 'Please click \"Start analysis\" first — I need to summarize the trace once.');
                     return;
                 }
                 input.value = '';
                 addMsg('user', text);
-                setLoading(true, '正在思考，请稍候...');
+                setLoading(true, 'Thinking, please wait...');
                 try {
                     const currentUuid = window.__tritonVizCurrentOp || null;
                     const resp = await fetch('/api/llm/chat', {
@@ -422,19 +422,19 @@
                     });
                     const data = await resp.json();
                     if (!resp.ok) {
-                        addMsg('assistant', data.error || '请求失败');
+                        addMsg('assistant', data.error || 'Request failed');
                     } else {
-                        addMsg('assistant', data.answer || '(空回复)');
+                        addMsg('assistant', data.answer || '(empty reply)');
                     }
                 } catch (err) {
-                    addMsg('assistant', '网络错误: ' + err);
+                    addMsg('assistant', 'Network error: ' + err);
                 } finally {
                     setLoading(false);
                 }
             }
 
             async function runAnalyze() {
-                setLoading(true, '正在分析 Trace，这可能需要几秒...');
+                setLoading(true, 'Analyzing trace — this may take a few seconds...');
                 try {
                     const resp = await fetch('/api/llm/analyze', {
                         method: 'POST',
@@ -444,15 +444,15 @@
                     const data = await resp.json();
                     if (!resp.ok) {
                         analysisReady = false;
-                        addMsg('assistant', data.error || '初步分析失败');
+                        addMsg('assistant', data.error || 'Initial analysis failed');
                         return;
                     }
                     analysisReady = !!data.analysis_ready;
-                    addMsg('assistant', data.summary || '初步分析完成，但没有可展示内容。');
-                    addMsg('assistant', '初步分析已完成。你可以继续给我下达排查指令。');
+                    addMsg('assistant', data.summary || 'Initial analysis finished, but there is nothing to show.');
+                    addMsg('assistant', 'Initial analysis is done. You can continue with debugging questions.');
                 } catch (err) {
                     analysisReady = false;
-                    addMsg('assistant', '网络错误: ' + err);
+                    addMsg('assistant', 'Network error: ' + err);
                 } finally {
                     setLoading(false);
                 }

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -6,7 +6,7 @@ import zipfile
 import json
 from flask import Flask, render_template, jsonify, request, send_file
 from .analysis import analyze_records
-from .draw import get_visualization_data, delinearized, make_3d
+from .draw import get_visualization_data
 from .llm_records import LLMRecordStore
 from .llm_utils import (
     LLM_SETUP_KEYS,
@@ -129,9 +129,7 @@ def _build_llm_system_records_prompt() -> str:
     text = json.dumps(payload, ensure_ascii=False)
     if len(text) > LLM_SYS_CONTEXT_MAX_CHARS:
         text = text[:LLM_SYS_CONTEXT_MAX_CHARS]
-        return (
-            "Kernel run records summary (JSON, truncated due to size limit): " + text
-        )
+        return "Kernel run records summary (JSON, truncated due to size limit): " + text
     return "Kernel run records summary (JSON): " + text
 
 
@@ -243,7 +241,11 @@ def _build_llm_compute_trace_prompt() -> str:
         item: dict[str, Any] = {
             "trace_index": idx,
             "op_type": rec_type,
-            "grid_idx": [int(current_grid[0]), int(current_grid[1]), int(current_grid[2])],
+            "grid_idx": [
+                int(current_grid[0]),
+                int(current_grid[1]),
+                int(current_grid[2]),
+            ],
         }
         for attr in (
             "op",

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -3,9 +3,17 @@ from typing import Any
 import sys
 from io import BytesIO
 import zipfile
+import json
 from flask import Flask, render_template, jsonify, request, send_file
 from .analysis import analyze_records
-from .draw import get_visualization_data
+from .draw import get_visualization_data, delinearized, make_3d
+from .llm_records import LLMRecordStore
+from .llm_utils import (
+    load_prompt_template,
+    DEFAULT_PROMPT_NAME,
+    OpenAICompatibleClient,
+    LLMAPIError,
+)
 from ..utils.traceback_utils import read_source_segment
 import os
 import torch
@@ -31,6 +39,10 @@ last_launch_snapshot = None
 sbuf_events = []
 load_overall_maps = {}
 store_overall_maps = {}
+llm_record_store = LLMRecordStore()
+llm_trace_summary: str | None = None
+llm_trace_summary_meta: dict[str, Any] = {}
+llm_analysis_lock = threading.Lock()
 DEVICE_LIMITS = {
     "TRN1_NC_V2": 24 * 1024 * 1024,
     "TRN1_CHIP": 48 * 1024 * 1024,
@@ -40,6 +52,249 @@ DEVICE_LIMITS = {
     "TRN2_CHIP": 224 * 1024 * 1024,
     "TRN2_48XL": 3584 * 1024 * 1024,
 }
+
+
+def _safe_int_env(name: str, default: int, min_value: int = 1) -> int:
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(min_value, value)
+
+
+LLM_SYS_CONTEXT_MAX_CHARS = _safe_int_env(
+    "TRITON_VIZ_LLM_SYS_CONTEXT_MAX_CHARS", 8000, min_value=512
+)
+LLM_SYS_CONTEXT_MAX_RECORDS = _safe_int_env(
+    "TRITON_VIZ_LLM_SYS_CONTEXT_MAX_RECORDS", 200, min_value=1
+)
+LLM_CODE_CONTEXT_MAX_CHARS = _safe_int_env(
+    "TRITON_VIZ_LLM_CODE_CONTEXT_MAX_CHARS", 6000, min_value=512
+)
+LLM_CODE_CONTEXT_MAX_RECORDS = _safe_int_env(
+    "TRITON_VIZ_LLM_CODE_CONTEXT_MAX_RECORDS", 12, min_value=1
+)
+LLM_COMPUTE_CONTEXT_MAX_CHARS = _safe_int_env(
+    "TRITON_VIZ_LLM_COMPUTE_CONTEXT_MAX_CHARS", 8000, min_value=512
+)
+LLM_COMPUTE_CONTEXT_MAX_OPS = _safe_int_env(
+    "TRITON_VIZ_LLM_COMPUTE_CONTEXT_MAX_OPS", 120, min_value=1
+)
+
+
+def _build_llm_system_records_prompt() -> str:
+    """
+    Build a compact run-level op snapshot for system prompt injection.
+    This gives the assistant global kernel/op awareness on every chat turn.
+    """
+    snapshot = llm_record_store.get_snapshot() or {}
+    records = list(snapshot.get("records") or [])
+    compact_records = []
+    max_records = min(len(records), LLM_SYS_CONTEXT_MAX_RECORDS)
+    for record in records[:max_records]:
+        compact_records.append(
+            {
+                "uuid": record.get("uuid"),
+                "op_type": record.get("op_type"),
+                "grid_idx": record.get("grid_idx"),
+                "op_index": record.get("op_index"),
+                "time_idx": record.get("time_idx"),
+                "overall_key": record.get("overall_key"),
+                "mem_src": record.get("mem_src"),
+                "mem_dst": record.get("mem_dst"),
+                "bytes": record.get("bytes"),
+                "input_shape": record.get("input_shape"),
+                "other_shape": record.get("other_shape"),
+                "output_shape": record.get("output_shape"),
+                "global_shape": record.get("global_shape"),
+                "slice_shape": record.get("slice_shape"),
+            }
+        )
+
+    payload = {
+        "total_ops": snapshot.get("total_ops", 0),
+        "grids": snapshot.get("grids", []),
+        "record_count": len(records),
+        "included_records": compact_records,
+        "included_record_count": len(compact_records),
+        "truncated": len(compact_records) < len(records),
+    }
+    text = json.dumps(payload, ensure_ascii=False)
+    if len(text) > LLM_SYS_CONTEXT_MAX_CHARS:
+        text = text[:LLM_SYS_CONTEXT_MAX_CHARS]
+        return (
+            "Kernel run records summary (JSON, truncated due to size limit): " + text
+        )
+    return "Kernel run records summary (JSON): " + text
+
+
+def _format_code_lines(code: dict[str, Any]) -> str:
+    lines = list(code.get("lines") or [])
+    highlight = code.get("highlight")
+    out: list[str] = []
+    for item in lines:
+        no = item.get("no")
+        text = item.get("text") or ""
+        marker = ">" if no == highlight else " "
+        out.append(f"{marker}{str(no).rjust(6)} | {text}")
+    return "\n".join(out)
+
+
+def _build_llm_code_context_prompt(selected_uuid: str | None = None) -> str:
+    """
+    Build a code-centric context block from traceback source segments.
+    Prioritizes selected op code when available.
+    """
+    snapshot = llm_record_store.get_snapshot() or {}
+    records = list(snapshot.get("records") or [])
+    if not records:
+        return "User kernel code context: unavailable"
+
+    selected = str(selected_uuid) if selected_uuid else None
+    ordered: list[dict[str, Any]] = []
+    if selected:
+        chosen = [r for r in records if str(r.get("uuid")) == selected]
+        ordered.extend(chosen)
+    ordered.extend([r for r in records if str(r.get("uuid")) != selected])
+
+    snippets: list[dict[str, Any]] = []
+    for record in ordered:
+        code = record.get("code")
+        if not isinstance(code, dict):
+            continue
+        filename = code.get("filename")
+        if not filename:
+            continue
+        snippets.append(
+            {
+                "uuid": record.get("uuid"),
+                "op_type": record.get("op_type"),
+                "grid_idx": record.get("grid_idx"),
+                "filename": filename,
+                "highlight_lineno": code.get("highlight"),
+                "snippet": _format_code_lines(code),
+            }
+        )
+        if len(snippets) >= LLM_CODE_CONTEXT_MAX_RECORDS:
+            break
+
+    if not snippets:
+        return "User kernel code context: no readable source snippets captured"
+
+    payload = {
+        "selected_uuid": selected,
+        "snippet_count": len(snippets),
+        "snippets": snippets,
+    }
+    text = json.dumps(payload, ensure_ascii=False)
+    if len(text) > LLM_CODE_CONTEXT_MAX_CHARS:
+        text = text[:LLM_CODE_CONTEXT_MAX_CHARS]
+        return "User kernel code context (JSON, truncated): " + text
+    return "User kernel code context (JSON): " + text
+
+
+def _shape_like(value: Any) -> list[int] | None:
+    if not isinstance(value, (list, tuple)):
+        return None
+    out: list[int] = []
+    for item in value:
+        try:
+            out.append(int(item))
+        except (TypeError, ValueError):
+            return None
+    return out
+
+
+def _build_llm_compute_trace_prompt() -> str:
+    """
+    Build a compact summary of non-Load/Store ops from raw launch records.
+    This reduces the "only load/store seen" issue from visualization-level data.
+    """
+    from ..core.trace import launches
+
+    if not launches:
+        return "Kernel compute trace context: unavailable"
+
+    launch = launches[-1]
+    records = list(getattr(launch, "records", []) or [])
+    if not records:
+        return "Kernel compute trace context: empty records"
+
+    compute_ops: list[dict[str, Any]] = []
+    current_grid = (0, 0, 0)
+    skip_names = {"Grid", "Load", "Store", "RawLoad", "RawStore", "ProgramId"}
+    for idx, rec in enumerate(records):
+        rec_type = type(rec).__name__
+        if rec_type == "Grid":
+            grid_val = getattr(rec, "idx", None)
+            if isinstance(grid_val, tuple) and len(grid_val) == 3:
+                current_grid = grid_val
+            continue
+        if rec_type in skip_names:
+            continue
+
+        item: dict[str, Any] = {
+            "trace_index": idx,
+            "op_type": rec_type,
+            "grid_idx": [int(current_grid[0]), int(current_grid[1]), int(current_grid[2])],
+        }
+        for attr in (
+            "op",
+            "index",
+            "keep_dims",
+            "mem_src",
+            "mem_dst",
+            "bytes",
+            "time_idx",
+            "dim",
+        ):
+            val = getattr(rec, attr, None)
+            if isinstance(val, (str, int, float, bool)) and val != "":
+                item[attr] = val
+        for shape_attr in ("input_shape", "other_shape", "output_shape"):
+            shape_val = _shape_like(getattr(rec, shape_attr, None))
+            if shape_val:
+                item[shape_attr] = shape_val
+
+        call_path = getattr(rec, "call_path", None) or []
+        if call_path:
+            frame = call_path[-1]
+            item["code_ref"] = {
+                "filename": getattr(frame, "filename", None),
+                "lineno": int(getattr(frame, "lineno", 0) or 0),
+                "name": getattr(frame, "name", None),
+                "line": getattr(frame, "line", None),
+            }
+        compute_ops.append(item)
+        if len(compute_ops) >= LLM_COMPUTE_CONTEXT_MAX_OPS:
+            break
+
+    payload = {
+        "compute_op_count": len(compute_ops),
+        "compute_ops": compute_ops,
+        "truncated": len(compute_ops) >= LLM_COMPUTE_CONTEXT_MAX_OPS,
+    }
+    text = json.dumps(payload, ensure_ascii=False)
+    if len(text) > LLM_COMPUTE_CONTEXT_MAX_CHARS:
+        text = text[:LLM_COMPUTE_CONTEXT_MAX_CHARS]
+        return "Kernel compute trace context (JSON, truncated): " + text
+    return "Kernel compute trace context (JSON): " + text
+
+
+def _reset_llm_trace_summary() -> None:
+    global llm_trace_summary
+    global llm_trace_summary_meta
+    with llm_analysis_lock:
+        llm_trace_summary = None
+        llm_trace_summary_meta = {}
+
+
+def _get_llm_trace_summary() -> tuple[str | None, dict[str, Any]]:
+    with llm_analysis_lock:
+        return llm_trace_summary, dict(llm_trace_summary_meta)
 
 
 def _compute_sbuf_timeline(events: list[dict]) -> tuple[list[dict], int]:
@@ -143,6 +398,9 @@ def update_global_data(force: bool = False):
     global sbuf_events
     global load_overall_maps
     global store_overall_maps
+    global llm_record_store
+    global llm_trace_summary
+    global llm_trace_summary_meta
     global last_launch_snapshot
 
     # Collect all records from launches
@@ -177,6 +435,8 @@ def update_global_data(force: bool = False):
     sbuf_events = raw_tensor_data.pop("__sbuf_events__", [])
     load_overall_maps = viz_data.get("load_overall", {})
     store_overall_maps = viz_data.get("store_overall", {})
+    llm_record_store.update(viz_data.get("visualization_data", {}), raw_tensor_data)
+    _reset_llm_trace_summary()
 
     # Precompute C values for each Dot operation
     precomputed_c_values = {}
@@ -193,6 +453,231 @@ def update_global_data(force: bool = False):
             df_dict["Value"].append(value)
 
     global_data["analysis"] = df_dict
+
+
+@app.route("/api/llm/records")
+def get_llm_records():
+    if global_data is None or raw_tensor_data is None:
+        update_global_data()
+    return jsonify(llm_record_store.get_snapshot())
+
+
+@app.route("/api/llm/record", methods=["POST"])
+def get_llm_record():
+    data = request.json or {}
+    uuid = data.get("uuid")
+    if not uuid:
+        return jsonify({"error": "Missing uuid"}), 400
+    if global_data is None or raw_tensor_data is None:
+        update_global_data()
+    payload = llm_record_store.get_record(str(uuid))
+    if payload is None:
+        return jsonify({"error": "Record not found"}), 404
+    return jsonify(payload)
+
+
+@app.route("/api/llm/prompt")
+def get_llm_prompt():
+    name = request.args.get("name") or DEFAULT_PROMPT_NAME
+    try:
+        content = load_prompt_template(name)
+    except FileNotFoundError:
+        return jsonify({"error": "Prompt template not found"}), 404
+    return jsonify({"name": name, "content": content})
+
+
+@app.route("/api/llm/chat", methods=["POST"])
+def llm_chat():
+    data = request.json or {}
+    message = (data.get("message") or "").strip()
+    if not message:
+        return jsonify({"error": "Missing message"}), 400
+
+    if global_data is None or raw_tensor_data is None:
+        update_global_data()
+
+    prompt_name = data.get("prompt_name") or DEFAULT_PROMPT_NAME
+    try:
+        system_prompt = load_prompt_template(prompt_name)
+    except FileNotFoundError:
+        return jsonify({"error": "Prompt template not found"}), 404
+
+    uuid = data.get("uuid")
+    summary_text, summary_meta = _get_llm_trace_summary()
+    if not summary_text:
+        return (
+            jsonify(
+                {
+                    "error": "Trace analysis is not ready. Please run /api/llm/analyze first."
+                }
+            ),
+            400,
+        )
+
+    code_context_prompt = _build_llm_code_context_prompt(str(uuid) if uuid else None)
+    compute_context_prompt = _build_llm_compute_trace_prompt()
+    messages = [{"role": "system", "content": system_prompt}]
+    messages.append(
+        {
+            "role": "system",
+            "content": (
+                "Pre-analyzed trace summary (use this as the only trace context):\n"
+                + summary_text
+            ),
+        }
+    )
+    messages.append({"role": "system", "content": code_context_prompt})
+    messages.append({"role": "system", "content": compute_context_prompt})
+    messages.append(
+        {
+            "role": "system",
+            "content": (
+                "You are a kernel-debug assistant for users. "
+                "Response policy: prioritize likely bug analysis in user kernel code. "
+                "Do not focus on trace-quality complaints unless they directly block "
+                "a concrete code-level conclusion. Always give likely root causes, "
+                "evidence, and next fix/check actions."
+            ),
+        }
+    )
+    if uuid:
+        messages.append(
+            {"role": "system", "content": f"Current selected op uuid: {str(uuid)}"}
+        )
+    messages.append({"role": "user", "content": message})
+
+    client = OpenAICompatibleClient()
+    selected_model = data.get("model") or client.config.model
+    req_max_tokens = int(data.get("max_tokens", client.config.max_tokens))
+    try:
+        raw_response = client.chat_completions(
+            messages,
+            model=data.get("model"),
+            temperature=float(data["temperature"]) if "temperature" in data else None,
+            max_tokens=req_max_tokens,
+        )
+        answer, llm_debug = client.extract_answer_and_debug(raw_response)
+
+        client.append_debug_log(
+            {
+                "event": "llm_chat",
+                "ok": True,
+                "model": selected_model,
+                "prompt_name": prompt_name,
+                "uuid": uuid,
+                "user_message": message,
+                "answer": answer,
+                "answer_len": len(answer or ""),
+                "llm_debug": llm_debug,
+                "initial_max_tokens": req_max_tokens,
+                "trace_summary_ready": bool(summary_text),
+                "trace_summary_generated_at": summary_meta.get("generated_at"),
+            }
+        )
+    except (LLMAPIError, ValueError) as exc:
+        client.append_debug_log(
+            {
+                "event": "llm_chat",
+                "ok": False,
+                "model": selected_model,
+                "prompt_name": prompt_name,
+                "uuid": uuid,
+                "user_message": message,
+                "error": str(exc),
+            }
+        )
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify({"answer": answer, "uuid": uuid})
+
+
+@app.route("/api/llm/analyze", methods=["POST"])
+def llm_analyze():
+    data = request.json or {}
+    if global_data is None or raw_tensor_data is None:
+        update_global_data()
+
+    prompt_name = data.get("prompt_name") or DEFAULT_PROMPT_NAME
+    try:
+        system_prompt = load_prompt_template(prompt_name)
+    except FileNotFoundError:
+        return jsonify({"error": "Prompt template not found"}), 404
+
+    run_records_prompt = _build_llm_system_records_prompt()
+    code_context_prompt = _build_llm_code_context_prompt()
+    compute_context_prompt = _build_llm_compute_trace_prompt()
+    user_instruction = (
+        "You are a kernel-debug assistant. "
+        "Please perform an initial bug-oriented analysis for this Triton kernel run. "
+        "Prioritize likely code-level bug hypotheses based on source snippets and op flow. "
+        "Return concise structured output with: "
+        "(1) likely bug candidates (ranked, each with why + related uuid/line), "
+        "(2) expected symptom in output values, "
+        "(3) concrete checks/fixes the user should try next. "
+        "Only mention missing trace fields briefly when they block a specific conclusion."
+    )
+    messages = [
+        {"role": "system", "content": system_prompt},
+        {"role": "system", "content": run_records_prompt},
+        {"role": "system", "content": code_context_prompt},
+        {"role": "system", "content": compute_context_prompt},
+        {"role": "user", "content": user_instruction},
+    ]
+
+    client = OpenAICompatibleClient()
+    selected_model = data.get("model") or client.config.model
+    req_max_tokens = int(data.get("max_tokens", client.config.max_tokens))
+    try:
+        raw_response = client.chat_completions(
+            messages,
+            model=data.get("model"),
+            temperature=float(data["temperature"]) if "temperature" in data else None,
+            max_tokens=req_max_tokens,
+        )
+        summary, llm_debug = client.extract_answer_and_debug(raw_response)
+        if not summary.strip():
+            raise ValueError("LLM returned an empty analysis summary")
+
+        with llm_analysis_lock:
+            global llm_trace_summary
+            global llm_trace_summary_meta
+            llm_trace_summary = summary
+            llm_trace_summary_meta = {
+                "model": selected_model,
+                "prompt_name": prompt_name,
+                "generated_at": int(time.time()),
+            }
+
+        client.append_debug_log(
+            {
+                "event": "llm_analyze",
+                "ok": True,
+                "model": selected_model,
+                "prompt_name": prompt_name,
+                "summary_len": len(summary or ""),
+                "llm_debug": llm_debug,
+                "initial_max_tokens": req_max_tokens,
+            }
+        )
+    except (LLMAPIError, ValueError) as exc:
+        client.append_debug_log(
+            {
+                "event": "llm_analyze",
+                "ok": False,
+                "model": selected_model,
+                "prompt_name": prompt_name,
+                "error": str(exc),
+            }
+        )
+        return jsonify({"error": str(exc)}), 500
+
+    return jsonify(
+        {
+            "summary": summary,
+            "analysis_ready": True,
+            "meta": _get_llm_trace_summary()[1],
+        }
+    )
 
 
 @app.route("/")

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -9,10 +9,14 @@ from .analysis import analyze_records
 from .draw import get_visualization_data, delinearized, make_3d
 from .llm_records import LLMRecordStore
 from .llm_utils import (
+    LLM_SETUP_KEYS,
+    _get_llm_setup_snapshot,
     load_prompt_template,
     DEFAULT_PROMPT_NAME,
     OpenAICompatibleClient,
+    OpenAICompatibleConfig,
     LLMAPIError,
+    setup_llm,
 )
 from ..utils.traceback_utils import read_source_segment
 import os
@@ -484,6 +488,68 @@ def get_llm_prompt():
     except FileNotFoundError:
         return jsonify({"error": "Prompt template not found"}), 404
     return jsonify({"name": name, "content": content})
+
+
+@app.route("/api/llm/config", methods=["GET"])
+def get_llm_config_status():
+    """Return effective LLM settings (never echo the API key)."""
+    cfg = OpenAICompatibleConfig.from_env()
+    setup_path, _patch = _get_llm_setup_snapshot()
+    setup_basename = os.path.basename(setup_path) if setup_path else None
+    return jsonify(
+        {
+            "has_api_key": bool(cfg.api_key),
+            "base_url": cfg.base_url,
+            "model": cfg.model,
+            "timeout_sec": cfg.timeout_sec,
+            "max_tokens": cfg.max_tokens,
+            "debug_log_enabled": cfg.debug_log_enabled,
+            "llm_setup_file": setup_basename,
+            "allowed_keys": sorted(LLM_SETUP_KEYS),
+        }
+    )
+
+
+@app.route("/api/llm/config", methods=["POST"])
+def post_llm_config():
+    """
+    Merge JSON fields into the in-memory LLM setup (same as ``triton_viz.setup_llm``).
+
+    Allowed keys: same as ``LLM_SETUP_KEYS`` (see GET response). Does **not** accept
+    ``config_path`` (use ``setup_llm(config_path=...)`` in Python before ``launch``).
+
+    Pass ``null`` or ``\"\"`` for string fields to clear that patch entry.
+    """
+    data = request.json or {}
+    payload = {k: data[k] for k in data if k in LLM_SETUP_KEYS}
+    if not payload:
+        return (
+            jsonify(
+                {
+                    "error": f"Provide at least one of: {sorted(LLM_SETUP_KEYS)}",
+                    "allowed_keys": sorted(LLM_SETUP_KEYS),
+                }
+            ),
+            400,
+        )
+    try:
+        setup_llm(**payload)
+    except (TypeError, ValueError) as exc:
+        return jsonify({"error": str(exc)}), 400
+    cfg = OpenAICompatibleConfig.from_env()
+    setup_path, _ = _get_llm_setup_snapshot()
+    return jsonify(
+        {
+            "ok": True,
+            "has_api_key": bool(cfg.api_key),
+            "base_url": cfg.base_url,
+            "model": cfg.model,
+            "timeout_sec": cfg.timeout_sec,
+            "max_tokens": cfg.max_tokens,
+            "debug_log_enabled": cfg.debug_log_enabled,
+            "llm_setup_file": os.path.basename(setup_path) if setup_path else None,
+        }
+    )
 
 
 @app.route("/api/llm/chat", methods=["POST"])
@@ -1513,6 +1579,10 @@ def launch(share: bool = True, port: int | None = None, block: bool | None = Non
 
     :param block: Whether to block the caller when share=True. Defaults to
                   True outside interactive sessions.
+
+    For the in-app LLM assistant, call ``triton_viz.setup_llm(...)`` **before**
+    ``launch`` (optionally ``setup_llm(config_path=...)`` to load a JSON file), or
+    use ``POST /api/llm/config`` after the server is up.
     """
     default_port = 8000 if share else 5001
     actual_port = port or int(os.getenv("TRITON_VIZ_PORT", default_port))

--- a/triton_viz/visualizer/llm_config.example.json
+++ b/triton_viz/visualizer/llm_config.example.json
@@ -1,0 +1,10 @@
+{
+  "base_url": "https://api.openai.com/v1",
+  "api_key": "sk-your-key-here",
+  "model": "gpt-5-mini",
+  "timeout_sec": 60,
+  "max_tokens": 2048,
+  "debug_log_enabled": false,
+  "debug_log_path": "llm_chat_debug.jsonl",
+  "extra_headers": {}
+}

--- a/triton_viz/visualizer/llm_records.py
+++ b/triton_viz/visualizer/llm_records.py
@@ -104,7 +104,9 @@ class LLMRecordStore:
                 return asdict(record)
         return None
 
-    def _code_from_tracebacks(self, tracebacks: list[dict[str, Any]]) -> dict[str, Any] | None:
+    def _code_from_tracebacks(
+        self, tracebacks: list[dict[str, Any]]
+    ) -> dict[str, Any] | None:
         if not tracebacks:
             return None
         frame = tracebacks[-1] or {}

--- a/triton_viz/visualizer/llm_records.py
+++ b/triton_viz/visualizer/llm_records.py
@@ -1,0 +1,148 @@
+import os
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+from ..utils.traceback_utils import read_source_segment
+
+
+@dataclass
+class LLMOpRecord:
+    """LLM-facing op record with compact metadata and debugging context."""
+
+    uuid: str
+    op_type: str
+    grid_idx: str
+    op_index: int | None = None
+    time_idx: int | None = None
+    overall_key: str | None = None
+    input_shape: list[int] = field(default_factory=list)
+    other_shape: list[int] = field(default_factory=list)
+    output_shape: list[int] = field(default_factory=list)
+    global_shape: list[int] = field(default_factory=list)
+    slice_shape: list[int] = field(default_factory=list)
+    mem_src: str | None = None
+    mem_dst: str | None = None
+    bytes: int | None = None
+    tracebacks: list[dict[str, Any]] = field(default_factory=list)
+    code: dict[str, Any] | None = None
+
+
+@dataclass
+class LLMRecordsSnapshot:
+    """Serializable snapshot consumed by the frontend LLM chat widget."""
+
+    total_ops: int
+    grids: list[str]
+    records: list[LLMOpRecord]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "total_ops": self.total_ops,
+            "grids": self.grids,
+            "records": [asdict(r) for r in self.records],
+        }
+
+
+class LLMRecordStore:
+    """
+    Builds and caches LLM-focused records from visualizer payloads.
+
+    This stays separate from core tracer records to avoid affecting existing
+    tracing and frontend rendering contracts.
+    """
+
+    def __init__(self, code_context: int = 8):
+        self._snapshot = LLMRecordsSnapshot(total_ops=0, grids=[], records=[])
+        self._code_context = max(1, int(code_context))
+
+    def update(
+        self,
+        visualization_data: dict[str, list[dict[str, Any]]] | None,
+        raw_tensor_data: dict[str, dict[str, Any]] | None,
+    ) -> None:
+        viz = visualization_data or {}
+        raw = raw_tensor_data or {}
+        records: list[LLMOpRecord] = []
+        grids = sorted(viz.keys())
+
+        for grid_idx in grids:
+            for op in viz.get(grid_idx, []) or []:
+                uuid = str(op.get("uuid") or "")
+                payload = raw.get(uuid, {}) if uuid else {}
+                tracebacks = list(payload.get("tracebacks") or [])
+                code = self._code_from_tracebacks(tracebacks)
+                record = LLMOpRecord(
+                    uuid=uuid,
+                    op_type=str(op.get("type") or "Unknown"),
+                    grid_idx=grid_idx,
+                    op_index=self._safe_int(op.get("op_index")),
+                    time_idx=self._safe_int(op.get("time_idx")),
+                    overall_key=self._safe_str(op.get("overall_key")),
+                    input_shape=self._to_int_list(op.get("input_shape")),
+                    other_shape=self._to_int_list(op.get("other_shape")),
+                    output_shape=self._to_int_list(op.get("output_shape")),
+                    global_shape=self._to_int_list(op.get("global_shape")),
+                    slice_shape=self._to_int_list(op.get("slice_shape")),
+                    mem_src=self._safe_str(op.get("mem_src")),
+                    mem_dst=self._safe_str(op.get("mem_dst")),
+                    bytes=self._safe_int(op.get("bytes")),
+                    tracebacks=tracebacks,
+                    code=code,
+                )
+                records.append(record)
+
+        self._snapshot = LLMRecordsSnapshot(
+            total_ops=len(records), grids=grids, records=records
+        )
+
+    def get_snapshot(self) -> dict[str, Any]:
+        return self._snapshot.to_dict()
+
+    def get_record(self, uuid: str) -> dict[str, Any] | None:
+        for record in self._snapshot.records:
+            if record.uuid == uuid:
+                return asdict(record)
+        return None
+
+    def _code_from_tracebacks(self, tracebacks: list[dict[str, Any]]) -> dict[str, Any] | None:
+        if not tracebacks:
+            return None
+        frame = tracebacks[-1] or {}
+        filename = frame.get("filename")
+        lineno = self._safe_int(frame.get("lineno"))
+        if not filename or lineno is None:
+            return None
+
+        cwd = os.path.realpath(os.getcwd())
+        path = os.path.realpath(filename)
+        if not path.startswith(cwd):
+            return None
+        return read_source_segment(filename, lineno, self._code_context)
+
+    @staticmethod
+    def _safe_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _safe_str(value: Any) -> str | None:
+        if value is None:
+            return None
+        text = str(value)
+        return text if text else None
+
+    @staticmethod
+    def _to_int_list(value: Any) -> list[int]:
+        if not isinstance(value, (list, tuple)):
+            return []
+        out: list[int] = []
+        for item in value:
+            try:
+                out.append(int(item))
+            except (TypeError, ValueError):
+                continue
+        return out

--- a/triton_viz/visualizer/llm_records.py
+++ b/triton_viz/visualizer/llm_records.py
@@ -1,5 +1,5 @@
-import os
 from dataclasses import asdict, dataclass, field
+from pathlib import Path
 from typing import Any
 
 from ..utils.traceback_utils import read_source_segment
@@ -115,11 +115,14 @@ class LLMRecordStore:
         if not filename or lineno is None:
             return None
 
-        cwd = os.path.realpath(os.getcwd())
-        path = os.path.realpath(filename)
-        if not path.startswith(cwd):
+        cwd = Path.cwd().resolve()
+        try:
+            resolved = Path(filename).resolve()
+            # Reject path-boundary tricks (e.g. cwd /foo vs /foo-secret) vs naive startswith.
+            resolved.relative_to(cwd)
+        except (ValueError, OSError):
             return None
-        return read_source_segment(filename, lineno, self._code_context)
+        return read_source_segment(str(resolved), lineno, self._code_context)
 
     @staticmethod
     def _safe_int(value: Any) -> int | None:

--- a/triton_viz/visualizer/llm_utils.py
+++ b/triton_viz/visualizer/llm_utils.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import json
 import threading
@@ -15,6 +17,204 @@ DEFAULT_PROMPT_NAME = "system_default.md"
 LOCAL_CONFIG_NAME = "llm_config.local.json"
 DEFAULT_DEBUG_LOG_NAME = "llm_chat_debug.jsonl"
 _DEBUG_LOG_LOCK = threading.Lock()
+
+_MISSING = object()
+
+# LLM setup state (``setup_llm`` / ``POST /api/llm/config``). Highest priority in ``from_env``.
+_LLM_SETUP_LOCK = threading.Lock()
+_llm_setup_config_path: str | None = None
+_llm_setup_patch: dict[str, Any] = {}
+
+# Keys shared with ``llm_config.local.json`` / ``llm_config.example.json`` / env vars.
+LLM_SETUP_KEYS = frozenset(
+    {
+        "base_url",
+        "api_key",
+        "model",
+        "timeout_sec",
+        "max_tokens",
+        "extra_headers",
+        "debug_log_enabled",
+        "debug_log_path",
+    }
+)
+
+
+def clear_llm_setup() -> None:
+    """Clear setup file path and in-memory field patches (fall back to env + local JSON only)."""
+    global _llm_setup_config_path, _llm_setup_patch
+    with _LLM_SETUP_LOCK:
+        _llm_setup_config_path = None
+        _llm_setup_patch = {}
+
+
+def setup_llm(*, config_path: Any = _MISSING, clear: bool = False, **kwargs: Any) -> None:
+    """
+    Configure the visualizer LLM client (in-process). Call **before** ``launch()``, or use
+    ``POST /api/llm/config`` for the same fields (HTTP API does **not** accept ``config_path``
+    for security).
+
+    :param config_path: Optional JSON file (same shape as ``llm_config.example.json``). Merged
+        after ``llm_config.local.json`` and before environment variables.
+    :param clear: If True, ignore other arguments and reset setup state entirely.
+    :param kwargs: Any keys in ``LLM_SETUP_KEYS``. Pass ``None`` or ``\"\"`` for string fields
+        to remove that key from the patch so lower layers apply.
+
+    Final resolution order (each step overwrites defined, non-blank values from the previous):
+
+    1. Built-in defaults
+    2. ``llm_config.local.json`` (optional)
+    3. JSON file from ``config_path`` (optional)
+    4. Environment variables (``TRITON_VIZ_LLM_*``, ``OPENAI_API_KEY``)
+    5. Keyword arguments passed here (or JSON body for ``POST /api/llm/config``) — highest
+    """
+    global _llm_setup_config_path, _llm_setup_patch
+    with _LLM_SETUP_LOCK:
+        if clear:
+            _llm_setup_config_path = None
+            _llm_setup_patch = {}
+            return
+
+        if config_path is not _MISSING:
+            if config_path is None or (
+                isinstance(config_path, str) and not str(config_path).strip()
+            ):
+                _llm_setup_config_path = None
+            else:
+                _llm_setup_config_path = os.path.abspath(
+                    os.path.expanduser(str(config_path).strip())
+                )
+
+        bad = set(kwargs) - LLM_SETUP_KEYS
+        if bad:
+            raise TypeError(
+                f"setup_llm: unknown keyword argument(s): {sorted(bad)}. "
+                f"Allowed: {sorted(LLM_SETUP_KEYS)}"
+            )
+
+        for k, v in kwargs.items():
+            if k == "extra_headers":
+                if v is None:
+                    _llm_setup_patch.pop(k, None)
+                elif isinstance(v, dict):
+                    _llm_setup_patch[k] = {
+                        str(x): str(y)
+                        for x, y in v.items()
+                        if x is not None and y is not None
+                    }
+                else:
+                    raise TypeError("extra_headers must be a dict or None")
+                continue
+            if v is None or (isinstance(v, str) and not str(v).strip()):
+                _llm_setup_patch.pop(k, None)
+            elif k in ("debug_log_enabled",):
+                _llm_setup_patch[k] = v
+            elif k == "max_tokens":
+                try:
+                    _llm_setup_patch[k] = int(v)
+                except (TypeError, ValueError) as exc:
+                    raise TypeError(
+                        f"setup_llm: max_tokens must be int-compatible, got {v!r}"
+                    ) from exc
+            elif k == "timeout_sec":
+                try:
+                    _llm_setup_patch[k] = float(v)
+                except (TypeError, ValueError) as exc:
+                    raise TypeError(
+                        f"setup_llm: timeout_sec must be float-compatible, got {v!r}"
+                    ) from exc
+            elif isinstance(v, str):
+                _llm_setup_patch[k] = str(v).strip()
+            else:
+                _llm_setup_patch[k] = v
+
+
+def setup_llm_from_file(path: str) -> None:
+    """Convenience: ``setup_llm(config_path=path)``."""
+    setup_llm(config_path=path)
+
+
+def _get_llm_setup_snapshot() -> tuple[str | None, dict[str, Any]]:
+    with _LLM_SETUP_LOCK:
+        return _llm_setup_config_path, dict(_llm_setup_patch)
+
+
+def _load_llm_config_at_path(path: str | None) -> dict[str, Any]:
+    """Load a JSON LLM config file; never raises; returns {} if missing or invalid."""
+    if not path:
+        return {}
+    try:
+        if not os.path.isfile(path):
+            return {}
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _llm_env_layer() -> dict[str, Any]:
+    """Environment variables as a config layer (between setup file and setup patch)."""
+    layer: dict[str, Any] = {}
+    if v := _str_or_none(os.getenv("TRITON_VIZ_LLM_BASE_URL")):
+        layer["base_url"] = v
+    if v := _str_or_none(os.getenv("TRITON_VIZ_LLM_API_KEY")):
+        layer["api_key"] = v
+    elif v := _str_or_none(os.getenv("OPENAI_API_KEY")):
+        layer["api_key"] = v
+    if v := _str_or_none(os.getenv("TRITON_VIZ_LLM_MODEL")):
+        layer["model"] = v
+    if os.getenv("TRITON_VIZ_LLM_TIMEOUT") is not None:
+        layer["timeout_sec"] = os.getenv("TRITON_VIZ_LLM_TIMEOUT")
+    if os.getenv("TRITON_VIZ_LLM_MAX_TOKENS") is not None:
+        layer["max_tokens"] = os.getenv("TRITON_VIZ_LLM_MAX_TOKENS")
+    if os.getenv("TRITON_VIZ_LLM_DEBUG_LOG") is not None:
+        layer["debug_log_enabled"] = os.getenv("TRITON_VIZ_LLM_DEBUG_LOG")
+    if os.getenv("TRITON_VIZ_LLM_DEBUG_LOG_PATH") is not None:
+        layer["debug_log_path"] = os.getenv("TRITON_VIZ_LLM_DEBUG_LOG_PATH")
+    return layer
+
+
+def _apply_llm_config_layer(target: dict[str, Any], layer: dict[str, Any]) -> None:
+    """Merge one JSON-style layer into *target* (only ``LLM_SETUP_KEYS``)."""
+    for k, v in layer.items():
+        if k not in LLM_SETUP_KEYS:
+            continue
+        if k == "extra_headers":
+            if isinstance(v, dict) and v:
+                target["extra_headers"] = {
+                    str(x): str(y)
+                    for x, y in v.items()
+                    if x is not None and y is not None
+                }
+            continue
+        if v is None:
+            continue
+        if isinstance(v, str) and not v.strip() and k != "debug_log_path":
+            continue
+        target[k] = v
+
+
+def _build_llm_merged_dict() -> dict[str, Any]:
+    """Merge defaults, local JSON, setup file, env, and setup patch into one dict."""
+    setup_path, patch = _get_llm_setup_snapshot()
+    file_cfg = _load_llm_config_at_path(setup_path)
+    local_cfg = _load_local_llm_config()
+    env_layer = _llm_env_layer()
+
+    merged: dict[str, Any] = {
+        "base_url": DEFAULT_BASE_URL,
+        "api_key": None,
+        "model": DEFAULT_MODEL,
+        "timeout_sec": 60.0,
+        "max_tokens": 2048,
+        "extra_headers": {},
+        "debug_log_enabled": False,
+        "debug_log_path": os.path.join(os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME),
+    }
+    for layer in (local_cfg, file_cfg, env_layer, patch):
+        _apply_llm_config_layer(merged, layer)
+    return merged
 
 
 class LLMAPIError(RuntimeError):
@@ -35,10 +235,18 @@ def _normalize_base_url(base_url: str) -> str:
     return base_url.rstrip("/")
 
 
+def _str_or_none(value: Any) -> str | None:
+    """Return stripped string or None if missing / blank (treats placeholders as empty)."""
+    if value is None:
+        return None
+    s = str(value).strip()
+    return s if s else None
+
+
 def _load_local_llm_config() -> dict[str, Any]:
     """
     Load optional local config from visualizer/llm_config.local.json.
-    Returns empty dict when file is missing or invalid.
+    Returns empty dict when file is missing or invalid (never raises).
     """
     config_path = os.path.join(os.path.dirname(__file__), LOCAL_CONFIG_NAME)
     if not os.path.isfile(config_path):
@@ -77,11 +285,15 @@ class OpenAICompatibleConfig:
     """
     Configuration for OpenAI-compatible Chat Completions API.
 
-    Environment variable fallbacks:
-    - TRITON_VIZ_LLM_BASE_URL (default: https://api.openai.com/v1)
-    - TRITON_VIZ_LLM_API_KEY (fallback: OPENAI_API_KEY)
-    - TRITON_VIZ_LLM_MODEL (default: gpt-5-mini)
-    - TRITON_VIZ_LLM_TIMEOUT (seconds, default: 60)
+    Built by ``from_env()`` using (lowest → highest priority):
+
+    1. Built-in defaults
+    2. ``llm_config.local.json`` next to this module (optional; missing file is OK)
+    3. JSON file path from ``setup_llm(config_path=...)`` (optional)
+    4. Environment variables — ``TRITON_VIZ_LLM_*``, ``OPENAI_API_KEY``
+    5. ``setup_llm(**kwargs)`` or ``POST /api/llm/config`` (same keys as the JSON file)
+
+    Missing files or invalid JSON never raise; blank values in lower layers are skipped.
     """
 
     base_url: str = DEFAULT_BASE_URL
@@ -95,54 +307,39 @@ class OpenAICompatibleConfig:
 
     @classmethod
     def from_env(cls) -> "OpenAICompatibleConfig":
-        local_cfg = _load_local_llm_config()
+        merged = _build_llm_merged_dict()
 
-        base_url = (
-            os.getenv("TRITON_VIZ_LLM_BASE_URL")
-            or local_cfg.get("base_url")
-            or DEFAULT_BASE_URL
-        )
-        api_key = (
-            os.getenv("TRITON_VIZ_LLM_API_KEY")
-            or os.getenv("OPENAI_API_KEY")
-            or local_cfg.get("api_key")
-        )
-        model = os.getenv("TRITON_VIZ_LLM_MODEL") or local_cfg.get("model") or DEFAULT_MODEL
-        timeout_raw = (
-            os.getenv("TRITON_VIZ_LLM_TIMEOUT")
-            or str(local_cfg.get("timeout_sec", "60"))
-        )
+        base_url_raw = _str_or_none(merged.get("base_url")) or DEFAULT_BASE_URL
+        base_url = _normalize_base_url(base_url_raw)
+        api_key = _str_or_none(merged.get("api_key"))
+        model = _str_or_none(merged.get("model")) or DEFAULT_MODEL
+
         try:
-            timeout = float(timeout_raw)
-        except ValueError:
-            timeout = 60.0
-        max_tokens_raw = os.getenv(
-            "TRITON_VIZ_LLM_MAX_TOKENS", str(local_cfg.get("max_tokens", 2048))
-        )
+            timeout_sec = float(merged.get("timeout_sec", 60.0))
+        except (TypeError, ValueError):
+            timeout_sec = 60.0
+
         try:
-            max_tokens = max(1, int(max_tokens_raw))
+            max_tokens = max(1, int(merged.get("max_tokens", 2048)))
         except (TypeError, ValueError):
             max_tokens = 2048
 
-        extra_headers_raw = local_cfg.get("extra_headers")
+        extra = merged.get("extra_headers") or {}
         extra_headers: dict[str, str] = {}
-        if isinstance(extra_headers_raw, dict):
-            for key, value in extra_headers_raw.items():
+        if isinstance(extra, dict):
+            for key, value in extra.items():
                 if key is None or value is None:
                     continue
                 extra_headers[str(key)] = str(value)
 
-        debug_log_enabled = _to_bool(
-            os.getenv("TRITON_VIZ_LLM_DEBUG_LOG", local_cfg.get("debug_log_enabled", False))
-        )
-        debug_log_path = _resolve_debug_log_path(
-            os.getenv("TRITON_VIZ_LLM_DEBUG_LOG_PATH", local_cfg.get("debug_log_path"))
-        )
+        debug_log_enabled = _to_bool(merged.get("debug_log_enabled", False))
+        debug_log_path = _resolve_debug_log_path(merged.get("debug_log_path"))
+
         return cls(
             base_url=base_url,
             api_key=api_key,
             model=model,
-            timeout_sec=timeout,
+            timeout_sec=timeout_sec,
             max_tokens=max_tokens,
             extra_headers=extra_headers,
             debug_log_enabled=debug_log_enabled,

--- a/triton_viz/visualizer/llm_utils.py
+++ b/triton_viz/visualizer/llm_utils.py
@@ -1,0 +1,343 @@
+import os
+import json
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+import requests
+
+
+DEFAULT_BASE_URL = "https://api.openai.com/v1"
+DEFAULT_MODEL = "gpt-5-mini"
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), "prompts")
+DEFAULT_PROMPT_NAME = "system_default.md"
+LOCAL_CONFIG_NAME = "llm_config.local.json"
+DEFAULT_DEBUG_LOG_NAME = "llm_chat_debug.jsonl"
+_DEBUG_LOG_LOCK = threading.Lock()
+
+
+class LLMAPIError(RuntimeError):
+    """Raised when an LLM API call fails."""
+
+
+def load_prompt_template(name: str = DEFAULT_PROMPT_NAME) -> str:
+    """Load a prompt template from visualizer/prompts."""
+    safe_name = os.path.basename(name or DEFAULT_PROMPT_NAME)
+    path = os.path.join(PROMPTS_DIR, safe_name)
+    if not os.path.isfile(path):
+        raise FileNotFoundError(f"Prompt template not found: {safe_name}")
+    with open(path, "r", encoding="utf-8") as f:
+        return f.read()
+
+
+def _normalize_base_url(base_url: str) -> str:
+    return base_url.rstrip("/")
+
+
+def _load_local_llm_config() -> dict[str, Any]:
+    """
+    Load optional local config from visualizer/llm_config.local.json.
+    Returns empty dict when file is missing or invalid.
+    """
+    config_path = os.path.join(os.path.dirname(__file__), LOCAL_CONFIG_NAME)
+    if not os.path.isfile(config_path):
+        return {}
+    try:
+        with open(config_path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, dict):
+            return data
+    except Exception:
+        return {}
+    return {}
+
+
+def _to_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value != 0
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+    return False
+
+
+def _resolve_debug_log_path(path_value: Any) -> str:
+    text = str(path_value or "").strip()
+    if not text:
+        return os.path.join(os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME)
+    if os.path.isabs(text):
+        return text
+    return os.path.join(os.path.dirname(__file__), text)
+
+
+@dataclass
+class OpenAICompatibleConfig:
+    """
+    Configuration for OpenAI-compatible Chat Completions API.
+
+    Environment variable fallbacks:
+    - TRITON_VIZ_LLM_BASE_URL (default: https://api.openai.com/v1)
+    - TRITON_VIZ_LLM_API_KEY (fallback: OPENAI_API_KEY)
+    - TRITON_VIZ_LLM_MODEL (default: gpt-5-mini)
+    - TRITON_VIZ_LLM_TIMEOUT (seconds, default: 60)
+    """
+
+    base_url: str = DEFAULT_BASE_URL
+    api_key: str | None = None
+    model: str = DEFAULT_MODEL
+    timeout_sec: float = 60.0
+    max_tokens: int = 2048
+    extra_headers: dict[str, str] = field(default_factory=dict)
+    debug_log_enabled: bool = False
+    debug_log_path: str = os.path.join(os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME)
+
+    @classmethod
+    def from_env(cls) -> "OpenAICompatibleConfig":
+        local_cfg = _load_local_llm_config()
+
+        base_url = (
+            os.getenv("TRITON_VIZ_LLM_BASE_URL")
+            or local_cfg.get("base_url")
+            or DEFAULT_BASE_URL
+        )
+        api_key = (
+            os.getenv("TRITON_VIZ_LLM_API_KEY")
+            or os.getenv("OPENAI_API_KEY")
+            or local_cfg.get("api_key")
+        )
+        model = os.getenv("TRITON_VIZ_LLM_MODEL") or local_cfg.get("model") or DEFAULT_MODEL
+        timeout_raw = (
+            os.getenv("TRITON_VIZ_LLM_TIMEOUT")
+            or str(local_cfg.get("timeout_sec", "60"))
+        )
+        try:
+            timeout = float(timeout_raw)
+        except ValueError:
+            timeout = 60.0
+        max_tokens_raw = os.getenv(
+            "TRITON_VIZ_LLM_MAX_TOKENS", str(local_cfg.get("max_tokens", 2048))
+        )
+        try:
+            max_tokens = max(1, int(max_tokens_raw))
+        except (TypeError, ValueError):
+            max_tokens = 2048
+
+        extra_headers_raw = local_cfg.get("extra_headers")
+        extra_headers: dict[str, str] = {}
+        if isinstance(extra_headers_raw, dict):
+            for key, value in extra_headers_raw.items():
+                if key is None or value is None:
+                    continue
+                extra_headers[str(key)] = str(value)
+
+        debug_log_enabled = _to_bool(
+            os.getenv("TRITON_VIZ_LLM_DEBUG_LOG", local_cfg.get("debug_log_enabled", False))
+        )
+        debug_log_path = _resolve_debug_log_path(
+            os.getenv("TRITON_VIZ_LLM_DEBUG_LOG_PATH", local_cfg.get("debug_log_path"))
+        )
+        return cls(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            timeout_sec=timeout,
+            max_tokens=max_tokens,
+            extra_headers=extra_headers,
+            debug_log_enabled=debug_log_enabled,
+            debug_log_path=debug_log_path,
+        )
+
+
+class OpenAICompatibleClient:
+    """
+    Lightweight wrapper for OpenAI-compatible Chat Completions APIs.
+    """
+
+    def __init__(self, config: OpenAICompatibleConfig | None = None):
+        self.config = config or OpenAICompatibleConfig.from_env()
+        self.base_url = _normalize_base_url(self.config.base_url)
+
+    def _headers(self) -> dict[str, str]:
+        headers = {
+            "Content-Type": "application/json",
+        }
+        if self.config.api_key:
+            headers["Authorization"] = f"Bearer {self.config.api_key}"
+        headers.update(self.config.extra_headers)
+        return headers
+
+    def _post_chat_completions(self, payload: dict[str, Any]) -> requests.Response:
+        url = f"{self.base_url}/chat/completions"
+        try:
+            return requests.post(
+                url,
+                headers=self._headers(),
+                json=payload,
+                timeout=self.config.timeout_sec,
+            )
+        except requests.RequestException as exc:
+            raise LLMAPIError(f"LLM request failed: {exc}") from exc
+
+    def append_debug_log(self, event: dict[str, Any]) -> None:
+        """
+        Append one JSONL debug event when debug logging is enabled.
+        Never raises to avoid affecting user requests.
+        """
+        if not self.config.debug_log_enabled:
+            return
+        try:
+            line = dict(event)
+            line["ts"] = datetime.now(timezone.utc).isoformat()
+            path = self.config.debug_log_path
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            with _DEBUG_LOG_LOCK:
+                with open(path, "a", encoding="utf-8") as f:
+                    f.write(json.dumps(line, ensure_ascii=False) + "\n")
+        except Exception:
+            return
+
+    @staticmethod
+    def _truncate_text(value: Any, limit: int = 2000) -> str:
+        text = "" if value is None else str(value)
+        if len(text) <= limit:
+            return text
+        return text[:limit] + "...(truncated)"
+
+    @staticmethod
+    def extract_answer_and_debug(data: dict[str, Any]) -> tuple[str, dict[str, Any]]:
+        """
+        Extract answer text from OpenAI-compatible response with diagnostics.
+        Supports both 'text' and 'output_text' content blocks.
+        """
+        choices = data.get("choices") or []
+        usage = data.get("usage")
+        debug: dict[str, Any] = {
+            "choices_count": len(choices),
+            "usage": usage,
+            "finish_reason": None,
+            "content_kind": None,
+            "content_block_types": [],
+            "refusal": None,
+            "message_preview": None,
+        }
+        if not choices:
+            return "", debug
+
+        first_choice = choices[0] if isinstance(choices[0], dict) else {}
+        debug["finish_reason"] = first_choice.get("finish_reason")
+        message = first_choice.get("message") or {}
+        content = message.get("content")
+
+        # String content
+        if isinstance(content, str):
+            debug["content_kind"] = "string"
+            debug["message_preview"] = OpenAICompatibleClient._truncate_text(content)
+            return content, debug
+
+        # Block content
+        if isinstance(content, list):
+            debug["content_kind"] = "list"
+            text_parts: list[str] = []
+            block_types: list[str] = []
+            for block in content:
+                if not isinstance(block, dict):
+                    continue
+                block_type = str(block.get("type") or "")
+                if block_type:
+                    block_types.append(block_type)
+                if block_type in {"text", "output_text"}:
+                    text = block.get("text")
+                    if isinstance(text, str):
+                        text_parts.append(text)
+                elif block_type == "refusal":
+                    refusal_text = block.get("refusal")
+                    if isinstance(refusal_text, str):
+                        debug["refusal"] = refusal_text
+            debug["content_block_types"] = block_types
+            answer = "".join(text_parts)
+            debug["message_preview"] = OpenAICompatibleClient._truncate_text(
+                json.dumps(message, ensure_ascii=False)
+            )
+            if answer:
+                return answer, debug
+
+        # Fallback: explicit refusal field or empty
+        refusal = message.get("refusal")
+        if isinstance(refusal, str) and refusal:
+            debug["refusal"] = refusal
+        debug["message_preview"] = OpenAICompatibleClient._truncate_text(
+            json.dumps(message, ensure_ascii=False)
+        )
+        return "", debug
+
+    def chat_completions(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
+        response_format: dict[str, Any] | None = None,
+        extra_body: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """
+        Call POST /chat/completions and return parsed JSON.
+        """
+        payload: dict[str, Any] = {
+            "model": model or self.config.model,
+            "messages": messages,
+        }
+        # gpt-5-mini only supports default temperature behavior.
+        # Only pass temperature when explicitly set to 1.
+        if temperature is not None and float(temperature) == 1.0:
+            payload["temperature"] = 1
+        # For gpt-5-mini on Chat Completions, use max_completion_tokens.
+        if max_tokens is not None:
+            payload["max_completion_tokens"] = max_tokens
+        if tools is not None:
+            payload["tools"] = tools
+        if tool_choice is not None:
+            payload["tool_choice"] = tool_choice
+        if response_format is not None:
+            payload["response_format"] = response_format
+        if extra_body:
+            payload.update(extra_body)
+
+        response = self._post_chat_completions(payload)
+
+        if not response.ok:
+            message = response.text
+            raise LLMAPIError(
+                f"LLM request returned {response.status_code}: {message}"
+            )
+
+        try:
+            return response.json()
+        except ValueError as exc:
+            raise LLMAPIError("LLM response is not valid JSON") from exc
+
+    def chat_completions_text(
+        self,
+        messages: list[dict[str, Any]],
+        *,
+        model: str | None = None,
+        temperature: float | None = None,
+        max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
+    ) -> str:
+        """
+        Convenience helper to return first text content from choices.
+        """
+        data = self.chat_completions(
+            messages,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            extra_body=extra_body,
+        )
+        answer, _debug = self.extract_answer_and_debug(data)
+        return answer

--- a/triton_viz/visualizer/llm_utils.py
+++ b/triton_viz/visualizer/llm_utils.py
@@ -48,7 +48,9 @@ def clear_llm_setup() -> None:
         _llm_setup_patch = {}
 
 
-def setup_llm(*, config_path: Any = _MISSING, clear: bool = False, **kwargs: Any) -> None:
+def setup_llm(
+    *, config_path: Any = _MISSING, clear: bool = False, **kwargs: Any
+) -> None:
     """
     Configure the visualizer LLM client (in-process). Call **before** ``launch()``, or use
     ``POST /api/llm/config`` for the same fields (HTTP API does **not** accept ``config_path``
@@ -210,7 +212,9 @@ def _build_llm_merged_dict() -> dict[str, Any]:
         "max_tokens": 2048,
         "extra_headers": {},
         "debug_log_enabled": False,
-        "debug_log_path": os.path.join(os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME),
+        "debug_log_path": os.path.join(
+            os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME
+        ),
     }
     for layer in (local_cfg, file_cfg, env_layer, patch):
         _apply_llm_config_layer(merged, layer)
@@ -303,7 +307,9 @@ class OpenAICompatibleConfig:
     max_tokens: int = 2048
     extra_headers: dict[str, str] = field(default_factory=dict)
     debug_log_enabled: bool = False
-    debug_log_path: str = os.path.join(os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME)
+    debug_log_path: str = os.path.join(
+        os.path.dirname(__file__), DEFAULT_DEBUG_LOG_NAME
+    )
 
     @classmethod
     def from_env(cls) -> "OpenAICompatibleConfig":
@@ -508,9 +514,7 @@ class OpenAICompatibleClient:
 
         if not response.ok:
             message = response.text
-            raise LLMAPIError(
-                f"LLM request returned {response.status_code}: {message}"
-            )
+            raise LLMAPIError(f"LLM request returned {response.status_code}: {message}")
 
         try:
             return response.json()

--- a/triton_viz/visualizer/prompts/system_default.md
+++ b/triton_viz/visualizer/prompts/system_default.md
@@ -1,0 +1,16 @@
+You are a kernel-debug assistant.
+Your primary job is to help users debug their Triton kernels with concrete, code-focused guidance.
+
+Goals:
+- Explain what each operation does and how data flows across ops.
+- Use provided op metadata, tracebacks, and source snippets.
+- Call out suspicious memory access, shape mismatch, and unexpected value patterns.
+- Focus on likely user-kernel code bugs first (indexing, masks, strides, bounds, reductions, dtype, and numerical stability).
+
+Rules:
+- Be concise and actionable.
+- Default to code-level hypotheses and concrete next checks, even if trace is imperfect.
+- Mention missing context only when it directly blocks a specific conclusion; keep it brief.
+- Prefer concrete references to op uuid, op type, and grid index.
+- Prefer pointing to relevant source lines/snippets over generic trace-quality comments.
+- Treat trace gaps as secondary context issues, not the main conclusion, unless they fully block debugging.

--- a/triton_viz/visualizer_cli.py
+++ b/triton_viz/visualizer_cli.py
@@ -1,5 +1,6 @@
 import argparse
 from pathlib import Path
+from typing import Any
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -20,6 +21,16 @@ def build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Return immediately instead of blocking on the visualizer server.",
     )
+    parser.add_argument(
+        "--llm-api-key",
+        default=None,
+        help="Optional API key for the visualizer LLM assistant (calls setup_llm).",
+    )
+    parser.add_argument(
+        "--llm-base-url",
+        default=None,
+        help="Optional OpenAI-compatible API base URL override.",
+    )
     return parser
 
 
@@ -29,6 +40,13 @@ def main(argv: list[str] | None = None):
     import triton_viz
 
     triton_viz.load(args.trace_file)
+    llm_kw: dict[str, Any] = {}
+    if args.llm_api_key is not None:
+        llm_kw["api_key"] = args.llm_api_key
+    if args.llm_base_url is not None:
+        llm_kw["base_url"] = args.llm_base_url
+    if llm_kw:
+        triton_viz.setup_llm(**llm_kw)
     return triton_viz.launch(
         share=args.share,
         port=args.port,


### PR DESCRIPTION
Summary
Adds an optional AI kernel debug assistant to the visualizer: users can run an initial trace-aware analysis, then ask follow-up questions grounded in recorded ops, source snippets, and a compact compute trace. Configuration follows the rest of the stack (local JSON, env, and programmatic setup) without putting secrets in the UI.

What’s included
Backend (Flask)

GET/POST /api/llm/config — inspect / merge effective settings (no API key echoed).
POST /api/llm/analyze — first-pass bug-oriented summary over trace + code context.
POST /api/llm/chat — follow-up Q&A after analysis is ready.
Supporting endpoints: records snapshot, single record, prompt template preview.
Client & config

OpenAI-compatible Chat Completions client (llm_utils.py).
Layered config: defaults → llm_config.local.json → optional setup_llm(config_path=...) → env (TRITON_VIZ_LLM_*, OPENAI_API_KEY) → setup_llm(**kwargs) / POST /api/llm/config.
Package exports: setup_llm, setup_llm_from_file, clear_llm_setup, LLM_SETUP_KEYS.
CLI: optional --llm-api-key / --llm-base-url before launch.
Frontend

Floating AI Assistant panel in index.html: Start analysis, chat input, English copy only for LLM UI strings.
Prompts

visualizer/prompts/system_default.md — English system instructions focused on concrete kernel debugging.
Examples

examples/LLMtest/ — small intentionally buggy kernels + README for smoke-testing the assistant.
Repo hygiene

.gitignore entries for local LLM config and optional debug log (e.g. llm_config.local.json, llm_chat_debug.jsonl).
How to try it
Configure API access (e.g. llm_config.local.json from llm_config.example.json, or triton_viz.setup_llm(...) before launch(), or env vars).
Run a traced script and triton_viz.launch(...).
Open AI Assistant → Start analysis → then ask questions.
See examples/LLMtest/README.md for minimal runnable examples.

Notes for reviewers
No secrets in git: example config only; real keys stay local / env / runtime setup.
POST /api/llm/config does not accept config_path (file path is Python-only via setup_llm).
LLM UI and prompt templates are English-only by design.
