### PR TITLE
Nki beta 2 pt3

### DIFF
--- a/frontend/components/op_workspace.ts
+++ b/frontend/components/op_workspace.ts
@@ -305,7 +305,7 @@ export class OpWorkspace {
         if (preserveCodePanel) {
             try { window.__tritonVizPreserveCodePanel = true; } catch (error) {}
         }
-        const isTensorOp = op.type === 'Dot' || op.type === 'Load' || op.type === 'Store';
+        const isTensorOp = op.type === 'Dot' || op.type === 'Load' || op.type === 'Store' || op.type === 'Transfer';
         const reuseTensorView = canReuseViz && isTensorOp && this.lastOpType === op.type;
         try {
             if (!reuseTensorView && this.visualizationCleanupFunction) {

--- a/frontend/components/tensor_view.ts
+++ b/frontend/components/tensor_view.ts
@@ -1736,7 +1736,7 @@ export function createTensorVisualization(
     const configs: TensorConfig[] = tensorConfigs.length > 0 ? tensorConfigs : [
         { name: 'Global', shape: op.global_shape || [], color: colors.GLOBAL || '#333', position: [0, 0, 0], endpoint: 'getLoadTensor' },
     ];
-    const supportsAllPrograms = type === 'Load' || type === 'Store';
+    const supportsAllPrograms = type === 'Load' || type === 'Store' || type === 'Transfer';
     const configByNameMap = new Map<string, TensorConfig>(configs.map((cfg) => [cfg.name, cfg as TensorConfig]));
     const downloadOptions = configs.map((cfg) => buildDownloadOption(type, cfg));
 

--- a/frontend/ops/defaults.ts
+++ b/frontend/ops/defaults.ts
@@ -2,7 +2,9 @@ import { registerVisualizer } from './registry.js';
 import { createMatMulVisualization } from './matmul.js';
 import { createLoadVisualization } from './load.js';
 import { createStoreVisualization } from './store.js';
+import { createTransferVisualization } from './transfer.js';
 
 registerVisualizer('Dot', createMatMulVisualization);
 registerVisualizer('Load', createLoadVisualization);
 registerVisualizer('Store', createStoreVisualization);
+registerVisualizer('Transfer', createTransferVisualization);

--- a/frontend/ops/transfer.ts
+++ b/frontend/ops/transfer.ts
@@ -1,0 +1,18 @@
+import { createTensorVisualization } from '../components/tensor_view.js';
+import * as THREE from 'https://esm.sh/three@0.155.0';
+import type { OpRecord } from '../types/types.js';
+import type { ViewState } from '../components/tensor_view.js';
+
+export function createTransferVisualization(containerElement: HTMLElement, op: OpRecord, viewState: ViewState | null = null): (() => void) | void {
+    const isStoreLike = (op.mem_dst || '').toUpperCase() === 'HBM';
+    return createTensorVisualization(containerElement, op, {
+        type: 'Transfer',
+        colors: {
+            GLOBAL: new THREE.Color(0.2, 0.2, 0.2),
+            HIGHLIGHT: isStoreLike
+                ? new THREE.Color(1.0, 0.55, 0.0)
+                : new THREE.Color(0.0, 0.7, 1.0)
+        },
+        viewState
+    });
+}

--- a/frontend/utils/colormap.ts
+++ b/frontend/utils/colormap.ts
@@ -1,6 +1,7 @@
 export const HUES: Record<string, number> = {
     Load: 200,
     Store: 45,
+    Transfer: 200,
     A: 200,
     B: 45,
     C: 140,

--- a/tests/frontend/nki.test.mjs
+++ b/tests/frontend/nki.test.mjs
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createFlowDiagram } from '../../triton_viz/static/ops/nki.js';
+import { getHue } from '../../triton_viz/static/utils/colormap.js';
+
+function createCanvasContext(logs) {
+    return {
+        fillStyle: '',
+        strokeStyle: '',
+        lineWidth: 1,
+        font: '',
+        beginPath() {},
+        moveTo() {},
+        lineTo() {},
+        stroke() {},
+        fill() {},
+        closePath() {},
+        clearRect() {},
+        strokeRect() {},
+        fillText(text) {
+            logs.push(String(text));
+        },
+    };
+}
+
+function createElement(tag, ctx) {
+    return {
+        tagName: tag.toUpperCase(),
+        style: {},
+        children: [],
+        innerHTML: '',
+        textContent: '',
+        clientWidth: 0,
+        width: 0,
+        height: 0,
+        appendChild(child) {
+            this.children.push(child);
+            return child;
+        },
+        addEventListener() {},
+        removeEventListener() {},
+        getContext(kind) {
+            return tag === 'canvas' && kind === '2d' ? ctx : null;
+        },
+    };
+}
+
+function installDom() {
+    const labels = [];
+    const ctx = createCanvasContext(labels);
+    const body = createElement('body', ctx);
+    const document = {
+        body,
+        createElement(tag) {
+            return createElement(tag, ctx);
+        },
+    };
+    const window = {
+        location: { href: 'http://localhost/visualizer/' },
+        addEventListener() {},
+        removeEventListener() {},
+    };
+    const previous = { document: globalThis.document, window: globalThis.window };
+    globalThis.document = document;
+    globalThis.window = window;
+    return {
+        labels,
+        restore() {
+            globalThis.document = previous.document;
+            globalThis.window = previous.window;
+        },
+    };
+}
+
+test('transfer hue matches load hue', () => {
+    assert.equal(getHue('Transfer'), 200);
+});

--- a/tests/frontend/transfer_build.test.mjs
+++ b/tests/frontend/transfer_build.test.mjs
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+function read(path) {
+    return readFileSync(new URL(`../../${path}`, import.meta.url), 'utf8');
+}
+
+test('built frontend includes transfer support hooks', () => {
+    const defaults = read('triton_viz/static/ops/defaults.js');
+    const transfer = read('triton_viz/static/ops/transfer.js');
+    const workspace = read('triton_viz/static/components/op_workspace.js');
+    const tensorView = read('triton_viz/static/components/tensor_view.js');
+
+    assert.match(defaults, /registerVisualizer\('Transfer', createTransferVisualization\)/);
+    assert.match(transfer, /type:\s*'Transfer'/);
+    assert.match(transfer, /isStoreLike/);
+    assert.match(workspace, /op\.type === 'Transfer'/);
+    assert.match(tensorView, /type === 'Transfer'/);
+});

--- a/tests/nki/test_nki_beta2.py
+++ b/tests/nki/test_nki_beta2.py
@@ -8,7 +8,7 @@ import triton_viz
 try:
     from triton_viz.core.patch import _LangPatchScope
     from triton_viz.clients import Tracer
-    from triton_viz.core.data import Dot
+    from triton_viz.core.data import Dot, Transfer
     from triton_viz.core.trace import launches
     import nki.isa as nisa
     import nki.language as nl
@@ -268,6 +268,74 @@ def test_trace_records_beta2_nc_matmul():
     ]
     assert grid_records[0].idx == (0, 0, 0)
     assert any(isinstance(record, Dot) for record in launches[-1].records)
+
+
+def test_trace_records_beta2_transfers():
+    """beta2 tracing should record dma_copy/tensor_copy as Transfer ops."""
+    triton_viz.clear()
+
+    # check tracer records Transfer ops
+    def kernel(src, out):
+        src_tile = nl.ndarray((128, 128), dtype=src.dtype, buffer=nl.sbuf)
+        psum_tile = nl.ndarray((128, 128), dtype=nl.float32, buffer=nl.psum)
+        out_tile = nl.ndarray((128, 128), dtype=out.dtype, buffer=nl.sbuf)
+        nisa.dma_copy(src_tile, src)
+        nisa.tensor_copy(psum_tile, src_tile)
+        nisa.tensor_copy(out_tile, psum_tile)
+        nisa.dma_copy(out, out_tile)
+
+    traced = triton_viz.trace(client=Tracer(), backend="nki_beta2")(kernel)
+    src = np.arange(128 * 128, dtype=np.float32).reshape(128, 128)
+    out = np.empty((128, 128), dtype=np.float32)
+    traced[(1,)](src, out)
+
+    transfers = [
+        record for record in launches[-1].records if isinstance(record, Transfer)
+    ]
+    assert [(record.mem_src, record.mem_dst) for record in transfers] == [
+        ("hbm", "sbuf"),
+        ("sbuf", "psum"),
+        ("psum", "sbuf"),
+        ("sbuf", "hbm"),
+    ]
+
+    # check the visualizer interface can handle tracer-produced Transfer records
+    from triton_viz.visualizer.draw import get_visualization_data
+
+    viz_data = get_visualization_data()
+    ops = viz_data["visualization_data"]["(0, 0, 0)"]
+    transfer_ops = [op for op in ops if op["type"] == "Transfer"]
+    assert transfer_ops
+    assert all(tuple(op["global_shape"]) == (128, 128) for op in transfer_ops)
+
+
+def test_trace_records_beta2_transfer_bytes_for_mixed_dtypes():
+    """beta2 tracing should size transfer bytes from the destination dtype."""
+    triton_viz.clear()
+
+    def kernel(src, out):
+        src_tile = nl.ndarray((128, 128), dtype=src.dtype, buffer=nl.sbuf)
+        psum_tile = nl.ndarray((128, 128), dtype=nl.float32, buffer=nl.psum)
+        out_tile = nl.ndarray((128, 128), dtype=out.dtype, buffer=nl.sbuf)
+        nisa.dma_copy(src_tile, src)
+        nisa.tensor_copy(psum_tile, src_tile)
+        nisa.tensor_copy(out_tile, psum_tile)
+        nisa.dma_copy(out, out_tile)
+
+    traced = triton_viz.trace(client=Tracer(), backend="nki_beta2")(kernel)
+    src = np.arange(128 * 128, dtype=np.float32).reshape(128, 128)
+    out = np.empty((128, 128), dtype=np.float16)
+    traced[(1,)](src, out)
+
+    transfers = [
+        record for record in launches[-1].records if isinstance(record, Transfer)
+    ]
+    assert [record.bytes for record in transfers] == [
+        src.nbytes,
+        src.nbytes,
+        out.nbytes,
+        out.nbytes,
+    ]
 
 
 def test_trace_no_grid_needed():
@@ -1896,7 +1964,7 @@ def test_ndarray_public_surface_and_value_backed_paths(patched_scope):
     assert tensor.shape == (2, 2)
     assert tensor.address == tensor.data.ctypes.data
     assert tensor.data_ptr() == tensor.address
-    assert tensor.stride() == tensor.data.strides
+    assert tensor.stride() == (2, 1)
     assert tensor.element_size() == tensor.data.dtype.itemsize
     assert tensor.cpu() is tensor
     assert tensor.detach() is tensor

--- a/tests/unit/test_client_manager.py
+++ b/tests/unit/test_client_manager.py
@@ -1,0 +1,58 @@
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client, ClientManager
+
+
+class _DummyClient(Client):
+    """Dummy client whose `self.tensors` comes from user input."""
+
+    NAME = "dummy"
+
+    def __init__(self, tensors=None, records=None):
+        super().__init__()
+        self.tensors = [] if tensors is None else list(tensors)
+        self._records = [] if records is None else list(records)
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        return None
+
+    def grid_callback(self, grid):
+        return None
+
+    def grid_idx_callback(self, grid_idx):
+        return None
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return list(self._records)
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return False
+
+    def post_warmup_callback(self, jit_fn, ret):
+        return None
+
+
+def test_client_manager_finalize_collects_client_tensors():
+    """Test that the client manager collects any internal tensors that a client stores tensors.
+    Important for the tracer + visualizer as the tracer stores tensors allocated in kernel scope,
+    which the visualizer then displays.
+    """
+    tensor = object()
+    record = object()
+    manager = ClientManager([_DummyClient(tensors=[tensor], records=[record])])
+
+    manager.finalize()
+
+    assert tensor in manager.launch.tensors
+    assert manager.launch.records == [record]

--- a/tests/unit/test_draw.py
+++ b/tests/unit/test_draw.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pytest
+
+from triton_viz.core.data import Tensor, Transfer
+from triton_viz.visualizer.draw import prepare_visualization_data
+
+
+def _tensor(ptr, data):
+    return Tensor(
+        ptr=ptr,
+        dtype=str(data.dtype),
+        stride=tuple(data.strides),
+        shape=tuple(data.shape),
+        element_size=data.dtype.itemsize,
+        data=data,
+    )
+
+
+@pytest.mark.parametrize(
+    "mem_src,mem_dst,expected_kind,expected_ptr,expected_offsets",
+    [
+        ("HBM", "SBUF", "load", 101, np.array([[0, 4], [8, 12]])),
+        ("PSUM", "SBUF", "transfer", 101, np.array([[0, 4], [8, 12]])),
+        ("SBUF", "HBM", "store", 202, np.array([[4, 8], [12, 16]])),
+    ],
+)
+def test_prepare_visualization_data_records_transfer_focus(
+    mem_src, mem_dst, expected_kind, expected_ptr, expected_offsets
+):
+    """Test that Transfer ops resolve focus tensors and overall maps correctly."""
+    src_data = np.arange(6, dtype=np.float32).reshape(2, 3)
+    dst_data = np.arange(6, dtype=np.float32).reshape(2, 3) + 10
+    record = Transfer(
+        src_ptr=101,
+        dst_ptr=202,
+        src_offsets=np.array([[0, 4], [8, 12]], dtype=np.int64),
+        dst_offsets=np.array([[4, 8], [12, 16]], dtype=np.int64),
+        mem_src=mem_src,
+        mem_dst=mem_dst,
+        bytes=16,
+        time_idx=3,
+    )
+    tensor_table = {
+        101: (_tensor(101, src_data), 0),
+        202: (_tensor(202, dst_data), 1),
+    }
+
+    viz_data, raw_tensor_data, _, _, _, transfer_overall = prepare_visualization_data(
+        [record], tensor_table
+    )
+
+    op = viz_data[0]
+    record_uuid = op["uuid"]
+    ptr_key = f"TRANSFER:{expected_ptr}"
+    coords = transfer_overall[ptr_key]["tiles"][0]["global_coords"]
+    linear = np.asarray(expected_offsets, dtype=np.int64).reshape(-1)
+    linear_indices = linear // src_data.dtype.itemsize
+    expected_coords = np.column_stack(np.unravel_index(linear_indices, (2, 3)))
+    expected_coords = [
+        tuple(float(value) for value in coord) for coord in expected_coords
+    ]
+
+    assert op["type"] == "Transfer"
+    assert op["transfer_kind"] == expected_kind
+    assert op["overall_key"] == ptr_key
+    assert raw_tensor_data[record_uuid]["offsets"] == expected_offsets.tolist()
+    assert raw_tensor_data[record_uuid]["transfer_kind"] == expected_kind
+    assert raw_tensor_data["__sbuf_events__"] == []
+    assert coords == expected_coords

--- a/tests/unit/test_highlight_descriptor.py
+++ b/tests/unit/test_highlight_descriptor.py
@@ -14,14 +14,18 @@ def _isolate_viz_interface_state():
     """Save and restore viz_interface global state around a test."""
     saved = (
         viz_interface.global_data,
+        viz_interface.raw_tensor_data,
         viz_interface.load_overall_maps,
         viz_interface.store_overall_maps,
+        viz_interface.transfer_overall_maps,
     )
     yield
     (
         viz_interface.global_data,
+        viz_interface.raw_tensor_data,
         viz_interface.load_overall_maps,
         viz_interface.store_overall_maps,
+        viz_interface.transfer_overall_maps,
     ) = saved
 
 
@@ -154,9 +158,98 @@ def test_collect_load_store_program_subsets_supports_nd_coords(
         }
     }
     viz_interface.store_overall_maps = {}
+    viz_interface.transfer_overall_maps = {}
 
     payload = _collect_load_store_program_subsets("Load", "LOAD:ptr", 0, 0)
     coord_to_count = {tuple(entry[:-1]): int(entry[-1]) for entry in payload["counts"]}
     assert coord_to_count[(0, 1, 0, 1, 0)] == 1
     assert coord_to_count[(1, 1, 0, 1, 0)] == 2
     assert payload["subset_count"] == 2
+
+
+def test_collect_transfer_program_subsets(
+    _isolate_viz_interface_state,
+):
+    """Aggregates Transfer subsets through the same endpoint path."""
+    viz_interface.global_data = {
+        "ops": {
+            "visualization_data": {
+                "(0,0,0)": [
+                    {
+                        "type": "Transfer",
+                        "overall_key": "TRANSFER:ptr",
+                        "time_idx": 0,
+                        "op_index": 0,
+                        "uuid": "u0",
+                    }
+                ],
+                "(1,0,0)": [
+                    {
+                        "type": "Transfer",
+                        "overall_key": "TRANSFER:ptr",
+                        "time_idx": 0,
+                        "op_index": 0,
+                        "uuid": "u1",
+                    }
+                ],
+            }
+        }
+    }
+    viz_interface.load_overall_maps = {}
+    viz_interface.store_overall_maps = {}
+    viz_interface.transfer_overall_maps = {
+        "TRANSFER:ptr": {
+            "shape": [4, 4],
+            "tiles": [
+                {"uuid": "u0", "global_coords": [[0, 0], [0, 1]]},
+                {"uuid": "u1", "global_coords": [[0, 1], [1, 1]]},
+            ],
+        }
+    }
+
+    payload = _collect_load_store_program_subsets("Transfer", "TRANSFER:ptr", 0, 0)
+    coord_to_count = {tuple(entry[:-1]): int(entry[-1]) for entry in payload["counts"]}
+    assert coord_to_count[(0, 0)] == 1
+    assert coord_to_count[(0, 1)] == 2
+    assert coord_to_count[(1, 1)] == 1
+
+
+def test_get_load_store_all_programs_accepts_transfer(
+    _isolate_viz_interface_state,
+):
+    viz_interface.global_data = {
+        "ops": {
+            "visualization_data": {
+                "(0,0,0)": [
+                    {
+                        "type": "Transfer",
+                        "overall_key": "TRANSFER:ptr",
+                        "time_idx": 0,
+                        "op_index": 0,
+                        "uuid": "u0",
+                    }
+                ]
+            }
+        }
+    }
+    viz_interface.raw_tensor_data = {}
+    viz_interface.load_overall_maps = {}
+    viz_interface.store_overall_maps = {}
+    viz_interface.transfer_overall_maps = {
+        "TRANSFER:ptr": {
+            "shape": [2, 2],
+            "tiles": [{"uuid": "u0", "global_coords": [[0, 0], [1, 1]]}],
+        }
+    }
+
+    with viz_interface.app.test_client() as client:
+        response = client.post(
+            "/api/getLoadStoreAllPrograms",
+            json={"type": "Transfer", "overall_key": "TRANSFER:ptr", "time_idx": 0},
+        )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    coord_to_count = {tuple(entry[:-1]): int(entry[-1]) for entry in payload["counts"]}
+    assert coord_to_count[(0, 0)] == 1
+    assert coord_to_count[(1, 1)] == 1

--- a/tests/unit/test_tracer.py
+++ b/tests/unit/test_tracer.py
@@ -1,6 +1,10 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import numpy as np
+
 from triton_viz.clients.tracer.tracer import Tracer, _convert_grid_idx
+from triton_viz.core.data import Transfer
 
 
 # ======== _convert_grid_idx Tests ===========
@@ -120,3 +124,37 @@ def test_tracer_get_tensor():
     assert tracer._get_tensor(2000) == mock_tensor2
     assert tracer._get_tensor(2500) == mock_tensor2
     assert tracer._get_tensor(3500) == mock_tensor3
+
+
+def test_tracer_transfer_records_element_strides_as_bytes():
+    """Test that transfer tracing converts element strides into byte offsets."""
+    tracer = Tracer()
+    callback = tracer.register_op_callback(Transfer).before_callback
+    src_data = np.zeros((2, 3), dtype=np.float32)
+    dst_data = np.zeros((2, 3), dtype=np.float16)
+    src = SimpleNamespace(
+        shape=src_data.shape,
+        data=src_data,
+        buffer="hbm",
+        _parent=None,
+        data_ptr=lambda: 1000,
+        stride=lambda: (3, 1),
+        element_size=lambda: 4,
+    )
+    dst = SimpleNamespace(
+        shape=dst_data.shape,
+        data=dst_data,
+        buffer="sbuf",
+        _parent=None,
+        data_ptr=lambda: 2000,
+        stride=lambda: (3, 1),
+        element_size=lambda: 2,
+    )
+
+    callback(src, dst, src.buffer, dst.buffer)
+
+    record = tracer.records[-1]
+    linear = np.arange(6, dtype=np.int64).reshape(2, 3)
+    assert np.array_equal(record.src_offsets, linear * 4)
+    assert np.array_equal(record.dst_offsets, linear * 2)
+    assert record.bytes == dst_data.nbytes

--- a/triton_viz/clients/tracer/tracer.py
+++ b/triton_viz/clients/tracer/tracer.py
@@ -6,6 +6,7 @@ from ...core.data import (
     Op,
     Load,
     Store,
+    Transfer,
     ReduceSum,
     Dot,
     Grid,
@@ -92,10 +93,7 @@ class Tracer(Client):
             """Convert any NDArrays in keys to numpy arrays."""
             if isinstance(keys, (tuple, list)):
                 return tuple(_convert_keys_to_numpy(k) for k in keys)
-            elif hasattr(keys, "data"):
-                return keys.data
-            else:
-                return keys
+            return keys.data if hasattr(keys, "data") else keys
 
         @self.lock_fn
         def pre_load_callback(ptr, mask, keys):
@@ -136,6 +134,50 @@ class Tracer(Client):
                 tensor = ptr
 
             rec = Store(tensor.data_ptr(), offsets, mask_data)
+            rec.call_path = extract_user_frames(num_frames=1)
+            self.records.append(rec)
+
+        @self.lock_fn
+        def pre_transfer_callback(src, dst, mem_src, mem_dst):
+            # TODO: currently only works with NKI Beta 2. Make DSL-agnostic by
+            # making tensor interface so we can safely call data_ptr/data/...
+            if not self.sample:
+                return
+
+            def _get_offsets(ptr):
+                strides = tuple(
+                    int(stride) * int(ptr.element_size()) for stride in ptr.stride()
+                )
+                offsets = np.int64(0)
+                for dim_size, stride in zip(ptr.shape, strides):
+                    offsets = np.expand_dims(offsets, -1) + (
+                        np.arange(dim_size, dtype=np.int64) * stride
+                    )
+                return offsets
+
+            def _base_tensor(ptr):
+                base = ptr
+                while getattr(base, "_parent", None) is not None:
+                    base = base._parent
+                return (
+                    base
+                    if hasattr(base, "data_ptr")
+                    else self._get_tensor(ptr.data_ptr())
+                )
+
+            src_tensor = _base_tensor(src)
+            dst_tensor = _base_tensor(dst)
+            src_offsets = _get_offsets(src) + (src.data_ptr() - src_tensor.data_ptr())
+            dst_offsets = _get_offsets(dst) + (dst.data_ptr() - dst_tensor.data_ptr())
+            rec = Transfer(
+                src_ptr=src_tensor.data_ptr(),
+                dst_ptr=dst_tensor.data_ptr(),
+                src_offsets=src_offsets,
+                dst_offsets=dst_offsets,
+                mem_src=mem_src,
+                mem_dst=mem_dst,
+                bytes=np.prod(dst.shape) * dst.element_size(),
+            )
             rec.call_path = extract_user_frames(num_frames=1)
             self.records.append(rec)
 
@@ -186,20 +228,17 @@ class Tracer(Client):
             rec.call_path = extract_user_frames(num_frames=1)
             self.records.append(rec)
 
-        if op_type is Allocate:
-            return OpCallbacks(after_callback=post_allocate_callback)
-        elif op_type is Load:
-            return OpCallbacks(before_callback=pre_load_callback)
-        elif op_type is Store:
-            return OpCallbacks(before_callback=pre_store_callback)
-        elif op_type is ReduceSum:
-            return OpCallbacks(after_callback=post_reduce_sum_callback)
-        elif op_type is Dot:
-            return OpCallbacks(after_callback=post_dot_callback)
+        callbacks = {
+            Allocate: OpCallbacks(after_callback=post_allocate_callback),
+            Load: OpCallbacks(before_callback=pre_load_callback),
+            Store: OpCallbacks(before_callback=pre_store_callback),
+            Transfer: OpCallbacks(before_callback=pre_transfer_callback),
+            ReduceSum: OpCallbacks(after_callback=post_reduce_sum_callback),
+            Dot: OpCallbacks(after_callback=post_dot_callback),
+        }
         # Flip is wrapped at tl.flip; we don't have an interpreter op to hook here.
         # The wrapper in patch_lang will append Flip records directly to tracer.
-
-        return OpCallbacks()
+        return callbacks.get(op_type, OpCallbacks())
 
     def register_for_loop_callback(self):
         return ForLoopCallbacks()

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -196,22 +196,20 @@ class ClientManager:
 
     def pre_run_callback(self, fn: Callable) -> bool:
         with self._lock_context():
-            rets = []
-            for client in self.clients.values():
-                rets.append(client.pre_run_callback(fn))
+            rets = [client.pre_run_callback(fn) for client in self.clients.values()]
             return all(rets) if rets else True
 
     def post_run_callback(self, fn: Callable) -> bool:
         with self._lock_context():
-            rets = []
-            for client in self.clients.values():
-                rets.append(client.post_run_callback(fn))
+            rets = [client.post_run_callback(fn) for client in self.clients.values()]
             return any(rets)
 
     def finalize(self) -> None:
         with self._lock_context():
             self.launch.records = []
             for client in self.clients.values():
+                # client may introduce tensors not declared in kernel args (e.g. tracer recording a tensor allocation)
+                self.launch.tensors.update(getattr(client, "tensors", []) or [])
                 self.launch.records += client.finalize()
 
     def arg_callback(self, name, arg, arg_cvt):

--- a/triton_viz/core/data.py
+++ b/triton_viz/core/data.py
@@ -66,6 +66,19 @@ class Load(Op):
 
 
 @dataclass
+class Transfer(Op):
+    name: ClassVar[str] = "transfer"
+    src_ptr: int
+    dst_ptr: int
+    src_offsets: npt.NDArray[np.int_]
+    dst_offsets: npt.NDArray[np.int_]
+    mem_src: str
+    mem_dst: str
+    bytes: int = 0
+    time_idx: int = 0
+
+
+@dataclass
 class UnaryOp(Op):
     name: ClassVar[str] = "unary_op"
 

--- a/triton_viz/core/nki_beta2.py
+++ b/triton_viz/core/nki_beta2.py
@@ -232,8 +232,9 @@ class NDArray:
         return self.address
 
     def stride(self) -> tuple[int, ...]:
-        """Return byte strides."""
-        return self.data.strides
+        """Return element strides."""
+        itemsize = self.element_size()
+        return tuple(int(stride // itemsize) for stride in self.data.strides)
 
     def element_size(self) -> int:
         """Return item size in bytes."""
@@ -1227,7 +1228,7 @@ class NKIBeta2InterpretedFunction:
         kernel_args = tuple(
             arg
             if isinstance(arg, (NDArray, bool, int, float, str)) or arg is None
-            else NDArray(value=arg)
+            else NDArray(value=arg, buffer="hbm")
             for arg in args
         )
         bound = inspect.signature(self.fn).bind(*kernel_args, **kwargs)

--- a/triton_viz/frontends/nki_beta2.py
+++ b/triton_viz/frontends/nki_beta2.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from triton_viz.core.data import Allocate, Dot, Op, ProgramId
+from triton_viz.core.data import Allocate, Dot, Op, ProgramId, Transfer
 from triton_viz.frontends.base import AdapterResult, Frontend, OPERATION_REGISTRY
 
 HAS_NKI_BETA2 = False
@@ -39,6 +39,12 @@ def _nki_beta2_dot_adapter(
     return AdapterResult(x, moving)
 
 
+def _nki_beta2_transfer_adapter(
+    dst: Any, src: Any, *_args: Any, **_kwargs: Any
+) -> AdapterResult:
+    return AdapterResult(src, dst, src.buffer, dst.buffer)
+
+
 NKI_BETA2_ADAPTERS: dict[type[Op], Callable[..., AdapterResult]] = {}
 NKI_BETA2_NAMESPACES: dict[Any, dict[str, type[Op]]] = {}
 if HAS_NKI_BETA2:
@@ -49,6 +55,8 @@ if HAS_NKI_BETA2:
             "program_id": ProgramId,
             "ndarray": Allocate,
             "nc_matmul": Dot,
+            "dma_copy": Transfer,
+            "tensor_copy": Transfer,
         },
     }
 
@@ -56,6 +64,7 @@ if HAS_NKI_BETA2:
         ProgramId: program_id_adapter,
         Allocate: _nki_beta2_allocate_adapter,
         Dot: _nki_beta2_dot_adapter,
+        Transfer: _nki_beta2_transfer_adapter,
     }
 
 NKI_BETA2_FRONTEND = Frontend.from_namespaces(

--- a/triton_viz/static/components/op_workspace.js
+++ b/triton_viz/static/components/op_workspace.js
@@ -263,7 +263,7 @@ export class OpWorkspace {
             }
             catch (error) { }
         }
-        const isTensorOp = op.type === 'Dot' || op.type === 'Load' || op.type === 'Store';
+        const isTensorOp = op.type === 'Dot' || op.type === 'Load' || op.type === 'Store' || op.type === 'Transfer';
         const reuseTensorView = canReuseViz && isTensorOp && this.lastOpType === op.type;
         try {
             if (!reuseTensorView && this.visualizationCleanupFunction) {

--- a/triton_viz/static/components/tensor_view.js
+++ b/triton_viz/static/components/tensor_view.js
@@ -1414,7 +1414,7 @@ export function createTensorVisualization(containerElement, op, options = {}) {
     const configs = tensorConfigs.length > 0 ? tensorConfigs : [
         { name: 'Global', shape: op.global_shape || [], color: colors.GLOBAL || '#333', position: [0, 0, 0], endpoint: 'getLoadTensor' },
     ];
-    const supportsAllPrograms = type === 'Load' || type === 'Store';
+    const supportsAllPrograms = type === 'Load' || type === 'Store' || type === 'Transfer';
     const configByNameMap = new Map(configs.map((cfg) => [cfg.name, cfg]));
     const downloadOptions = configs.map((cfg) => buildDownloadOption(type, cfg));
     let cache = VIZ_CACHE.get(containerElement);

--- a/triton_viz/static/ops/defaults.js
+++ b/triton_viz/static/ops/defaults.js
@@ -2,6 +2,8 @@ import { registerVisualizer } from './registry.js';
 import { createMatMulVisualization } from './matmul.js';
 import { createLoadVisualization } from './load.js';
 import { createStoreVisualization } from './store.js';
+import { createTransferVisualization } from './transfer.js';
 registerVisualizer('Dot', createMatMulVisualization);
 registerVisualizer('Load', createLoadVisualization);
 registerVisualizer('Store', createStoreVisualization);
+registerVisualizer('Transfer', createTransferVisualization);

--- a/triton_viz/static/ops/transfer.js
+++ b/triton_viz/static/ops/transfer.js
@@ -1,0 +1,15 @@
+import { createTensorVisualization } from '../components/tensor_view.js';
+import * as THREE from 'https://esm.sh/three@0.155.0';
+export function createTransferVisualization(containerElement, op, viewState = null) {
+    const isStoreLike = (op.mem_dst || '').toUpperCase() === 'HBM';
+    return createTensorVisualization(containerElement, op, {
+        type: 'Transfer',
+        colors: {
+            GLOBAL: new THREE.Color(0.2, 0.2, 0.2),
+            HIGHLIGHT: isStoreLike
+                ? new THREE.Color(1.0, 0.55, 0.0)
+                : new THREE.Color(0.0, 0.7, 1.0)
+        },
+        viewState
+    });
+}

--- a/triton_viz/static/utils/colormap.js
+++ b/triton_viz/static/utils/colormap.js
@@ -1,6 +1,7 @@
 export const HUES = {
     Load: 200,
     Store: 45,
+    Transfer: 200,
     A: 200,
     B: 45,
     C: 140,

--- a/triton_viz/visualizer/draw.py
+++ b/triton_viz/visualizer/draw.py
@@ -4,6 +4,7 @@ from triton_viz.core.data import (
     Dot,
     Load,
     Store,
+    Transfer,
     Flip,
 )
 from triton_viz.clients.sanitizer.data import OutOfBoundsRecordBruteForce
@@ -84,7 +85,7 @@ def extract_load_coords(record, global_tensor: Tensor) -> list[tuple[float, ...]
         return []
 
     offsets = np.asarray(record.offsets, dtype=np.int64)
-    masks = np.asarray(record.masks, dtype=bool)
+    masks = _record_masks(record, offsets)
     if offsets.shape != masks.shape:
         offsets = np.broadcast_to(offsets, masks.shape)
 
@@ -144,8 +145,8 @@ def make_3d(shape: tuple[int, ...]):
 def build_slice_tensor(record, tensor: Tensor, global_arr: np.ndarray):
     """Reconstruct slice-tensor values by sampling the global tensor via recorded offsets."""
     try:
-        mask = np.asarray(record.masks, dtype=bool)
         offsets = np.asarray(record.offsets, dtype=np.int64)
+        mask = _record_masks(record, offsets)
         if offsets.shape != mask.shape:
             offsets = np.broadcast_to(offsets, mask.shape)
         elem_size = getattr(tensor, "element_size", None)
@@ -173,8 +174,27 @@ def build_slice_tensor(record, tensor: Tensor, global_arr: np.ndarray):
 
         return slice_flat.reshape(mask.shape), slice_min, slice_max
     except Exception:
-        shape = np.asarray(record.masks).shape
+        shape = _record_masks(record).shape
         return np.zeros(shape, dtype=float), 0.0, 0.0
+
+
+def _transfer_focus(record: Transfer) -> tuple[str, int, np.ndarray]:
+    mem_src = getattr(record, "mem_src", "").upper()
+    mem_dst = getattr(record, "mem_dst", "").upper()
+    if mem_src == "HBM":
+        return "load", int(record.src_ptr), np.asarray(record.src_offsets)
+    if mem_dst == "HBM":
+        return "store", int(record.dst_ptr), np.asarray(record.dst_offsets)
+    return "transfer", int(record.src_ptr), np.asarray(record.src_offsets)
+
+
+def _record_masks(record, offsets=None) -> np.ndarray:
+    """Return explicit masks or infer a dense one from offsets."""
+    masks = getattr(record, "masks", None)
+    if masks is not None:
+        return np.asarray(masks, dtype=bool)
+    inferred = getattr(record, "offsets", None) if offsets is None else offsets
+    return np.ones(np.asarray(inferred).shape, dtype=bool)
 
 
 def delinearized(
@@ -221,6 +241,7 @@ def prepare_visualization_data(program_records, tensor_table):
     sbuf_events = []
     load_overall = {}
     store_overall = {}
+    transfer_overall = {}
     for record in program_records:
         record_uuid = str(uuid.uuid4())[:8]
         # Use the current length of visualization_data as the default time_idx
@@ -595,8 +616,141 @@ def prepare_visualization_data(program_records, tensor_table):
                 }
             )
 
+        # TODO: codex says that this can be refactored to share most logic with Load/Store, do in another PR
+        elif isinstance(record, Transfer):
+            focus_kind, focus_ptr, offsets = _transfer_focus(record)
+            global_tensor, _ = tensor_table[focus_ptr]
+            masks = _record_masks(record, offsets)
+            view_record = type(
+                "TransferView",
+                (),
+                {"offsets": offsets, "masks": masks},
+            )()
+            global_coords = extract_load_coords(view_record, global_tensor)
+
+            ptr_key = f"TRANSFER:{focus_ptr}"
+            time_idx = int(getattr(record, "time_idx", current_time))
+
+            visualization_data.append(
+                {
+                    "type": "Transfer",
+                    "global_shape": global_tensor.shape,
+                    "slice_shape": masks.shape,
+                    "uuid": record_uuid,
+                    "op_index": current_time,
+                    "overall_key": ptr_key,
+                    "time_idx": time_idx,
+                    "mem_src": getattr(record, "mem_src", None),
+                    "mem_dst": getattr(record, "mem_dst", None),
+                    "bytes": int(getattr(record, "bytes", 0)),
+                    "transfer_kind": focus_kind,
+                }
+            )
+
+            entry = transfer_overall.setdefault(
+                ptr_key,
+                {
+                    "shape": list(global_tensor.shape),
+                    "dims": len(global_tensor.shape),
+                    "slice_shape": list(masks.shape),
+                    "tiles": [],
+                },
+            )
+            entry["tiles"].append(
+                {
+                    "uuid": record_uuid,
+                    "global_coords": global_coords,
+                    "ptr_key": ptr_key,
+                    "time_idx": time_idx,
+                }
+            )
+
+            try:
+                import numpy as _np
+
+                gt = global_tensor.data
+                if hasattr(gt, "cpu") and callable(getattr(gt, "cpu", None)):
+                    try:
+                        arr = gt.detach().cpu().numpy()
+                    except Exception:
+                        arr = _np.asarray(gt)
+                elif hasattr(gt, "data"):
+                    arr = _np.asarray(getattr(gt, "data"))
+                elif hasattr(gt, "_value"):
+                    arr = _np.asarray(getattr(gt, "_value"))
+                else:
+                    arr = _np.asarray(gt)
+            except Exception:
+                import numpy as _np
+
+                arr = _np.asarray([])
+
+            try:
+                import numpy as _np
+
+                def _unwrap(v):
+                    vv = getattr(v, "data", v)
+                    return _unwrap(vv) if hasattr(vv, "data") else vv
+
+                arr = _unwrap(arr)
+                arr = _np.asarray(arr)
+                if arr.dtype == object:
+                    flat = [_unwrap(x) for x in arr.ravel()]
+                    try:
+                        arr = _np.asarray(flat, dtype=float).reshape(arr.shape)
+                    except Exception:
+                        try:
+                            scalars = []
+                            for x in flat:
+                                xx = _np.asarray(_unwrap(x))
+                                if xx.size == 0:
+                                    scalars.append(0.0)
+                                else:
+                                    scalars.append(float(xx.astype(float).ravel()[0]))
+                            arr = _np.asarray(scalars, dtype=float).reshape(arr.shape)
+                        except Exception:
+                            arr = _np.zeros(arr.shape, dtype=float)
+            except Exception:
+                pass
+
+            t_min = float(np.min(arr)) if getattr(arr, "size", 0) else 0.0
+            t_max = float(np.max(arr)) if getattr(arr, "size", 0) else 0.0
+
+            raw_tensor_data[record_uuid] = {
+                "op_type": "Transfer",
+                "op_index": current_time,
+                "global_tensor": arr,
+                "dims": int(arr.ndim),
+                "shape": list(arr.shape),
+                "min": t_min,
+                "max": t_max,
+                "tracebacks": [
+                    {
+                        "filename": f.filename,
+                        "lineno": f.lineno,
+                        "line": f.line_of_code,
+                        "name": f.func_name,
+                    }
+                    for f in getattr(record, "call_path", [])
+                ],
+                "global_shape": list(global_tensor.shape),
+                "global_dtype": str(global_tensor.dtype),
+                "offsets": serialize_for_json(offsets),
+                "masks": serialize_for_json(masks),
+                "mem_src": getattr(record, "mem_src", None),
+                "mem_dst": getattr(record, "mem_dst", None),
+                "transfer_kind": focus_kind,
+            }
+
     raw_tensor_data["__sbuf_events__"] = sbuf_events
-    return visualization_data, raw_tensor_data, "", load_overall, store_overall
+    return (
+        visualization_data,
+        raw_tensor_data,
+        "",
+        load_overall,
+        store_overall,
+        transfer_overall,
+    )
 
 
 def get_visualization_data():
@@ -607,6 +761,7 @@ def get_visualization_data():
     kernel_src = ""
     load_overall_maps = {}
     store_overall_maps = {}
+    transfer_overall_maps = {}
 
     for grid_idx, program_records in records.items():
         (
@@ -615,19 +770,20 @@ def get_visualization_data():
             kernel_src,
             load_overall,
             store_overall,
+            transfer_overall,
         ) = prepare_visualization_data(program_records, tensor_table)
         visualization_data[str(grid_idx)] = viz_data
         raw_tensor_data.update(raw_data)
-        for key, val in load_overall.items():
-            if key in load_overall_maps:
-                load_overall_maps[key]["tiles"].extend(val.get("tiles", []))
-            else:
-                load_overall_maps[key] = val
-        for key, val in store_overall.items():
-            if key in store_overall_maps:
-                store_overall_maps[key]["tiles"].extend(val.get("tiles", []))
-            else:
-                store_overall_maps[key] = val
+        for overall_map, target in (
+            (load_overall, load_overall_maps),
+            (store_overall, store_overall_maps),
+            (transfer_overall, transfer_overall_maps),
+        ):
+            for key, val in overall_map.items():
+                if key in target:
+                    target[key]["tiles"].extend(val.get("tiles", []))
+                else:
+                    target[key] = val
 
     # Ensure failures dict has JSON-serializable keys
     safe_failures = {str(k): v for k, v in failures.items()}
@@ -639,6 +795,7 @@ def get_visualization_data():
         "kernel_src": kernel_src,
         "load_overall": load_overall_maps,
         "store_overall": store_overall_maps,
+        "transfer_overall": transfer_overall_maps,
     }
 
 

--- a/triton_viz/visualizer/interface.py
+++ b/triton_viz/visualizer/interface.py
@@ -31,6 +31,7 @@ last_launch_snapshot = None
 sbuf_events = []
 load_overall_maps = {}
 store_overall_maps = {}
+transfer_overall_maps = {}
 DEVICE_LIMITS = {
     "TRN1_NC_V2": 24 * 1024 * 1024,
     "TRN1_CHIP": 48 * 1024 * 1024,
@@ -143,6 +144,7 @@ def update_global_data(force: bool = False):
     global sbuf_events
     global load_overall_maps
     global store_overall_maps
+    global transfer_overall_maps
     global last_launch_snapshot
 
     # Collect all records from launches
@@ -177,6 +179,7 @@ def update_global_data(force: bool = False):
     sbuf_events = raw_tensor_data.pop("__sbuf_events__", [])
     load_overall_maps = viz_data.get("load_overall", {})
     store_overall_maps = viz_data.get("store_overall", {})
+    transfer_overall_maps = viz_data.get("transfer_overall", {})
 
     # Precompute C values for each Dot operation
     precomputed_c_values = {}
@@ -802,7 +805,10 @@ def get_load_tensor():
         # Calculate highlights
         if "offsets" in op_data:
             offsets = np.asarray(op_data["offsets"])
-            masks = np.asarray(op_data["masks"])
+            masks = op_data.get("masks")
+            if masks is None:
+                masks = np.ones(offsets.shape, dtype=bool)
+            masks = np.asarray(masks)
             shape = tuple(op_data["global_shape"])
             dtype = op_data["global_dtype"]
             coords = _coords_from_offsets(shape, offsets, masks, dtype)
@@ -862,7 +868,11 @@ def _collect_load_store_program_subsets(op_type, overall_key, op_index, time_idx
                 if uuid:
                     uuid_to_pid[uuid] = pid
 
-    overall_maps = load_overall_maps if op_type == "Load" else store_overall_maps
+    overall_maps = {
+        "Load": load_overall_maps,
+        "Store": store_overall_maps,
+        "Transfer": transfer_overall_maps,
+    }[op_type]
     entry = overall_maps.get(overall_key)
     if not entry or not uuid_to_pid:
         return {
@@ -929,7 +939,7 @@ def get_load_store_all_programs():
     if not op_type or not overall_key or time_idx is None:
         return jsonify({"error": "Missing type, overall_key, or time_idx"}), 400
     op_type = str(op_type).strip().capitalize()
-    if op_type not in {"Load", "Store"}:
+    if op_type not in {"Load", "Store", "Transfer"}:
         return jsonify({"error": "Unsupported type"}), 400
     try:
         time_idx = int(time_idx)


### PR DESCRIPTION
## Summary

Connects NKI Beta 2 interpreter with Triton-viz
- Created `Transfer` data op that represents general transfers from one memory buffer to another
  - `Load`/`Store` is not enough as NKI merges both into `dma_copy` (HBM <---> SBUF) and `tensor_copy` (SBUF <----> PSUM)
  - added tracer callback for `Transfer`
  - added visualizer support for Transfer ops
- adds triton-viz callback hooks for NKI Beta 2 frontend
- apparently there was a bug where kernel-allocated tensors were never sent to the visualizer (went undetected since for some reason we never tested triton-viz tracer on any NKI kernels that allocated tensors) - added fix + test for that in `tests/unit/test_client_manager.py`

**examples/nki_beta2/rmsnorm.py**
<img width="1920" height="1178" alt="image" src="https://github.com/user-attachments/assets/8308e17e-0dea-4d31-9e67-2b931f74ee04" />

<img width="1920" height="1178" alt="image" src="https://github.com/user-attachments/assets/bbfe0c56-81b5-4971-9ad3-b12426f972d8" />


## Test Plan

- CI passes
- tested on `examples/nki/tiled_attention.py` (and rmsnorm and add)

## Related Issues

<!-- Link any related issues: Fixes #123, Closes #456 -->

## Breaking Changes

<!-- Does this PR change any behavior in existing code? Describe here. -->

## Checklist

- [x] I added tests to all new functionality I added/bugs I fixed.
- [x] I verified that a human has reviewed all code in this PR.
- [x] I ran `npm run build:frontend` if the PR modified any TypeScript code.
- [x] I made sure that my code is well documented (comments explaining strange code, docstrings for functions, website modified if new functionality added).

## Line Change Summary
- core (`triton_viz/core/**`, `triton_viz/frontends/**`, `triton_viz/clients/**`): +86/-26 
- `triton_viz/visualizer/**`: +184/-17
- `tests/**`: +425/-2
- `frontend/**` and `triton_viz/static/**`: +43/-4

  Total: 738 added, 49 deleted, 787 changed


## Next Steps
- transfer tracer callback is NKI-specific because of fields that only NKI arrays have (e.g. `_parent`). Maybe make a refactor PR to introduce a shared DSL-agnostic tensor interface so these callbacks are DSL-agnostic
- `triton_viz/visualizer/draw.py` is bloated since a lot of logic is duplicated between Load/Store/Transfer. Make refactor PR to remove duplicate logic
  - didn't do in this PR since it would be harder to review
- maybe remove the NKI flow diagram? My concern is that it may be too low-level/NKI-specific to be handled in triton-viz (e.g. the tracer definitely should NOT be used for performance analysis since the compiler reorders and optimizes a lot of the computation that the interpreter is doing - the flow diagram likely makes more sense in a dedicated NKI profiler)
  - somewhat unrelated but my opinion on the tracer is that it should only store intermediate activations created by an eager execution of the kernel, as this could be useful for general kernel debugging - any deeper insights require DSL-specific knowledge, defeating the point of triton-viz abstractions (which is to handle all DSLs with a mostly unified IR)