### PR TITLE
[FEAT] race_detector PR3: concrete candidate finder + HBSolver + epoch/barrier

### DIFF
--- a/tests/end_to_end/test_race_detector_sync.py
+++ b/tests/end_to_end/test_race_detector_sync.py
@@ -1,0 +1,237 @@
+"""End-to-end race detection on real traced kernels.
+
+Each test launches a kernel through ``triton_viz.trace`` with the race
+detector enabled and inspects ``detector.finalize()``'s RaceReports.
+Covers the headline scenarios PR3 needs to defend:
+  * unsynchronized plain cross-block reads/writes -> reported
+  * producer/consumer handshake via release/acquire xchg -> suppressed
+  * failed CAS still reports races on the underlying memory
+  * atomic_xchg handoff with reads-from -> suppressed
+  * epoch barrier preserves cross-phase pairs
+  * spinning cas(1, 1) poll does NOT split phases (upstream #350)
+  * private (per-block) sync addresses are not mistaken for a shared
+    barrier (upstream #346)
+  * single-SM vs multi-SM produce the same suppression decisions
+    (upstream #352 symbolic-HB regression)
+"""
+
+from __future__ import annotations
+
+import pytest
+import torch
+import triton
+import triton.language as tl
+
+import triton_viz
+from triton_viz.clients.race_detector.data import RaceType
+from triton_viz.clients.race_detector.race_detector import SymbolicRaceDetector
+from triton_viz.core.config import config as cfg
+
+
+@pytest.fixture
+def _race_detector_on():
+    saved = cfg.enable_race_detector
+    cfg.enable_race_detector = True
+    yield
+    cfg.enable_race_detector = saved
+
+
+def _traced(kernel, detector: SymbolicRaceDetector):
+    return triton_viz.trace(client=detector)(kernel)
+
+
+@triton.jit
+def _unsynchronized_store_load(x_ptr, out_ptr):
+    pid = tl.program_id(axis=0)
+    tl.store(x_ptr, 7, mask=(pid == 0))
+    v = tl.load(x_ptr, mask=(pid == 1))
+    tl.store(out_ptr + pid, v, mask=(pid == 1))
+
+
+def test_unsynchronized_plain_store_load_reports_race(_race_detector_on):
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_unsynchronized_store_load, detector)
+    x = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+    traced[(2,)](x, out)
+    reports = detector.finalize()
+    assert any(
+        r.race_type is RaceType.RAW and r.grid_a != r.grid_b for r in reports
+    ), f"expected RAW cross-block report, got {reports}"
+
+
+@triton.jit
+def _producer_consumer_xchg(flag_ptr, sync_ptr):
+    pid = tl.program_id(axis=0)
+    tl.store(flag_ptr, 42, mask=(pid == 0))
+    tl.atomic_xchg(sync_ptr, 1, mask=(pid == 0), sem="release", scope="gpu")
+    _obtained = tl.atomic_xchg(sync_ptr, 2, mask=(pid == 1), sem="acquire", scope="gpu")
+    tl.load(flag_ptr, mask=(pid == 1))
+
+
+def test_producer_consumer_release_acquire_suppresses_race(_race_detector_on):
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_producer_consumer_xchg, detector)
+    flag = torch.zeros(1, dtype=torch.int32)
+    sync = torch.zeros(1, dtype=torch.int32)
+    traced[(2,)](flag, sync)
+    reports = detector.finalize()
+    flag_addr = flag.data_ptr()
+    flag_reports = [
+        r
+        for r in reports
+        if flag_addr <= r.witness_addr < flag_addr + flag.element_size()
+    ]
+    assert not flag_reports, (
+        f"release/acquire reads-from should suppress cross-block race "
+        f"on flag_ptr; got {flag_reports}"
+    )
+
+
+def test_atomic_xchg_handoff_suppresses_race(_race_detector_on):
+    """Same handshake shape as the producer/consumer test but phrased as
+    an explicit ``sw`` existence check: at least one report in the launch
+    must carry a ``release_acquire_reads_from`` reason when suppression
+    is observed via ``_last_candidates`` vs ``_last_reports`` difference.
+    """
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_producer_consumer_xchg, detector)
+    flag = torch.zeros(1, dtype=torch.int32)
+    sync = torch.zeros(1, dtype=torch.int32)
+    traced[(2,)](flag, sync)
+    detector.finalize()
+    assert len(detector._last_candidates) > len(
+        detector._last_reports
+    ), "HB must suppress at least one candidate when reads-from holds"
+
+
+@triton.jit
+def _failed_cas_plus_plain_store_kernel(x_ptr, sync_ptr):
+    pid = tl.program_id(axis=0)
+    # Block 0: plain write to x.
+    tl.store(x_ptr, 42, mask=(pid == 0))
+    # Both blocks CAS with a mismatched compare (99 vs real 0) so the
+    # write ARM never fires -- same-value writeback, no phase change.
+    # ``atomic_cas`` in the interpreter does not support a mask, so the
+    # CAS runs for every block; both trigger a failed-compare writeback.
+    tl.atomic_cas(sync_ptr, 99, 1, sem="release", scope="gpu")
+    # Consumer acquire-xchg; reader sees sync_ptr=0 because the CAS never
+    # wrote it -> reads-from match against the CAS's written_value (0)
+    # is not useful here. The race on x_ptr should survive.
+    tl.atomic_xchg(sync_ptr, 2, mask=(pid == 1), sem="acquire", scope="gpu")
+    tl.load(x_ptr, mask=(pid == 1))
+
+
+def test_failed_cas_mixed_access_still_reports_race(_race_detector_on):
+    """Even with release sem, a CAS whose compare fails doesn't change
+    the sync value (written_value == old). reads-from gate fails (reader
+    observes something other than ``1``), so the sw edge is absent and
+    the plain race on ``x_ptr`` must still be reported.
+    """
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_failed_cas_plus_plain_store_kernel, detector)
+    x = torch.zeros(1, dtype=torch.int32)
+    sync = torch.zeros(1, dtype=torch.int32)
+    traced[(2,)](x, sync)
+    reports = detector.finalize()
+    x_addr = x.data_ptr()
+    x_reports = [
+        r for r in reports if x_addr <= r.witness_addr < x_addr + x.element_size()
+    ]
+    assert x_reports, (
+        f"failed CAS must not suppress cross-block race on x_ptr; " f"got {reports}"
+    )
+
+
+@triton.jit
+def _private_sync_per_block(flag_ptr, sync_ptr):
+    """Each block uses its own sync slot (``sync_ptr + pid``), so no two
+    blocks ever hit the same sync address - this should NOT count as
+    a global barrier and the cross-block race on ``flag_ptr`` stays
+    visible (upstream #346)."""
+    pid = tl.program_id(axis=0)
+    tl.store(flag_ptr, 42, mask=(pid == 0))
+    tl.atomic_xchg(sync_ptr + pid, 1, mask=(pid == 0), sem="release", scope="gpu")
+    tl.atomic_xchg(sync_ptr + pid, 2, mask=(pid == 1), sem="acquire", scope="gpu")
+    tl.load(flag_ptr, mask=(pid == 1))
+
+
+def test_private_sync_address_per_block_still_reports_race(_race_detector_on):
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_private_sync_per_block, detector)
+    flag = torch.zeros(1, dtype=torch.int32)
+    sync = torch.zeros(2, dtype=torch.int32)
+    traced[(2,)](flag, sync)
+    reports = detector.finalize()
+    flag_addr = flag.data_ptr()
+    flag_reports = [
+        r
+        for r in reports
+        if flag_addr <= r.witness_addr < flag_addr + flag.element_size()
+    ]
+    assert flag_reports, (
+        f"per-block private sync addresses must not be mistaken for "
+        f"a shared barrier (#346); got {reports}"
+    )
+
+
+@triton.jit
+def _spinning_same_value_cas(barrier_ptr, flag_ptr):
+    """Every block does a ``cas(1, 1)`` on a shared barrier address -
+    same-value writeback, no phase advance (upstream #350). The epoch
+    partitioner must NOT split phases on this, so a cross-block plain
+    race on ``flag_ptr`` remains visible.
+    """
+    pid = tl.program_id(axis=0)
+    tl.atomic_cas(barrier_ptr, 1, 1, sem="acq_rel", scope="gpu")
+    tl.store(flag_ptr, pid, mask=(pid == 0))
+    tl.load(flag_ptr, mask=(pid == 1))
+
+
+def test_spinning_cas_poll_does_not_split_phase(_race_detector_on):
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = _traced(_spinning_same_value_cas, detector)
+    barrier = torch.ones(1, dtype=torch.int32)  # seed with the cmp value
+    flag = torch.zeros(1, dtype=torch.int32)
+    traced[(2,)](barrier, flag)
+    reports = detector.finalize()
+    # Epoch partitioner: same-value cas(1,1) on the barrier must not
+    # advance the phase, so the plain flag race stays in epoch 0 and
+    # gets paired.
+    flag_addr = flag.data_ptr()
+    flag_reports = [
+        r
+        for r in reports
+        if flag_addr <= r.witness_addr < flag_addr + flag.element_size()
+    ]
+    assert flag_reports, (
+        f"cas(1,1) polling should not split epochs (#350); " f"got {reports}"
+    )
+
+
+def test_num_sms_1_and_2_match_on_release_acquire(_race_detector_on):
+    """Single-SM and multi-SM launches must agree on suppression. The
+    race detector uses the concrete HB path unconditionally, so the
+    number-of-workers setting shouldn't change the verdict - upstream
+    #352 flagged single-SM symbolic-HB regressions this test guards.
+    """
+    saved_num_sms = cfg.num_sms
+    try:
+        results: dict[int, tuple[int, int]] = {}
+        for num_sms in (1, 2):
+            cfg.num_sms = num_sms
+            detector = SymbolicRaceDetector(abort_on_error=False)
+            traced = _traced(_producer_consumer_xchg, detector)
+            flag = torch.zeros(1, dtype=torch.int32)
+            sync = torch.zeros(1, dtype=torch.int32)
+            traced[(2,)](flag, sync)
+            reports = detector.finalize()
+            results[num_sms] = (
+                len(detector._last_candidates),
+                len(reports),
+            )
+        assert (
+            results[1] == results[2]
+        ), f"num_sms=1 vs num_sms=2 disagreed on suppression: {results}"
+    finally:
+        cfg.num_sms = saved_num_sms

--- a/tests/unit/test_race_detector.py
+++ b/tests/unit/test_race_detector.py
@@ -612,6 +612,47 @@ def test_concrete_events_carry_program_seq_and_launch_id(_isolate_race_detector_
     assert launch_ids == {detector._launch_id}
 
 
+def test_release_acquire_reads_from_suppresses_crossblock_plain_race(
+    _isolate_race_detector_cfg,
+):
+    """Producer-consumer handshake: block 0 writes a plain flag then
+    releases a barrier atomic; block 1 acquires on the same barrier and
+    then reads the plain flag. With reads-from (acquire reads exactly
+    what release wrote), the HBSolver orders the plain accesses via
+    ``po | sw`` so the cross-block race on the plain flag goes away."""
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    @triton.jit
+    def _producer_consumer(flag_ptr, sync_ptr):
+        pid = tl.program_id(axis=0)
+        # Producer (pid==0): plain store then release-xchg.
+        tl.store(flag_ptr, 42, mask=(pid == 0))
+        tl.atomic_xchg(sync_ptr, 1, mask=(pid == 0), sem="release", scope="gpu")
+        # Consumer (pid==1): acquire-xchg (reads what producer released),
+        # then plain load.
+        _obtained = tl.atomic_xchg(
+            sync_ptr, 2, mask=(pid == 1), sem="acquire", scope="gpu"
+        )
+        tl.load(flag_ptr, mask=(pid == 1))
+
+    traced = triton_viz.trace(client=detector)(_producer_consumer)
+    flag = torch.zeros(1, dtype=torch.int32)
+    sync = torch.zeros(1, dtype=torch.int32)
+    traced[(2,)](flag, sync)
+
+    reports = detector.finalize()
+    flag_addr = flag.data_ptr()
+    flag_reports = [
+        r
+        for r in reports
+        if flag_addr <= r.witness_addr < flag_addr + flag.element_size()
+    ]
+    assert not flag_reports, (
+        f"release/acquire+reads-from should suppress the cross-block race "
+        f"on flag_ptr; got {flag_reports}"
+    )
+
+
 def test_finalize_emits_report_for_crossblock_plain_store_load(
     _isolate_race_detector_cfg,
 ):

--- a/tests/unit/test_race_detector.py
+++ b/tests/unit/test_race_detector.py
@@ -13,7 +13,6 @@ from triton_viz.clients.race_detector.race_detector import (
 )
 from triton_viz.clients.race_detector.data import (
     AccessEventRecord,
-    PendingAtomicEvent,
     active_mask_for,
     apply_rmw,
     effects_at_addr,
@@ -22,7 +21,7 @@ from triton_viz.clients.race_detector.data import (
     resolve_tensor_from_pointer,
 )
 from triton_viz.core.config import config as cfg
-from triton_viz.core.data import AtomicCas, AtomicRMW, Load, Store
+from triton_viz.core.data import AtomicCas, Load, Store
 
 
 # ======== Config Isolation ========
@@ -436,176 +435,11 @@ def test_apply_rmw_unsupported_raises():
         apply_rmw("nope", np.array([0]), np.array([0]))
 
 
-# ======== Callback logic: hand-built PendingAtomicEvent ========
-
-
-def _prime_detector_for_callback(
-    grid_idx: tuple[int, int, int] = (0, 0, 0),
-) -> SymbolicRaceDetector:
-    """Construct a SymbolicRaceDetector with just enough state for a
-    before/after atomic callback to run. Skips the real grid_callback
-    path because these tests hand-build PendingAtomicEvent instances."""
-    detector = SymbolicRaceDetector(abort_on_error=False)
-    detector.grid_idx_callback(grid_idx)
-    return detector
-
-
-def test_atomic_cas_success_and_failure_compute_masks_correctly():
-    detector = _prime_detector_for_callback()
-    pending = PendingAtomicEvent(
-        event_id=42,
-        op_type=AtomicCas,
-        atomic_op="cas",
-        grid_idx=(0, 0, 0),
-        source_location=None,
-        tensor=None,
-        tensor_name=None,
-        lane_addrs=np.array([100, 104], dtype=np.int64),
-        active_mask=np.array([True, True]),
-        elem_size=4,
-        atomic_sem="acq_rel",
-        atomic_scope="gpu",
-        atomic_cmp=np.array([0, 99], dtype=np.int32),  # lane1 cmp won't match
-        atomic_val=np.array([7, 8], dtype=np.int32),
-    )
-    detector._pending_atomic_by_grid[(0, 0, 0)].append(pending)
-
-    # lane0 old=0 matches cmp=0 → success; lane1 old=5 != 99 → fail.
-    ret = np.array([0, 5], dtype=np.int32)
-    detector._after_atomic_cas(ret, ptr=None, cmp=None, val=None)
-
-    assert len(detector.concrete_events) == 1
-    event = detector.concrete_events[0]
-    np.testing.assert_array_equal(event.read_mask, [True, True])
-    np.testing.assert_array_equal(event.write_mask, [True, False])
-    np.testing.assert_array_equal(event.written_value, [7, 5])
-    np.testing.assert_array_equal(event.atomic_old, [0, 5])
-    assert event.atomic_op == "cas"
-
-
-def test_atomic_cas_after_pops_matching_grid_queue():
-    detector = _prime_detector_for_callback(grid_idx=(0, 0, 0))
-
-    def _mk_pending(gidx: tuple[int, int, int]) -> PendingAtomicEvent:
-        return PendingAtomicEvent(
-            event_id=gidx[0],
-            op_type=AtomicCas,
-            atomic_op="cas",
-            grid_idx=gidx,
-            source_location=None,
-            tensor=None,
-            tensor_name=None,
-            lane_addrs=np.array([100], dtype=np.int64),
-            active_mask=np.array([True]),
-            elem_size=4,
-            atomic_sem="acq_rel",
-            atomic_scope="gpu",
-            atomic_cmp=np.array([0], dtype=np.int32),
-            atomic_val=np.array([1], dtype=np.int32),
-        )
-
-    detector._pending_atomic_by_grid[(0, 0, 0)].append(_mk_pending((0, 0, 0)))
-    detector._pending_atomic_by_grid[(1, 0, 0)].append(_mk_pending((1, 0, 0)))
-
-    # detector.grid_idx is currently (0, 0, 0) from priming.
-    ret = np.array([0], dtype=np.int32)
-    detector._after_atomic_cas(ret, ptr=None, cmp=None, val=None)
-
-    # (0,0,0) popped; (1,0,0) untouched.
-    assert len(detector._pending_atomic_by_grid[(0, 0, 0)]) == 0
-    assert len(detector._pending_atomic_by_grid[(1, 0, 0)]) == 1
-
-
-def test_atomic_rmw_add_written_value_uses_old_plus_val():
-    detector = _prime_detector_for_callback()
-    pending = PendingAtomicEvent(
-        event_id=7,
-        op_type=AtomicRMW,
-        atomic_op="add",
-        grid_idx=(0, 0, 0),
-        source_location=None,
-        tensor=None,
-        tensor_name=None,
-        lane_addrs=np.array([100, 104], dtype=np.int64),
-        active_mask=np.array([True, True]),
-        elem_size=4,
-        atomic_sem="acq_rel",
-        atomic_scope="gpu",
-        atomic_cmp=None,
-        atomic_val=np.array([5, 7], dtype=np.int32),
-    )
-    detector._pending_atomic_by_grid[(0, 0, 0)].append(pending)
-
-    ret = np.array([10, 20], dtype=np.int32)
-    detector._after_atomic_rmw(ret, rmwOp=None, ptr=None, val=None)
-    event = detector.concrete_events[0]
-    np.testing.assert_array_equal(event.written_value, [15, 27])
-
-
-def test_atomic_rmw_xchg_written_value_equals_val():
-    detector = _prime_detector_for_callback()
-    pending = PendingAtomicEvent(
-        event_id=7,
-        op_type=AtomicRMW,
-        atomic_op="xchg",
-        grid_idx=(0, 0, 0),
-        source_location=None,
-        tensor=None,
-        tensor_name=None,
-        lane_addrs=np.array([100], dtype=np.int64),
-        active_mask=np.array([True]),
-        elem_size=4,
-        atomic_sem="acq_rel",
-        atomic_scope="gpu",
-        atomic_cmp=None,
-        atomic_val=np.array([99], dtype=np.int32),
-    )
-    detector._pending_atomic_by_grid[(0, 0, 0)].append(pending)
-
-    ret = np.array([7], dtype=np.int32)
-    detector._after_atomic_rmw(ret, rmwOp=None, ptr=None, val=None)
-    event = detector.concrete_events[0]
-    np.testing.assert_array_equal(event.written_value, [99])
-
-
 # ======== atomic_symbolic_escape lifecycle ========
 
 
-def test_atomic_symbolic_escape_flag_set_after_atomic():
-    # Unit-level: hand-call _before_atomic_cas with mock args so the test
-    # has no coupling with kernel-launch lifecycle.
-    detector = _prime_detector_for_callback()
-    assert detector.atomic_symbolic_escape is False
-
-    class _ElemTy:
-        primitive_bitwidth = 32
-
-    class _PtrTy:
-        element_ty = _ElemTy()
-
-    class _Ptr:
-        type = _PtrTy()
-
-        def __init__(self, addrs: np.ndarray):
-            self.addrs = addrs
-
-    # flatten_np walks .handle/.data; expose .data → address array.
-    ptr = _Ptr(np.array([100], dtype=np.int64))
-    ptr.data = ptr.addrs  # type: ignore[attr-defined]
-
-    detector._before_atomic_cas(
-        ptr,
-        cmp=np.array([0], dtype=np.int32),
-        val=np.array([1], dtype=np.int32),
-        mask=None,
-        sem=None,
-        scope=None,
-    )
-    assert detector.atomic_symbolic_escape is True
-
-
 def test_atomic_symbolic_escape_survives_finalize_and_resets_on_next_grid_callback():
-    detector = _prime_detector_for_callback()
+    detector = SymbolicRaceDetector(abort_on_error=False)
     # Forcibly set the flag as if an atomic had been captured.
     detector.atomic_symbolic_escape = True
 
@@ -620,59 +454,13 @@ def test_atomic_symbolic_escape_survives_finalize_and_resets_on_next_grid_callba
     assert detector.atomic_symbolic_escape is False
 
 
-# ======== finalize: dangling-pending assertion ========
-
-
-def test_finalize_raises_on_dangling_pending():
-    detector = _prime_detector_for_callback()
-    detector._pending_atomic_by_grid[(9, 9, 9)].append(
-        PendingAtomicEvent(
-            event_id=0,
-            op_type=AtomicCas,
-            atomic_op="cas",
-            grid_idx=(9, 9, 9),
-            source_location=None,
-            tensor=None,
-            tensor_name=None,
-            lane_addrs=np.array([100], dtype=np.int64),
-            active_mask=np.array([True]),
-            elem_size=4,
-            atomic_sem="acq_rel",
-            atomic_scope="gpu",
-            atomic_cmp=np.array([0], dtype=np.int32),
-            atomic_val=np.array([1], dtype=np.int32),
-        )
-    )
-    with pytest.raises(RuntimeError, match="Dangling pending atomic events"):
-        detector.finalize()
-
-
-# ======== End-to-end tests (xfail) ========
+# ======== End-to-end tests ========
 #
-# These exercise the full path: traced kernel → SymbolicClient → atomic
-# before/after callbacks → concrete_events. They're marked xfail because
-# the race detector currently inherits SymbolicClient's symbolic
-# overriders for Load/AddPtr/Splat/etc., which rewrite every expression
-# along the way into a SymbolicExpr. By the time ``tl.atomic_cas(ptr,
-# cmp, val)`` fires, its inputs are SymbolicExpr values that can't be
-# fed to the real interpreter-builder ``create_atomic_cas`` (no
-# op_overrider is registered for atomics on race_detector, so the
-# original op is expected to run — but only on concrete inputs).
-#
-# The fix is an adapter-level concretize-on-entry for atomic ops
-# (probably a race-detector-specific op_overrider that pulls out numpy
-# values, simulates the CAS/RMW, records the effect event, and returns
-# a SymbolicExpr const wrapping the resulting old value). That's a
-# separate scope from this PR's data-model + callback skeleton. The
-# callback *logic* is validated by the hand-built-pending tests above.
-
-
-ATOMIC_E2E_XFAIL_REASON = (
-    "Symbolic overriders upstream of tl.atomic_* turn the atomic's args "
-    "into SymbolicExpr; race_detector's op_overrider=None requires real "
-    "hardware execution on concrete inputs. Needs adapter-level "
-    "concretize-on-entry scaffolding — follow-up PR."
-)
+# Exercise the full path: traced kernel → race_detector atomic overrider →
+# concrete_events. The overrider concretizes ``SymbolicExpr`` inputs, runs
+# the real ``interpreter_builder.create_atomic_*`` on the concrete values,
+# records the effect, and returns a ``const`` SymbolicExpr wrapping the
+# hardware ``old`` so downstream symbolic consumers keep working.
 
 
 @triton.jit
@@ -687,7 +475,15 @@ def _atomic_add_kernel(x_ptr, val_ptr):
     tl.store(val_ptr + 1, old)
 
 
-@pytest.mark.xfail(reason=ATOMIC_E2E_XFAIL_REASON, strict=True)
+@triton.jit
+def _atomic_cas_downstream_kernel(x_ptr, out_ptr):
+    # Consume the atomic return value via a downstream symbolic op so the
+    # Step-0c return-type decision (``const`` SymbolicExpr carrying the
+    # concrete ``old``) stays honest end-to-end.
+    old = tl.atomic_cas(x_ptr, 0, 1)
+    tl.store(out_ptr, old + 1)
+
+
 def test_traced_kernel_emits_concrete_cas_event(_isolate_race_detector_cfg):
     detector = SymbolicRaceDetector(abort_on_error=False)
     traced = triton_viz.trace(client=detector)(_atomic_cas_kernel)
@@ -706,7 +502,6 @@ def test_traced_kernel_emits_concrete_cas_event(_isolate_race_detector_cfg):
     assert e.write_mask is not None and bool(e.write_mask.all())
 
 
-@pytest.mark.xfail(reason=ATOMIC_E2E_XFAIL_REASON, strict=True)
 def test_traced_kernel_emits_concrete_atomic_add_event(_isolate_race_detector_cfg):
     detector = SymbolicRaceDetector(abort_on_error=False)
     traced = triton_viz.trace(client=detector)(_atomic_add_kernel)
@@ -726,7 +521,6 @@ def test_traced_kernel_emits_concrete_atomic_add_event(_isolate_race_detector_cf
     np.testing.assert_array_equal(e.written_value, np.array([15], dtype=np.int32))
 
 
-@pytest.mark.xfail(reason=ATOMIC_E2E_XFAIL_REASON, strict=True)
 def test_finalize_still_returns_empty(_isolate_race_detector_cfg):
     detector = SymbolicRaceDetector(abort_on_error=False)
     traced = triton_viz.trace(client=detector)(_atomic_add_kernel)
@@ -734,10 +528,10 @@ def test_finalize_still_returns_empty(_isolate_race_detector_cfg):
     val = torch.tensor([1, 0], dtype=torch.int32)
     traced[(1,)](x, val)
 
+    # Step 0 (this commit) does not yet emit RaceReports from finalize().
     assert detector.finalize() == []
 
 
-@pytest.mark.xfail(reason=ATOMIC_E2E_XFAIL_REASON, strict=True)
 def test_repeat_launches_are_deterministic_for_atomics(_isolate_race_detector_cfg):
     detector = SymbolicRaceDetector(abort_on_error=False)
     traced = triton_viz.trace(client=detector)(_atomic_add_kernel)
@@ -755,18 +549,12 @@ def test_repeat_launches_are_deterministic_for_atomics(_isolate_race_detector_cf
     assert len(detector.concrete_events) == 1
     assert detector.concrete_events[0].atomic_op == "add"
 
-    # Pending queue must have drained between launches.
-    assert all(len(q) == 0 for q in detector._pending_atomic_by_grid.values())
 
-
-@pytest.mark.xfail(reason=ATOMIC_E2E_XFAIL_REASON, strict=True)
-def test_concurrent_blocks_drain_pending_queue_cleanly():
+def test_concurrent_blocks_capture_atomics_cleanly():
     """cfg.num_sms = 2 with a 2-block kernel, each block issues one atomic
-    add. Let the ThreadPoolExecutor interleave as it wants. The dangling-
-    queue assertion lives in finalize() (which runs once, post-launch),
-    NOT in per-block post_run_callback — so natural scheduling must not
-    trigger a false RuntimeError, and the queue must be empty after the
-    launch ends."""
+    add. Let the ThreadPoolExecutor interleave as it wants — overrider-based
+    capture is single-shot per op (no cross-callback pending state) so the
+    expected count is exactly one event per block regardless of ordering."""
     saved_num_sms = cfg.num_sms
     saved_flag = cfg.enable_race_detector
     try:
@@ -785,7 +573,28 @@ def test_concurrent_blocks_drain_pending_queue_cleanly():
 
         assert detector.finalize() == []
         assert len(detector.concrete_events) == 2
-        assert all(len(q) == 0 for q in detector._pending_atomic_by_grid.values())
     finally:
         cfg.num_sms = saved_num_sms
         cfg.enable_race_detector = saved_flag
+
+
+def test_atomic_cas_return_is_consumable_downstream(_isolate_race_detector_cfg):
+    """Locks the Step-0c return-type decision: the overrider returns a
+    ``const`` SymbolicExpr wrapping the concrete ``old`` TensorHandle, so
+    (a) the launch doesn't raise when downstream ops consume the result
+    and (b) a CAS concrete event is still captured."""
+    detector = SymbolicRaceDetector(abort_on_error=False)
+    traced = triton_viz.trace(client=detector)(_atomic_cas_downstream_kernel)
+
+    x = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(1, dtype=torch.int32)
+
+    traced[(1,)](x, out)  # must not raise
+
+    cas_events = [e for e in detector.concrete_events if e.atomic_op == "cas"]
+    assert len(cas_events) == 1
+    event = cas_events[0]
+    assert event.atomic_old is not None
+    assert int(event.atomic_old[0]) == 0
+    # detector.atomic_symbolic_escape flips on first atomic capture.
+    assert detector.atomic_symbolic_escape is True

--- a/tests/unit/test_race_detector.py
+++ b/tests/unit/test_race_detector.py
@@ -13,6 +13,8 @@ from triton_viz.clients.race_detector.race_detector import (
 )
 from triton_viz.clients.race_detector.data import (
     AccessEventRecord,
+    RaceReport,
+    RaceType,
     active_mask_for,
     apply_rmw,
     effects_at_addr,
@@ -608,6 +610,43 @@ def test_concrete_events_carry_program_seq_and_launch_id(_isolate_race_detector_
 
     launch_ids = {e.launch_id for e in detector.concrete_events}
     assert launch_ids == {detector._launch_id}
+
+
+def test_finalize_emits_report_for_crossblock_plain_store_load(
+    _isolate_race_detector_cfg,
+):
+    """Smoke test for the Step 4 candidate pipeline.
+
+    Block 0 stores to ``x_ptr``; block 1 loads from ``x_ptr``. Without
+    HB suppression (Step 5 lands in the next commit), this emits one
+    RAW RaceReport — canonical ordering places block 0's store first,
+    so the flow is write-then-read.
+    """
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    @triton.jit
+    def _crossblock_rw(x_ptr, out_ptr):
+        pid = tl.program_id(axis=0)
+        tl.store(x_ptr, 1, mask=(pid == 0))
+        v = tl.load(x_ptr, mask=(pid == 1))
+        tl.store(out_ptr + pid, v, mask=(pid == 1))
+
+    traced = triton_viz.trace(client=detector)(_crossblock_rw)
+    x = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+    traced[(2,)](x, out)
+
+    reports = detector.finalize()
+    # At least one RAW report on x_ptr between block 0 and block 1.
+    raw_reports = [
+        r
+        for r in reports
+        if isinstance(r, RaceReport)
+        and r.race_type is RaceType.RAW
+        and r.grid_a == (0, 0, 0)
+        and r.grid_b == (1, 0, 0)
+    ]
+    assert raw_reports, f"expected a RAW cross-block report, got {reports}"
 
 
 def test_atomic_cas_return_is_consumable_downstream(_isolate_race_detector_cfg):

--- a/tests/unit/test_race_detector.py
+++ b/tests/unit/test_race_detector.py
@@ -542,12 +542,14 @@ def test_repeat_launches_are_deterministic_for_atomics(_isolate_race_detector_cf
         traced[(1,)](x, val)
 
     _launch(10, 5)
-    assert len(detector.concrete_events) == 1
+    atomic_events = [e for e in detector.concrete_events if e.atomic_op is not None]
+    assert len(atomic_events) == 1
     detector.concrete_events.clear()
 
     _launch(10, 5)
-    assert len(detector.concrete_events) == 1
-    assert detector.concrete_events[0].atomic_op == "add"
+    atomic_events = [e for e in detector.concrete_events if e.atomic_op is not None]
+    assert len(atomic_events) == 1
+    assert atomic_events[0].atomic_op == "add"
 
 
 def test_concurrent_blocks_capture_atomics_cleanly():
@@ -576,6 +578,36 @@ def test_concurrent_blocks_capture_atomics_cleanly():
     finally:
         cfg.num_sms = saved_num_sms
         cfg.enable_race_detector = saved_flag
+
+
+def test_concrete_events_carry_program_seq_and_launch_id(_isolate_race_detector_cfg):
+    """Both plain load/store events and atomic events must be tagged with a
+    per-grid ``program_seq`` and the current ``launch_id`` — po / epoch
+    partitioning / same-value ambiguity all depend on this sequencing."""
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    @triton.jit
+    def _mixed_kernel(x_ptr, flag_ptr, BLOCK: tl.constexpr):
+        offs = tl.arange(0, BLOCK)
+        v = tl.load(x_ptr + offs)
+        tl.store(x_ptr + offs, v + 1)
+        tl.atomic_add(flag_ptr, 1)
+
+    traced = triton_viz.trace(client=detector)(_mixed_kernel)
+    x = torch.zeros(4, dtype=torch.int32)
+    flag = torch.zeros(1, dtype=torch.int32)
+    traced[(1,)](x, flag, BLOCK=4)
+
+    # Three concrete events expected: load, store, atomic_add.
+    assert len(detector.concrete_events) == 3
+    seqs = [e.program_seq for e in detector.concrete_events]
+    # Within a single grid_idx the program_seq values are 0, 1, 2 in issue
+    # order — NOT event_id order under multi-SM (unused here but locks
+    # the invariant that per-grid sequencing is contiguous).
+    assert seqs == [0, 1, 2], f"expected [0,1,2] program_seq, got {seqs}"
+
+    launch_ids = {e.launch_id for e in detector.concrete_events}
+    assert launch_ids == {detector._launch_id}
 
 
 def test_atomic_cas_return_is_consumable_downstream(_isolate_race_detector_cfg):

--- a/tests/unit/test_race_detector_hb.py
+++ b/tests/unit/test_race_detector_hb.py
@@ -1,0 +1,516 @@
+"""Step 5 (HBSolver) + Step 6 (epoch partitioning) invariants.
+
+Hand-built AccessEventRecords exercise each edge class in isolation so
+the po / sw / reads-from / ambiguous-writer / phase-advance rules can be
+independently regressed. Kernel-level coverage is in
+``tests/end_to_end/test_race_detector_sync.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import torch
+
+import triton
+import triton.language as tl
+
+import triton_viz
+
+from triton_viz.clients.race_detector.data import (
+    AccessEventRecord,
+    RaceCandidate,
+    RaceType,
+)
+from triton_viz.core.config import config as cfg
+from triton_viz.clients.race_detector.hb_solver import HBSolver
+from triton_viz.clients.race_detector.race_detector import (
+    SymbolicRaceDetector,
+    _is_phase_advancing_write,
+)
+from triton_viz.core.data import AtomicCas, AtomicRMW, Load, Store
+
+
+def _make_plain(
+    *,
+    event_id: int,
+    grid_idx: tuple[int, ...],
+    program_seq: int,
+    lane_addrs: list[int],
+    access_mode: str,
+    elem_size: int = 4,
+    epoch: int = 0,
+) -> AccessEventRecord:
+    lane_arr = np.array(lane_addrs, dtype=np.int64)
+    active = np.ones(len(lane_addrs), dtype=bool)
+    if access_mode == "read":
+        read_mask = active.copy()
+        write_mask = np.zeros_like(active)
+        op_type = Load
+    else:
+        read_mask = np.zeros_like(active)
+        write_mask = active.copy()
+        op_type = Store
+    return AccessEventRecord(
+        event_id=event_id,
+        op_type=op_type,
+        grid_idx=grid_idx,
+        program_seq=program_seq,
+        lane_addrs=lane_arr,
+        active_mask=active,
+        elem_size=elem_size,
+        read_mask=read_mask,
+        write_mask=write_mask,
+        epoch=epoch,
+    )
+
+
+def _make_atomic(
+    *,
+    event_id: int,
+    grid_idx: tuple[int, ...],
+    program_seq: int,
+    lane_addrs: list[int],
+    atomic_op: str,
+    atomic_old: list[int],
+    written_value: list[int],
+    atomic_sem: str,
+    atomic_scope: str,
+    elem_size: int = 4,
+    epoch: int = 0,
+    op_type: type = AtomicRMW,
+    atomic_val: list[int] | None = None,
+) -> AccessEventRecord:
+    lane_arr = np.array(lane_addrs, dtype=np.int64)
+    active = np.ones(len(lane_addrs), dtype=bool)
+    return AccessEventRecord(
+        event_id=event_id,
+        op_type=op_type,
+        grid_idx=grid_idx,
+        program_seq=program_seq,
+        lane_addrs=lane_arr,
+        active_mask=active,
+        elem_size=elem_size,
+        read_mask=active.copy(),
+        write_mask=active.copy(),
+        atomic_op=atomic_op,
+        atomic_sem=atomic_sem,
+        atomic_scope=atomic_scope,
+        atomic_old=np.array(atomic_old, dtype=np.int32),
+        atomic_val=np.array(atomic_val or written_value, dtype=np.int32),
+        written_value=np.array(written_value, dtype=np.int32),
+        epoch=epoch,
+    )
+
+
+# ── po construction ───────────────────────────────────────────────────────
+
+
+def test_hb_solver_builds_po_from_program_seq():
+    """po must key on ``program_seq``, not ``event_id`` — under multi-SM
+    execution ``event_id`` is append order, not program order (upstream #346)."""
+    a = _make_plain(
+        event_id=42,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    b = _make_plain(
+        event_id=5,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    solver = HBSolver([a, b])
+    cand = RaceCandidate(
+        first=a,
+        second=b,
+        race_type=RaceType.RAW,
+        witness_addr=100,
+        epoch=0,
+    )
+    result = solver.check_candidate(cand)
+    assert result.ordered, "po must order same-grid events by program_seq"
+    assert result.reason == "po_path"
+
+
+# ── sw: reads-from gate ───────────────────────────────────────────────────
+
+
+def test_release_acquire_requires_reads_from():
+    """Matching sem / scope alone does not create sw. The reader must
+    observe the writer's written value (#345)."""
+    # Producer: plain store THEN release. Consumer: acquire THEN plain load.
+    # Program-order: store@seq0 -> release@seq1 (block 0)
+    #                acquire@seq0 -> load@seq1   (block 1)
+    plain_store = _make_plain(
+        event_id=3,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[500],
+        access_mode="write",
+    )
+    writer = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="release",
+        atomic_scope="gpu",
+    )
+    # Reader sees a DIFFERENT value (not 1) -> no sw edge.
+    bad_reader = _make_atomic(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[7],
+        written_value=[2],
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+    )
+    plain_load = _make_plain(
+        event_id=4,
+        grid_idx=(1, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="read",
+    )
+    solver = HBSolver([plain_store, writer, bad_reader, plain_load])
+    cand = RaceCandidate(
+        first=plain_store,
+        second=plain_load,
+        race_type=RaceType.RAW,
+        witness_addr=500,
+        epoch=0,
+    )
+    assert not solver.check_candidate(
+        cand
+    ).ordered, "reads-from must fail when reader.atomic_old != writer.written_value"
+
+    # Reader now observes 1 (writer's written_value) -> sw edge formed.
+    good_reader = _make_atomic(
+        event_id=5,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[1],
+        written_value=[2],
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+    )
+    solver2 = HBSolver([plain_store, writer, good_reader, plain_load])
+    result = solver2.check_candidate(cand)
+    assert result.ordered
+    assert result.reason == "release_acquire_reads_from"
+
+
+def test_relaxed_atomic_does_not_create_sw():
+    writer = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+    reader = _make_atomic(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[1],
+        written_value=[2],
+        atomic_sem="relaxed",
+        atomic_scope="gpu",
+    )
+    plain_store = _make_plain(
+        event_id=3,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="write",
+    )
+    plain_load = _make_plain(
+        event_id=4,
+        grid_idx=(1, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="read",
+    )
+    solver = HBSolver([plain_store, writer, reader, plain_load])
+    cand = RaceCandidate(
+        first=plain_store,
+        second=plain_load,
+        race_type=RaceType.RAW,
+        witness_addr=500,
+        epoch=0,
+    )
+    assert not solver.check_candidate(cand).ordered
+
+
+def test_cta_scope_does_not_create_sw_or_barrier():
+    """CTA scope is block-local and not valid as cross-block sync (#345)."""
+    writer = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="release",
+        atomic_scope="cta",
+    )
+    reader = _make_atomic(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[1],
+        written_value=[2],
+        atomic_sem="acquire",
+        atomic_scope="cta",
+    )
+    plain_store = _make_plain(
+        event_id=3,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="write",
+    )
+    plain_load = _make_plain(
+        event_id=4,
+        grid_idx=(1, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="read",
+    )
+    solver = HBSolver([plain_store, writer, reader, plain_load])
+    cand = RaceCandidate(
+        first=plain_store,
+        second=plain_load,
+        race_type=RaceType.RAW,
+        witness_addr=500,
+        epoch=0,
+    )
+    assert not solver.check_candidate(cand).ordered
+
+
+# ── Same-value ABA ambiguity ──────────────────────────────────────────────
+
+
+def test_ambiguous_same_value_writer_blocks_sw():
+    """If a third-party writer also wrote the same value, the reader's
+    atomic_old can't uniquely attribute back to ``wi`` (#350)."""
+    wi = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="release",
+        atomic_scope="gpu",
+    )
+    # Third block ALSO writes value 1 at addr 200 -> ambiguity.
+    w_ambig = _make_atomic(
+        event_id=2,
+        grid_idx=(2, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="release",
+        atomic_scope="gpu",
+    )
+    ri = _make_atomic(
+        event_id=3,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[1],
+        written_value=[2],
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+    )
+    plain_store = _make_plain(
+        event_id=4,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="write",
+    )
+    plain_load = _make_plain(
+        event_id=5,
+        grid_idx=(1, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="read",
+    )
+    solver = HBSolver([plain_store, wi, w_ambig, ri, plain_load])
+    cand = RaceCandidate(
+        first=plain_store,
+        second=plain_load,
+        race_type=RaceType.RAW,
+        witness_addr=500,
+        epoch=0,
+    )
+    assert not solver.check_candidate(
+        cand
+    ).ordered, "same-value third-party writer must block sw (#350)"
+
+
+def test_reader_self_same_value_cas_writeback_is_not_ambiguous():
+    """``cas(1, 1)`` polling loops have the reader itself write back the
+    same value it saw (#347). The ambiguity scan must skip ``ri`` so this
+    doesn't falsely block sw from the real writer.
+    """
+    plain_store = _make_plain(
+        event_id=3,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[500],
+        access_mode="write",
+    )
+    wi = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[200],
+        atomic_op="xchg",
+        atomic_old=[0],
+        written_value=[1],
+        atomic_sem="release",
+        atomic_scope="gpu",
+    )
+    # Reader is a CAS that writes back 1 on success.
+    ri = _make_atomic(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[200],
+        atomic_op="cas",
+        atomic_old=[1],
+        written_value=[1],
+        atomic_sem="acquire",
+        atomic_scope="gpu",
+        op_type=AtomicCas,
+    )
+    plain_load = _make_plain(
+        event_id=4,
+        grid_idx=(1, 0, 0),
+        program_seq=1,
+        lane_addrs=[500],
+        access_mode="read",
+    )
+    solver = HBSolver([plain_store, wi, ri, plain_load])
+    cand = RaceCandidate(
+        first=plain_store,
+        second=plain_load,
+        race_type=RaceType.RAW,
+        witness_addr=500,
+        epoch=0,
+    )
+    result = solver.check_candidate(cand)
+    assert (
+        result.ordered
+    ), "reader's own writeback must not trip the ambiguity check (#347)"
+    assert result.reason == "release_acquire_reads_from"
+
+
+# ── Phase-advance epoch bump ──────────────────────────────────────────────
+
+
+def test_epoch_does_not_advance_on_failed_cas():
+    """Failed CAS writes the pre-op value back (written_value == old).
+    Step 6 must NOT count this as a phase advance."""
+    failed_cas = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[300],
+        atomic_op="cas",
+        atomic_old=[7],
+        written_value=[7],
+        atomic_sem="acq_rel",
+        atomic_scope="gpu",
+        op_type=AtomicCas,
+    )
+    assert not _is_phase_advancing_write(failed_cas, 300)
+
+
+def test_epoch_does_not_advance_on_same_value_rmw_add_zero():
+    """``atomic_add(0)`` touches the barrier address but leaves the value
+    unchanged. Conservative epoch partitioning must keep it in-phase."""
+    rmw_add_zero = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[300],
+        atomic_op="add",
+        atomic_old=[5],
+        written_value=[5],
+        atomic_sem="acq_rel",
+        atomic_scope="gpu",
+    )
+    assert not _is_phase_advancing_write(rmw_add_zero, 300)
+
+
+def test_epoch_advances_on_real_phase_bump():
+    """Sanity counterpart: a true value change DOES advance the phase."""
+    inc = _make_atomic(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[300],
+        atomic_op="add",
+        atomic_old=[5],
+        written_value=[6],
+        atomic_sem="acq_rel",
+        atomic_scope="gpu",
+    )
+    assert _is_phase_advancing_write(inc, 300)
+
+
+# ── program_seq propagation through atomics ───────────────────────────────
+
+
+@triton.jit
+def _mix_for_program_seq(x_ptr, flag_ptr):
+    tl.store(x_ptr, 1)
+    tl.atomic_add(flag_ptr, 1, sem="release", scope="gpu")
+    tl.atomic_cas(flag_ptr, 1, 2, sem="acquire", scope="gpu")
+
+
+def test_atomic_events_carry_program_seq():
+    """Step 2 invariant: both atomic and plain paths must stamp
+    program_seq and launch_id — the HB solver's po, the epoch
+    partitioner, and the ambiguity scan all depend on it."""
+    saved = cfg.enable_race_detector
+    try:
+        cfg.enable_race_detector = True
+        detector = SymbolicRaceDetector(abort_on_error=False)
+        traced = triton_viz.trace(client=detector)(_mix_for_program_seq)
+        x = torch.zeros(1, dtype=torch.int32)
+        flag = torch.zeros(1, dtype=torch.int32)
+        traced[(1,)](x, flag)
+        # Each block's concrete events must have consecutive program_seq.
+        assert [e.program_seq for e in detector.concrete_events] == [0, 1, 2]
+        assert {e.launch_id for e in detector.concrete_events} == {detector._launch_id}
+    finally:
+        cfg.enable_race_detector = saved

--- a/tests/unit/test_race_detector_pairing.py
+++ b/tests/unit/test_race_detector_pairing.py
@@ -1,0 +1,264 @@
+"""Step 4 candidate-finder invariants, tested in isolation.
+
+These tests build ``AccessEventRecord`` instances by hand so they cover
+the pairing logic without kernel-launch overhead or interpreter behavior
+drift. End-to-end coverage lives in ``tests/end_to_end/test_race_detector_sync.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from triton_viz.clients.race_detector.data import (
+    AccessEventRecord,
+    RaceType,
+    flatten_np,
+)
+from triton_viz.clients.race_detector.race_detector import (
+    _canonical_pair,
+    _classify_candidate,
+    SymbolicRaceDetector,
+)
+from triton_viz.core.data import Load, Store
+
+
+def _plain_event(
+    *,
+    event_id: int,
+    grid_idx: tuple[int, ...],
+    program_seq: int,
+    lane_addrs: list[int],
+    elem_size: int = 4,
+    access_mode: str,
+    epoch: int = 0,
+) -> AccessEventRecord:
+    lane_arr = np.array(lane_addrs, dtype=np.int64)
+    active = np.ones(len(lane_addrs), dtype=bool)
+    if access_mode == "read":
+        read_mask = active.copy()
+        write_mask = np.zeros_like(active)
+        op_type = Load
+    else:
+        read_mask = np.zeros_like(active)
+        write_mask = active.copy()
+        op_type = Store
+    return AccessEventRecord(
+        event_id=event_id,
+        op_type=op_type,
+        grid_idx=grid_idx,
+        program_seq=program_seq,
+        lane_addrs=lane_arr,
+        active_mask=active,
+        elem_size=elem_size,
+        read_mask=read_mask,
+        write_mask=write_mask,
+        epoch=epoch,
+    )
+
+
+class _Concretizable:
+    """Minimal SymbolicExpr-alike with a ``concretize()`` method so
+    ``maybe_concretize`` has something to dispatch on."""
+
+    def __init__(self, inner: np.ndarray):
+        self._inner = inner
+
+    def concretize(self) -> np.ndarray:
+        return self._inner
+
+
+def test_flatten_np_concretizes_symbolic_expr():
+    """Locks the Step 0 plumbing: helpers must unwrap a SymbolicExpr-alike
+    before treating it as numeric data. Upstream #358 xfailed atomic E2E
+    tests over this exact gap."""
+    concrete = np.array([10, 20, 30], dtype=np.int64)
+    wrapped = _Concretizable(concrete)
+    np.testing.assert_array_equal(flatten_np(wrapped), concrete)
+
+
+def test_classify_race_type_directional_raw_war_waw():
+    """WAR must be a live return value, not a dead enum entry (#351).
+
+    Fixed canonical order places the write-first event as ``first``; the
+    WAR case has ``first=reader, second=writer`` by canonical order — so
+    the RAW/WAR distinction actually falls out of the ordering.
+    """
+    w0 = _plain_event(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    r1 = _plain_event(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    # Canonical order: block 0 precedes block 1. first=w0, second=r1 -> RAW.
+    first, second = _canonical_pair(w0, r1)
+    assert first is w0 and second is r1
+    assert _classify_candidate(first, second, 100) is RaceType.RAW
+
+    # Swap grid order to produce a WAR: reader in block 0, writer in block 1.
+    r0 = _plain_event(
+        event_id=3,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    w1 = _plain_event(
+        event_id=4,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    first, second = _canonical_pair(r0, w1)
+    assert first is r0 and second is w1
+    assert _classify_candidate(first, second, 100) is RaceType.WAR
+
+    # Both write -> WAW.
+    w0b = _plain_event(
+        event_id=5,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    w1b = _plain_event(
+        event_id=6,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    assert _classify_candidate(w0b, w1b, 100) is RaceType.WAW
+
+    # Both read -> None.
+    r0b = _plain_event(
+        event_id=7,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    r1b = _plain_event(
+        event_id=8,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    assert _classify_candidate(r0b, r1b, 100) is None
+
+
+def test_candidate_finder_skips_same_grid_idx():
+    """Intra-block pairs are po-ordered by construction, not a race. The
+    finder must drop them before classification."""
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    e_w = _plain_event(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    e_r = _plain_event(
+        event_id=2,
+        grid_idx=(0, 0, 0),
+        program_seq=1,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    assert detector._find_race_candidates([e_w, e_r]) == []
+
+
+def test_candidate_finder_dedups_same_pair_seen_on_multiple_bytes():
+    """A 4-byte element-size overlap produces 4 byte-bucket hits for the
+    same event pair — the finder must dedupe on ``(min_event_id,
+    max_event_id)`` so one RaceCandidate emerges, not four."""
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    w0 = _plain_event(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        elem_size=4,
+        access_mode="write",
+    )
+    r1 = _plain_event(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        elem_size=4,
+        access_mode="read",
+    )
+    cands = detector._find_race_candidates([w0, r1])
+    assert len(cands) == 1
+    assert cands[0].race_type is RaceType.RAW
+
+
+def test_candidate_finder_respects_epoch():
+    """Events in different epochs never pair, even on the same address.
+
+    Step 6 barrier-based partitioning relies on this — otherwise cross-
+    phase pairs would still show up as races.
+    """
+    detector = SymbolicRaceDetector(abort_on_error=False)
+
+    pre = _plain_event(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+        epoch=0,
+    )
+    post = _plain_event(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+        epoch=1,
+    )
+    assert detector._find_race_candidates([pre, post]) == []
+
+    # Same epoch -> pair is produced.
+    pre.epoch = 0
+    post.epoch = 0
+    cands = detector._find_race_candidates([pre, post])
+    assert len(cands) == 1
+    assert cands[0].epoch == 0
+
+
+def test_canonical_pair_is_stable_under_swap():
+    a = _plain_event(
+        event_id=1,
+        grid_idx=(0, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="write",
+    )
+    b = _plain_event(
+        event_id=2,
+        grid_idx=(1, 0, 0),
+        program_seq=0,
+        lane_addrs=[100],
+        access_mode="read",
+    )
+    first_ab, second_ab = _canonical_pair(a, b)
+    first_ba, second_ba = _canonical_pair(b, a)
+    assert (first_ab, second_ab) == (first_ba, second_ba)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/triton_viz/clients/race_detector/data.py
+++ b/triton_viz/clients/race_detector/data.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import deque  # noqa: F401  (re-exported for race_detector.py)
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
@@ -21,16 +20,24 @@ VALID_RMW_OPS: frozenset[str] = frozenset(
 )
 
 
+_MEM_SEM_ENUM_NAMES: dict[str, str] = {
+    "ACQUIRE": "acquire",
+    "RELEASE": "release",
+    "RELAXED": "relaxed",
+    "ACQUIRE_RELEASE": "acq_rel",
+}
+
+
 @dataclass
 class AccessEventRecord:
     """Effect-aware memory access event.
 
-    The same dataclass serves Step 1's symbolic load/store path and PR2's
-    concrete atomic path. Symbolic events populate ``symbolic_expr`` /
-    ``addr_expr`` / ``premises`` / ``local_constraints`` / ``access_mode``;
-    concrete atomic events populate ``lane_addrs`` / ``active_mask`` /
-    ``elem_size`` / ``read_mask`` / ``write_mask`` / ``atomic_*`` /
-    ``written_value``.
+    The same dataclass serves Step 1's symbolic load/store path and the
+    concrete atomic / plain load-store path. Symbolic events populate
+    ``symbolic_expr`` / ``addr_expr`` / ``premises`` / ``local_constraints``
+    / ``access_mode``; concrete events populate ``lane_addrs`` /
+    ``active_mask`` / ``elem_size`` / ``read_mask`` / ``write_mask`` /
+    ``atomic_*`` / ``written_value``.
     """
 
     # identity / source
@@ -50,7 +57,7 @@ class AccessEventRecord:
     premises: tuple[Any, ...] = field(default_factory=tuple)
     local_constraints: tuple[Any, ...] = field(default_factory=tuple)
 
-    # Concrete lane-level fields (populated for atomics)
+    # Concrete lane-level fields (populated for atomics + plain concrete events)
     lane_addrs: np.ndarray | None = None
     active_mask: np.ndarray | None = None
     elem_size: int | None = None
@@ -72,52 +79,72 @@ class AccessEventRecord:
     legacy_atomic: bool = False
 
 
-@dataclass
-class PendingAtomicEvent:
-    """Snapshot captured in ``_before_atomic_*``, consumed in ``_after_atomic_*``.
-
-    Keyed by ``grid_idx`` in a ``defaultdict(deque)``; within one block the
-    same grid_idx never collides with another worker (each block runs on one
-    worker thread), and multiple atomics inside one block pop FIFO.
-    """
-
-    event_id: int
-    op_type: type[Op]
-    atomic_op: str
-    grid_idx: tuple[int, ...]
-    source_location: tuple[str, int, str] | None
-
-    tensor: torch.Tensor | None
-    tensor_name: str | None
-
-    lane_addrs: np.ndarray
-    active_mask: np.ndarray
-    elem_size: int
-
-    atomic_sem: str
-    atomic_scope: str
-
-    atomic_cmp: np.ndarray | None = None
-    atomic_val: np.ndarray | None = None
-
-
 # ---------------------------------------------------------------------------
 # Module-level helpers
 # ---------------------------------------------------------------------------
 
 
-def normalize_sem_scope(sem: str | None, scope: str | None) -> tuple[str, str]:
-    """Triton defaults: ``sem='acq_rel'``, ``scope='gpu'``. Other values are
-    lowercased and passed through verbatim."""
-    sem_norm = "acq_rel" if sem is None else str(sem).lower()
-    scope_norm = "gpu" if scope is None else str(scope).lower()
-    return sem_norm, scope_norm
+def maybe_concretize(x: Any) -> Any:
+    """Best-effort reduce a possibly-symbolic value to its concrete form.
+
+    Handles two input shapes this package actually sees:
+      * ``SymbolicExpr`` (and its subclasses) — exposes ``concretize()`` that
+        walks the expression tree, runs the original ops, and returns a
+        ``TensorHandle`` (or scalar/tuple for const nodes).
+      * ``tl.core.tensor`` whose ``.handle`` is a ``SymbolicExpr`` — the
+        race detector's atomic overrider sees these when an upstream
+        symbolic overrider ran first, wrapping its result in ``tl.core.tensor``.
+
+    Anything already concrete (``TensorHandle``, numpy array, torch tensor,
+    Python scalar) passes through unchanged.
+    """
+    if x is None:
+        return None
+    handle = getattr(x, "handle", None)
+    if handle is not None and hasattr(handle, "concretize"):
+        # tl.core.tensor wrapping a SymbolicExpr
+        return handle.concretize()
+    if hasattr(x, "concretize"):
+        return x.concretize()
+    return x
+
+
+def normalize_sem_scope(sem: Any, scope: Any) -> tuple[str, str]:
+    """Triton defaults: ``sem='acq_rel'``, ``scope='gpu'``.
+
+    Accepts both string inputs (``"acquire"``, ``"cta"``) and interpreter
+    enum values (``MEM_SEMANTIC.ACQUIRE``). Enum names are mapped to the
+    short vocabulary used by the HB solver (``"acquire"``, ``"release"``,
+    ``"acq_rel"``, ``"relaxed"``); unknown enum names fall back to the
+    enum's lowercased name.
+    """
+    return _canonical_sem(sem), _canonical_scope(scope)
+
+
+def _canonical_sem(sem: Any) -> str:
+    if sem is None:
+        return "acq_rel"
+    name = getattr(sem, "name", None)
+    if isinstance(name, str):
+        return _MEM_SEM_ENUM_NAMES.get(name, name.lower())
+    return str(sem).lower()
+
+
+def _canonical_scope(scope: Any) -> str:
+    if scope is None:
+        return "gpu"
+    name = getattr(scope, "name", None)
+    if isinstance(name, str):
+        return name.lower()
+    return str(scope).lower()
 
 
 def flatten_np(x: Any) -> np.ndarray:
     """Coerce ``x`` (tl.tensor / TensorHandle / ndarray / torch.Tensor /
-    python scalar) into a 1-D ndarray."""
-    # tl.tensor wraps a .handle.data; interpreter TensorHandle exposes .data.
+    python scalar / SymbolicExpr / SymbolicExpr-wrapped tl.tensor) into a
+    1-D ndarray. Symbolic inputs are concretized first via
+    :func:`maybe_concretize`."""
+    x = maybe_concretize(x)
     inner: Any = x
     for attr in ("handle", "data"):
         while hasattr(inner, attr):
@@ -140,7 +167,10 @@ def active_mask_for(mask: Any, nlanes: int) -> np.ndarray:
       - scalar bool  → ``np.full(nlanes, bool(mask), dtype=bool)``
       - block/tensor → ``flatten_np(mask).astype(bool)``; length MUST
                        equal ``nlanes`` or ``ValueError`` (no silent broadcast).
+
+    Symbolic inputs are concretized first via :func:`maybe_concretize`.
     """
+    mask = maybe_concretize(mask)
     if mask is None:
         return np.ones(nlanes, dtype=bool)
 
@@ -168,7 +198,10 @@ def broadcast_lane_operand(x: Any, nlanes: int) -> np.ndarray:
       - python scalar / 0-d array → broadcast to ``nlanes``
       - 1-D array of length ``nlanes`` → pass through
       - anything else → ``ValueError`` with the offending shape
+
+    Symbolic inputs are concretized first via :func:`maybe_concretize`.
     """
+    x = maybe_concretize(x)
     if isinstance(x, (int, float, bool, np.integer, np.floating, np.bool_)):
         scalar = np.asarray(x)
         return np.full(nlanes, scalar, dtype=scalar.dtype)
@@ -192,6 +225,7 @@ def _pointer_elem_size(ptr: Any) -> int | None:
     over-fitting to one runtime shape. Returns ``None`` if nothing authoritative
     is reachable.
     """
+    ptr = maybe_concretize(ptr)
     candidate: Any = ptr
     for attr in ("handle", "data"):
         while hasattr(candidate, attr):
@@ -220,15 +254,20 @@ def infer_elem_size(val: Any, ptr: Any) -> int:
          — only taken if the value isn't a bare Python int/float/bool (those
          get boxed to int64/float64 and would mis-classify int32 atomics).
       3. else ``ValueError``.
+
+    Symbolic inputs are concretized first via :func:`maybe_concretize`.
     """
+    val = maybe_concretize(val)
+    ptr = maybe_concretize(ptr)
+
     ptr_size = _pointer_elem_size(ptr)
     if ptr_size is not None:
         return ptr_size
 
-    if isinstance(val, (int, float, bool)):
+    if val is None or isinstance(val, (int, float, bool)):
         raise ValueError(
             "infer_elem_size: pointer has no element type and value is a bare "
-            "Python scalar; refusing to guess element size."
+            "Python scalar or absent; refusing to guess element size."
         )
 
     flat = flatten_np(val)
@@ -253,6 +292,8 @@ def resolve_tensor_from_pointer(
     3. ``lo = min(active_addrs)``, ``hi = max(active_addrs) + elem_size - 1``.
     4. Find registered tensor intervals that fully cover ``[lo, hi]``.
     5. Exactly one match → return it; zero or >1 → ``None``.
+
+    Symbolic pointers are concretized first via :func:`maybe_concretize`.
     """
     lane_addrs = flatten_np(ptr).astype(np.int64, copy=False)
     if lane_addrs.shape[0] != active_mask.shape[0]:

--- a/triton_viz/clients/race_detector/data.py
+++ b/triton_viz/clients/race_detector/data.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import Any, Literal
 
 import numpy as np
@@ -75,8 +76,66 @@ class AccessEventRecord:
     atomic_old: np.ndarray | None = None
     written_value: np.ndarray | None = None
 
+    # Per-launch ordering / partitioning metadata (populated by the detector
+    # at capture time for concrete events — event_id is a client-lifetime
+    # unique id and NOT program order under multi-SM concurrency).
+    program_seq: int | None = None  # per-grid_idx program order index
+    epoch: int = 0  # assigned by Step 6 barrier partitioning
+    launch_id: int | None = None  # debug / cross-launch disambiguation
+
     # Reserved for Step 4/5 HB-exclusion; inert this PR.
     legacy_atomic: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Race classification / report schema
+# ---------------------------------------------------------------------------
+
+
+class RaceType(Enum):
+    """Category of a candidate data race.
+
+    Directional: ``first`` / ``second`` are ordered canonically by
+    ``(grid_idx, program_seq, event_id)`` so RAW and WAR are distinct
+    outcomes of classification — unlike upstream's dead WAR enum (#351).
+    """
+
+    RAW = auto()
+    WAR = auto()
+    WAW = auto()
+
+
+@dataclass
+class RaceCandidate:
+    """A pair of concrete events conflicting at a byte address before HB
+    suppression. Produced by the Step 4 candidate finder and fed into the
+    Step 5 HBSolver; `first` precedes `second` in the canonical ordering
+    so RAW / WAR / WAW reflect the direction of the flow."""
+
+    first: AccessEventRecord
+    second: AccessEventRecord
+    race_type: RaceType
+    witness_addr: int  # byte address
+    epoch: int
+
+
+@dataclass
+class RaceReport:
+    """Public race report emitted by `SymbolicRaceDetector.finalize()`
+    once HB suppression has run. Kept deliberately flat so consumers
+    downstream of `ClientManager.finalize()` (which appends per-client
+    finalize output to `launch.records`) can render it without walking
+    back into detector state."""
+
+    race_type: RaceType
+    witness_addr: int
+    epoch: int
+    tensor_name: str | None = None
+    grid_a: tuple[int, ...] | None = None
+    grid_b: tuple[int, ...] | None = None
+    source_a: tuple[str, int, str] | None = None
+    source_b: tuple[str, int, str] | None = None
+    hb_reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -221,27 +280,26 @@ def broadcast_lane_operand(x: Any, nlanes: int) -> np.ndarray:
 def _pointer_elem_size(ptr: Any) -> int | None:
     """Best-effort: pull the element byte-size out of a pointer value.
 
-    Looks for the usual interpreter pointer-element-type chains without
-    over-fitting to one runtime shape. Returns ``None`` if nothing authoritative
-    is reachable.
+    Tries the usual interpreter pointer-element-type chains:
+      * ``ptr.type.element_ty`` (tl.core.tensor carrying a pointer dtype)
+      * ``ptr.dtype.element_ty`` (TensorHandle / SymbolicExpr with
+        ``dtype == tl.pointer_type(...)``)
+
+    Returns ``None`` if nothing authoritative is reachable — callers that
+    then lack a concrete ``val`` can raise ``ValueError`` from
+    :func:`infer_elem_size`.
     """
-    ptr = maybe_concretize(ptr)
-    candidate: Any = ptr
-    for attr in ("handle", "data"):
-        while hasattr(candidate, attr):
-            nxt = getattr(candidate, attr)
-            if nxt is candidate:
-                break
-            candidate = nxt
-
-    type_obj = getattr(ptr, "type", None)
-    element_ty = getattr(type_obj, "element_ty", None) if type_obj is not None else None
-    if element_ty is not None:
-        bitwidth = getattr(element_ty, "primitive_bitwidth", None)
-        if isinstance(bitwidth, int) and bitwidth > 0 and bitwidth % 8 == 0:
-            return bitwidth // 8
-
-    # numpy / torch pointer arrays don't carry element_ty; bail out.
+    for candidate in (ptr, maybe_concretize(ptr)):
+        if candidate is None:
+            continue
+        for attr_name in ("type", "dtype"):
+            type_obj = getattr(candidate, attr_name, None)
+            element_ty = getattr(type_obj, "element_ty", None)
+            if element_ty is None:
+                continue
+            bitwidth = getattr(element_ty, "primitive_bitwidth", None)
+            if isinstance(bitwidth, int) and bitwidth > 0 and bitwidth % 8 == 0:
+                return bitwidth // 8
     return None
 
 

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -1,7 +1,255 @@
-"""Happens-before reasoning for race_detector.
+"""Concrete happens-before solver for the race detector.
 
-HB logic intentionally deferred until after Step 1. Step 0 keeps this file
-as a visible placeholder so the directory layout is stable, but nothing in
-Step 0/Step 1 should import from here. The real ``HBSolver`` lands with
-the Step-2 PR.
+Builds a per-epoch graph over concrete events:
+  * ``po`` edges - per ``grid_idx``, consecutive events ordered by
+    ``program_seq`` (upstream #346 fix: event_id is not program order
+    under multi-SM concurrency).
+  * ``sw`` edges - only between atomic operations where:
+      * writer.atomic_sem is release or acq_rel;
+      * reader.atomic_sem is acquire or acq_rel;
+      * writer.atomic_scope and reader.atomic_scope are in
+        ``{gpu, sys}`` - CTA scope is block-local and can't be inferred
+        as cross-block sync (upstream #345);
+      * reader.atomic_old equals writer.written_value at a shared
+        element base address (reads-from gate, upstream #345 - naive
+        release/acquire pairing over-suppresses);
+      * no ``same-value`` ambiguous writer exists (upstream #350 same-value
+        ABA - if a third-party writer also wrote the same value, the
+        reads-from evidence is inconclusive).
+
+Given a ``RaceCandidate``, ``check_candidate`` returns ``HBResult`` with
+``ordered=True`` when either direction is reachable, else ``ordered=False``
+(the candidate survives HB suppression and becomes a race report).
 """
+
+from __future__ import annotations
+
+from collections import defaultdict, deque
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import numpy as np
+
+from .data import AccessEventRecord, RaceCandidate
+
+
+_RELEASE_WRITER_SEMS: frozenset[str] = frozenset({"release", "acq_rel"})
+_ACQUIRE_READER_SEMS: frozenset[str] = frozenset({"acquire", "acq_rel"})
+_VALID_SW_SCOPES: frozenset[str] = frozenset({"gpu", "sys"})
+
+
+@dataclass
+class HBResult:
+    """Outcome of an HB reachability query.
+
+    ``ordered=True`` means the candidate pair is ordered by
+    ``po | sw`` - the race is suppressed. ``reason`` identifies the edge
+    class used so race reports (and tests) can distinguish ``po_path``
+    from ``release_acquire_reads_from`` suppression.
+    """
+
+    ordered: bool
+    reason: str | None = None
+    sync_addr: int | None = None
+
+
+def _iter_element_bases(event: AccessEventRecord):
+    """Yield element base addresses for every active lane of ``event``.
+
+    Unlike the candidate finder's byte iterator, sw edges are per-element
+    (release/acquire operate on the full element), so the HB solver keys
+    on element base addresses - not byte addresses.
+    """
+    if event.lane_addrs is None:
+        return
+    active = (
+        event.active_mask
+        if event.active_mask is not None
+        else np.ones_like(event.lane_addrs, dtype=bool)
+    )
+    for idx, hit in enumerate(active):
+        if not hit:
+            continue
+        yield int(event.lane_addrs[idx])
+
+
+def _value_at_addr(event: AccessEventRecord, elem_base: int, which: str) -> Any | None:
+    """Return ``event.atomic_old`` or ``event.written_value`` at a specific
+    element base, or ``None`` if the event has no atomic data or does not
+    touch that address on an active lane.
+    """
+    arr = getattr(event, which)
+    if arr is None or event.lane_addrs is None:
+        return None
+    mask = event.lane_addrs == elem_base
+    if event.active_mask is not None:
+        mask = mask & event.active_mask
+    hits = np.nonzero(mask)[0]
+    if hits.size == 0:
+        return None
+    return arr[hits[0]]
+
+
+def _reads_from(
+    writer: AccessEventRecord, reader: AccessEventRecord, elem_base: int
+) -> bool:
+    """True iff reader's ``atomic_old`` at ``elem_base`` equals writer's
+    ``written_value`` at the same address. This is the reads-from gate
+    that keeps release/acquire pairs from over-suppressing - just
+    matching sem/scope is not enough (upstream #345).
+    """
+    w_val = _value_at_addr(writer, elem_base, "written_value")
+    r_old = _value_at_addr(reader, elem_base, "atomic_old")
+    if w_val is None or r_old is None:
+        return False
+    return bool(np.array_equal(w_val, r_old))
+
+
+def _has_ambiguous_writer(
+    wi: AccessEventRecord,
+    ri: AccessEventRecord,
+    elem_base: int,
+    sync_events: Sequence[AccessEventRecord],
+) -> bool:
+    """Return True if another writer in the same epoch wrote the same value
+    at ``elem_base``. With matching values from different writers, the
+    reads-from gate can't uniquely attribute ``ri.atomic_old`` to ``wi``;
+    sound behavior is to block the sw edge (upstream #350).
+
+    Skips ``wi`` itself (obvious), ``ri`` itself (``cas(1,1)`` polling
+    loops writeback the same value - upstream #347), and events strictly
+    in ``ri``'s future within ``ri``'s own grid (reader hasn't executed
+    past its own program point yet so those aren't visible).
+    """
+    wi_val = _value_at_addr(wi, elem_base, "written_value")
+    if wi_val is None:
+        return False
+    for x in sync_events:
+        if x is wi or x is ri:
+            continue
+        if (
+            x.grid_idx == ri.grid_idx
+            and x.program_seq is not None
+            and (ri.program_seq is None or x.program_seq > ri.program_seq)
+        ):
+            continue
+        x_val = _value_at_addr(x, elem_base, "written_value")
+        if x_val is None:
+            continue
+        if np.array_equal(x_val, wi_val):
+            return True
+    return False
+
+
+class HBSolver:
+    """Concrete ``po + sw`` reachability solver for one epoch.
+
+    ``events`` must all share the same ``epoch`` - the caller groups
+    events by epoch and builds one solver per group (see
+    ``SymbolicRaceDetector.finalize``).
+    """
+
+    def __init__(self, events: Sequence[AccessEventRecord]):
+        self._events = list(events)
+        # Adjacency keyed on id(event) so two events that happen to
+        # compare equal stay distinct nodes.
+        self._adj: dict[int, list[tuple[int, str, int | None]]] = defaultdict(list)
+        self._build_po()
+        self._build_sw()
+
+    # ── Graph construction ────────────────────────────────────────────────
+
+    def _add_edge(
+        self,
+        src: AccessEventRecord,
+        dst: AccessEventRecord,
+        reason: str,
+        sync_addr: int | None = None,
+    ) -> None:
+        self._adj[id(src)].append((id(dst), reason, sync_addr))
+
+    def _build_po(self) -> None:
+        by_grid: dict[Any, list[AccessEventRecord]] = defaultdict(list)
+        for ev in self._events:
+            by_grid[ev.grid_idx].append(ev)
+        for grid_events in by_grid.values():
+            grid_events.sort(
+                key=lambda e: (
+                    e.program_seq if e.program_seq is not None else -1,
+                    e.event_id,
+                )
+            )
+            for i in range(len(grid_events) - 1):
+                self._add_edge(grid_events[i], grid_events[i + 1], "po_path")
+
+    def _build_sw(self) -> None:
+        by_addr: dict[int, list[AccessEventRecord]] = defaultdict(list)
+        sync_events: list[AccessEventRecord] = []
+        for ev in self._events:
+            if ev.atomic_op is None:
+                continue
+            sync_events.append(ev)
+            for base in _iter_element_bases(ev):
+                by_addr[base].append(ev)
+
+        for addr, bucket in by_addr.items():
+            for writer in bucket:
+                if writer.atomic_sem not in _RELEASE_WRITER_SEMS:
+                    continue
+                if writer.atomic_scope not in _VALID_SW_SCOPES:
+                    continue
+                for reader in bucket:
+                    if reader is writer:
+                        continue
+                    if reader.atomic_sem not in _ACQUIRE_READER_SEMS:
+                        continue
+                    if reader.atomic_scope not in _VALID_SW_SCOPES:
+                        continue
+                    if reader.grid_idx == writer.grid_idx:
+                        # Same-block release/acquire is already po-ordered.
+                        continue
+                    if not _reads_from(writer, reader, addr):
+                        continue
+                    if _has_ambiguous_writer(writer, reader, addr, sync_events):
+                        continue
+                    self._add_edge(writer, reader, "release_acquire_reads_from", addr)
+
+    # ── Reachability ──────────────────────────────────────────────────────
+
+    def _reachable(
+        self, src: AccessEventRecord, dst: AccessEventRecord
+    ) -> tuple[bool, str | None, int | None]:
+        """BFS from ``src``. Records the last sw edge traversed (if any) so
+        ``check_candidate`` can annotate why the race was suppressed.
+        Pure po paths return ``"po_path"``.
+        """
+        if src is dst:
+            return True, "po_path", None
+        start = id(src)
+        target = id(dst)
+        seen: set[int] = {start}
+        queue: deque[tuple[int, str | None, int | None]] = deque([(start, None, None)])
+        while queue:
+            node, last_reason, last_addr = queue.popleft()
+            for next_node, edge_reason, edge_addr in self._adj.get(node, ()):
+                if next_node in seen:
+                    continue
+                new_reason = last_reason
+                new_addr = last_addr
+                if edge_reason != "po_path":
+                    new_reason = edge_reason
+                    new_addr = edge_addr
+                if next_node == target:
+                    return True, new_reason or "po_path", new_addr
+                seen.add(next_node)
+                queue.append((next_node, new_reason, new_addr))
+        return False, None, None
+
+    def check_candidate(self, cand: RaceCandidate) -> HBResult:
+        ok_fwd, r_fwd, a_fwd = self._reachable(cand.first, cand.second)
+        if ok_fwd:
+            return HBResult(ordered=True, reason=r_fwd, sync_addr=a_fwd)
+        ok_bwd, r_bwd, a_bwd = self._reachable(cand.second, cand.first)
+        if ok_bwd:
+            return HBResult(ordered=True, reason=r_bwd, sync_addr=a_bwd)
+        return HBResult(ordered=False)

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -1,5 +1,3 @@
-import threading
-from collections import defaultdict, deque
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
@@ -11,6 +9,7 @@ from typing import (
 
 import numpy as np
 from z3.z3 import BoolRef
+from triton.runtime.interpreter import TensorHandle, interpreter_builder
 
 from ...core.client import Client
 from ...core.callbacks import OpCallbacks, ForLoopCallbacks
@@ -20,6 +19,7 @@ from ...core.data import (
     AtomicCas,
     AtomicRMW,
 )
+from ...frontends.base import OPERATION_REGISTRY
 from ..symbolic_engine import (
     SymbolicExpr,
     SymbolicClient,
@@ -32,13 +32,13 @@ from ..symbolic_engine import (
 )
 from .data import (
     AccessEventRecord,
-    PendingAtomicEvent,
     VALID_RMW_OPS,
     active_mask_for,
     apply_rmw,
     broadcast_lane_operand,
     flatten_np,
     infer_elem_size,
+    maybe_concretize,
     normalize_sem_scope,
     resolve_tensor_from_pointer,
 )
@@ -107,6 +107,21 @@ class PendingEvent(PendingCheck):
     op_type: type[Op] = Load
 
 
+def _wrap_atomic_old_as_symbolic(old_handle: TensorHandle) -> SymbolicExpr:
+    """Wrap the concrete ``old`` TensorHandle returned by a real atomic in
+    a ``const`` SymbolicExpr so downstream code sees a SymbolicExpr-like
+    object (matching what the rest of the symbolic pipeline produces) while
+    still being able to ``concretize()`` back to the hardware result.
+
+    ``ConstSymbolicExpr.concretize()`` returns the wrapped ``TensorHandle``
+    directly, and ``SymbolicExpr.concrete_fn`` is a writable class
+    attribute — ``PatchOp.__call__`` (``core/patch.py:L221``) assigns it
+    after the overrider returns. That satisfies the ``interpreter_builder``
+    branch's contract with no extra wrapping.
+    """
+    return SymbolicExpr.create("const", old_handle, old_handle.dtype)
+
+
 class RaceDetector(Client):
     """Factory class that returns the concrete race-detector implementation
     based on the value of ``cfg.enable_race_detector``.
@@ -170,18 +185,12 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # Step 1 symbolic path
         self.symbolic_events: list[AccessEventRecord] = []
         # ``records`` is Step 1's historical name — kept as an alias for the
-        # symbolic path so pre-existing tests (test_race_detector.py) keep
-        # working. Commit 2 adds the sibling ``concrete_events`` list for
-        # the atomic path.
+        # symbolic path so pre-existing tests keep working.
         self.records = self.symbolic_events
         self._next_event_id = 0
 
-        # PR2 concrete atomic path
+        # Concrete atomic + plain event path
         self.concrete_events: list[AccessEventRecord] = []
-        self._pending_atomic_by_grid: defaultdict[
-            tuple[int, ...], deque[PendingAtomicEvent]
-        ] = defaultdict(deque)
-        self._pending_atomic_lock = threading.Lock()
 
         # Tripped by any atomic capture. Step 4/5 consumers must fall back
         # to concrete-only reasoning (or conservatively not suppress) when
@@ -190,11 +199,22 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # after the launch completes must still see True.
         self.atomic_symbolic_escape: bool = False
 
+        # Cache the un-patched atomic ops so the overrider below can execute
+        # the real hardware atomic on concrete inputs without re-entering
+        # ``PatchOp`` (which would loop back into ourselves).
+        triton_frontend = OPERATION_REGISTRY["triton"]
+        self._original_atomic_cas = triton_frontend.original_ops[interpreter_builder][
+            "create_atomic_cas"
+        ]
+        self._original_atomic_rmw = triton_frontend.original_ops[interpreter_builder][
+            "create_atomic_rmw"
+        ]
+
     def _new_event_id(self) -> int:
         """Client-lifetime monotonic unique ID. NOT an execution-order
         indicator under multi-SM concurrency — blocks race to append, so
         append order != execution order. Consumers that need execution
-        order must key on grid_idx + queue position, not event_id."""
+        order must key on grid_idx + program_seq, not event_id."""
         eid = self._next_event_id
         self._next_event_id += 1
         return eid
@@ -211,14 +231,6 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # Step 4/5 consumers inspect the detector right after the launch
         # completes and must still see True. The flag is reset at the
         # next launch's grid_callback.
-        with self._pending_atomic_lock:
-            dangling = {k: len(v) for k, v in self._pending_atomic_by_grid.items() if v}
-            self._pending_atomic_by_grid.clear()
-        if dangling:
-            raise RuntimeError(
-                f"Dangling pending atomic events at finalize: {dangling}. "
-                "A before_atomic_* callback enqueued without a matching after_*."
-            )
         return SymbolicClient.finalize(self)
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
@@ -228,26 +240,17 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         SymbolicClient.arg_callback(self, name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int, ...]) -> None:
-        # Per-launch reset BEFORE the base sets up its solver/premises.
-        # Defensive clear in case a prior launch errored out of finalize()
-        # mid-assertion.
         self.atomic_symbolic_escape = False
-        with self._pending_atomic_lock:
-            self._pending_atomic_by_grid.clear()
         SymbolicClient.grid_callback(self, grid)
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
         if op_type is AtomicCas:
             return OpCallbacks(
-                before_callback=self.lock_fn(self._before_atomic_cas),
-                after_callback=self.lock_fn(self._after_atomic_cas),
-                op_overrider=None,  # required — PatchOp feeds overrider ret to after
+                op_overrider=self.lock_fn(self._op_atomic_cas_overrider),
             )
         if op_type is AtomicRMW:
             return OpCallbacks(
-                before_callback=self.lock_fn(self._before_atomic_rmw),
-                after_callback=self.lock_fn(self._after_atomic_rmw),
-                op_overrider=None,
+                op_overrider=self.lock_fn(self._op_atomic_rmw_overrider),
             )
         return SymbolicClient.register_op_callback(self, op_type)
 
@@ -257,7 +260,7 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
     def post_run_callback(self, fn: Callable) -> bool:
         return SymbolicClient.post_run_callback(self, fn)
 
-    # ── Event recording ───────────────────────────────────────────────────
+    # ── Event recording (symbolic) ────────────────────────────────────────
 
     def _emit_symbolic_event(
         self,
@@ -372,188 +375,135 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
             pending.source_location,
         )
 
-    # ── Concrete atomic capture (before/after callback pairs) ────────────
+    # ── Concrete atomic capture (concretize-and-execute overriders) ───────
     #
-    # PatchOp.__call__ runs before_callback → (overrider | original op) →
-    # after_callback. We register op_overrider=None so the original hardware
-    # atomic runs; after_callback then sees the real ``old`` value from the
-    # op's return. An overrider here would feed its (symbolic) return into
-    # after_callback, and we'd lose the hardware old.
-    #
-    # Side effect: the symbolic overrider for atomic_cas/atomic_rmw (defined
-    # on SymbolicClient) is bypassed for race_detector, so any post-atomic
-    # code that uses the atomic's return value to compute addresses/masks/
-    # control flow loses symbolic fidelity past that point. We track this
-    # via ``atomic_symbolic_escape`` — Step 4/5 consumers must gate on it.
+    # Each atomic overrider runs in PatchOp's interpreter_builder branch.
+    # Order of operations:
+    #   1. Concretize inputs (``maybe_concretize`` — no-op on already
+    #      concrete TensorHandles, walks the symbolic tree otherwise).
+    #   2. Build per-lane concrete address / mask / element-size metadata
+    #      from the concrete inputs.
+    #   3. Call the real ``interpreter_builder.create_atomic_*`` captured at
+    #      init time — this actually writes memory and returns a TensorHandle
+    #      carrying the hardware ``old``.
+    #   4. Compute the effect-model (read_mask / write_mask / written_value)
+    #      and append an AccessEventRecord to ``concrete_events``.
+    #   5. Return a ``const`` SymbolicExpr wrapping the TensorHandle so
+    #      downstream symbolic consumers keep working; PatchOp's
+    #      interpreter_builder branch then assigns ``.concrete_fn = self.op``
+    #      which makes a later ``concretize()`` on this node return the
+    #      cached old value without re-executing the atomic.
 
-    def _before_atomic_cas(
-        self,
-        ptr,
-        cmp,
-        val,
-        sem=None,
-        scope=None,
-        mask=None,
-        **_kwargs,
-    ) -> None:
+    def _op_atomic_cas_overrider(self, ptr, cmp, val, sem, scope):
         self.atomic_symbolic_escape = True
         grid_idx = self.grid_idx
-        assert grid_idx is not None, "atomic callback fired before grid_idx_callback"
-        lane_addrs = flatten_np(ptr).astype(np.int64, copy=False)
-        nlanes = lane_addrs.shape[0]
-        cmp_np = broadcast_lane_operand(cmp, nlanes)
-        val_np = broadcast_lane_operand(val, nlanes)
-        active = active_mask_for(mask, nlanes)
-        sem_norm, scope_norm = normalize_sem_scope(sem, scope)
-        elem_size = infer_elem_size(val, ptr)
-        tensor = resolve_tensor_from_pointer(ptr, active, elem_size, self.tensor_addrs)
-        pending = PendingAtomicEvent(
-            event_id=self._new_event_id(),
-            op_type=AtomicCas,
-            atomic_op="cas",
-            grid_idx=grid_idx,
-            source_location=capture_current_source_location(),
-            tensor=tensor,
-            tensor_name=(self._get_tensor_name(tensor) if tensor is not None else None),
-            lane_addrs=lane_addrs,
-            active_mask=active,
-            elem_size=elem_size,
-            atomic_sem=sem_norm,
-            atomic_scope=scope_norm,
-            atomic_cmp=cmp_np,
-            atomic_val=val_np,
-        )
-        with self._pending_atomic_lock:
-            self._pending_atomic_by_grid[grid_idx].append(pending)
+        assert grid_idx is not None, "atomic overrider fired before grid_idx_callback"
 
-    def _after_atomic_cas(
-        self,
-        ret,
-        ptr,
-        cmp,
-        val,
-        sem=None,
-        scope=None,
-        mask=None,
-        **_kwargs,
-    ) -> None:
-        del ptr, cmp, val, sem, scope, mask  # all already snapshotted in pending
-        grid_idx = self.grid_idx
-        assert grid_idx is not None, "atomic callback fired before grid_idx_callback"
-        with self._pending_atomic_lock:
-            pending = self._pending_atomic_by_grid[grid_idx].popleft()
-        old_np = flatten_np(ret)
-        success = pending.active_mask & np.equal(old_np, pending.atomic_cmp)
-        read_mask = pending.active_mask.copy()
+        c_ptr = maybe_concretize(ptr)
+        c_cmp = maybe_concretize(cmp)
+        c_val = maybe_concretize(val)
+
+        lane_addrs = flatten_np(c_ptr).astype(np.int64, copy=False)
+        nlanes = lane_addrs.shape[0]
+        cmp_np = broadcast_lane_operand(c_cmp, nlanes)
+        val_np = broadcast_lane_operand(c_val, nlanes)
+        active = active_mask_for(None, nlanes)  # CAS has no mask parameter
+        sem_norm, scope_norm = normalize_sem_scope(sem, scope)
+        elem_size = infer_elem_size(c_val, c_ptr)
+        tensor = resolve_tensor_from_pointer(
+            c_ptr, active, elem_size, self.tensor_addrs
+        )
+
+        ret_handle = self._original_atomic_cas(c_ptr, c_cmp, c_val, sem, scope)
+        old_np = flatten_np(ret_handle)
+
+        success = active & np.equal(old_np, cmp_np)
+        read_mask = active.copy()
         write_mask = success
-        written_value = np.where(success, pending.atomic_val, old_np).astype(
+        written_value = np.where(success, val_np, old_np).astype(
             old_np.dtype, copy=False
         )
+
         self.concrete_events.append(
             AccessEventRecord(
-                event_id=pending.event_id,
-                op_type=pending.op_type,
-                source_location=pending.source_location,
-                grid_idx=pending.grid_idx,
-                tensor=pending.tensor,
-                tensor_name=pending.tensor_name,
-                lane_addrs=pending.lane_addrs,
-                active_mask=pending.active_mask,
-                elem_size=pending.elem_size,
+                event_id=self._new_event_id(),
+                op_type=AtomicCas,
+                source_location=capture_current_source_location(),
+                grid_idx=grid_idx,
+                tensor=tensor,
+                tensor_name=(
+                    self._get_tensor_name(tensor) if tensor is not None else None
+                ),
+                lane_addrs=lane_addrs,
+                active_mask=active,
+                elem_size=elem_size,
                 read_mask=read_mask,
                 write_mask=write_mask,
                 atomic_op="cas",
-                atomic_sem=pending.atomic_sem,
-                atomic_scope=pending.atomic_scope,
-                atomic_cmp=pending.atomic_cmp,
-                atomic_val=pending.atomic_val,
+                atomic_sem=sem_norm,
+                atomic_scope=scope_norm,
+                atomic_cmp=cmp_np,
+                atomic_val=val_np,
                 atomic_old=old_np,
                 written_value=written_value,
             )
         )
 
-    def _before_atomic_rmw(
-        self,
-        rmwOp,
-        ptr,
-        val,
-        mask=None,
-        sem=None,
-        scope=None,
-        **_kwargs,
-    ) -> None:
+        return _wrap_atomic_old_as_symbolic(ret_handle)
+
+    def _op_atomic_rmw_overrider(self, rmwOp, ptr, val, mask, sem, scope):
         self.atomic_symbolic_escape = True
         grid_idx = self.grid_idx
-        assert grid_idx is not None, "atomic callback fired before grid_idx_callback"
-        atomic_op = _normalize_rmw_op(rmwOp)
-        lane_addrs = flatten_np(ptr).astype(np.int64, copy=False)
-        nlanes = lane_addrs.shape[0]
-        val_np = broadcast_lane_operand(val, nlanes)
-        active = active_mask_for(mask, nlanes)
-        sem_norm, scope_norm = normalize_sem_scope(sem, scope)
-        elem_size = infer_elem_size(val, ptr)
-        tensor = resolve_tensor_from_pointer(ptr, active, elem_size, self.tensor_addrs)
-        pending = PendingAtomicEvent(
-            event_id=self._new_event_id(),
-            op_type=AtomicRMW,
-            atomic_op=atomic_op,
-            grid_idx=grid_idx,
-            source_location=capture_current_source_location(),
-            tensor=tensor,
-            tensor_name=(self._get_tensor_name(tensor) if tensor is not None else None),
-            lane_addrs=lane_addrs,
-            active_mask=active,
-            elem_size=elem_size,
-            atomic_sem=sem_norm,
-            atomic_scope=scope_norm,
-            atomic_cmp=None,
-            atomic_val=val_np,
-        )
-        with self._pending_atomic_lock:
-            self._pending_atomic_by_grid[grid_idx].append(pending)
+        assert grid_idx is not None, "atomic overrider fired before grid_idx_callback"
 
-    def _after_atomic_rmw(
-        self,
-        ret,
-        rmwOp,
-        ptr,
-        val,
-        mask=None,
-        sem=None,
-        scope=None,
-        **_kwargs,
-    ) -> None:
-        del rmwOp, ptr, val, mask, sem, scope  # already snapshotted in pending
-        grid_idx = self.grid_idx
-        assert grid_idx is not None, "atomic callback fired before grid_idx_callback"
-        with self._pending_atomic_lock:
-            pending = self._pending_atomic_by_grid[grid_idx].popleft()
-        old_np = flatten_np(ret)
-        read_mask = pending.active_mask.copy()
-        write_mask = pending.active_mask.copy()
-        written_value = apply_rmw(pending.atomic_op, old_np, pending.atomic_val)
+        atomic_op = _normalize_rmw_op(rmwOp)
+        c_ptr = maybe_concretize(ptr)
+        c_val = maybe_concretize(val)
+        c_mask = maybe_concretize(mask)
+
+        lane_addrs = flatten_np(c_ptr).astype(np.int64, copy=False)
+        nlanes = lane_addrs.shape[0]
+        val_np = broadcast_lane_operand(c_val, nlanes)
+        active = active_mask_for(c_mask, nlanes)
+        sem_norm, scope_norm = normalize_sem_scope(sem, scope)
+        elem_size = infer_elem_size(c_val, c_ptr)
+        tensor = resolve_tensor_from_pointer(
+            c_ptr, active, elem_size, self.tensor_addrs
+        )
+
+        ret_handle = self._original_atomic_rmw(rmwOp, c_ptr, c_val, c_mask, sem, scope)
+        old_np = flatten_np(ret_handle)
+
+        read_mask = active.copy()
+        write_mask = active.copy()
+        written_value = apply_rmw(atomic_op, old_np, val_np)
+
         self.concrete_events.append(
             AccessEventRecord(
-                event_id=pending.event_id,
-                op_type=pending.op_type,
-                source_location=pending.source_location,
-                grid_idx=pending.grid_idx,
-                tensor=pending.tensor,
-                tensor_name=pending.tensor_name,
-                lane_addrs=pending.lane_addrs,
-                active_mask=pending.active_mask,
-                elem_size=pending.elem_size,
+                event_id=self._new_event_id(),
+                op_type=AtomicRMW,
+                source_location=capture_current_source_location(),
+                grid_idx=grid_idx,
+                tensor=tensor,
+                tensor_name=(
+                    self._get_tensor_name(tensor) if tensor is not None else None
+                ),
+                lane_addrs=lane_addrs,
+                active_mask=active,
+                elem_size=elem_size,
                 read_mask=read_mask,
                 write_mask=write_mask,
-                atomic_op=pending.atomic_op,
-                atomic_sem=pending.atomic_sem,
-                atomic_scope=pending.atomic_scope,
+                atomic_op=atomic_op,
+                atomic_sem=sem_norm,
+                atomic_scope=scope_norm,
                 atomic_cmp=None,
-                atomic_val=pending.atomic_val,
+                atomic_val=val_np,
                 atomic_old=old_np,
                 written_value=written_value,
             )
         )
+
+        return _wrap_atomic_old_as_symbolic(ret_handle)
 
 
 class NullRaceDetector(NullSymbolicClient, RaceDetector):

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -1,3 +1,4 @@
+from collections import defaultdict
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import (
@@ -16,6 +17,9 @@ from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import (
     Op,
     Load,
+    RawLoad,
+    Store,
+    RawStore,
     AtomicCas,
     AtomicRMW,
 )
@@ -199,6 +203,23 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # after the launch completes must still see True.
         self.atomic_symbolic_escape: bool = False
 
+        # Per-launch state. ``concrete_events`` / ``symbolic_events`` stay
+        # client-lifetime accumulations (preserves pre-PR3 test style); race
+        # detection slices from these ``*_start`` indices each launch.
+        self._launch_symbolic_start: int = 0
+        self._launch_concrete_start: int = 0
+        self._launch_id: int = 0
+
+        # Per-grid_idx program-order counter. event_id is a unique monotonic
+        # id, but under ``num_sms > 1`` blocks race to append so append order
+        # is not program order — ``po`` must key on ``(grid_idx, program_seq)``.
+        self._program_seq_by_grid: defaultdict[tuple[int, ...], int] = defaultdict(int)
+
+        # Stubs populated by the Step 4/5/6 pipeline (wired in commits 3–4).
+        self._last_candidates: list = []
+        self._last_reports: list = []
+        self._last_barrier_addrs: set[int] = set()
+
         # Cache the un-patched atomic ops so the overrider below can execute
         # the real hardware atomic on concrete inputs without re-entering
         # ``PatchOp`` (which would loop back into ourselves).
@@ -209,6 +230,16 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         self._original_atomic_rmw = triton_frontend.original_ops[interpreter_builder][
             "create_atomic_rmw"
         ]
+
+    def _next_program_seq(self, grid_idx: tuple[int, ...]) -> int:
+        """Allocate the next program-order index for ``grid_idx`` within
+        the current launch. Both the atomic overriders and the plain
+        load/store before-callbacks MUST call this when emitting concrete
+        events — po, epoch partitioning, and same-value-ambiguity checks
+        all depend on it."""
+        n = self._program_seq_by_grid[grid_idx]
+        self._program_seq_by_grid[grid_idx] = n + 1
+        return n
 
     def _new_event_id(self) -> int:
         """Client-lifetime monotonic unique ID. NOT an execution-order
@@ -240,7 +271,19 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         SymbolicClient.arg_callback(self, name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int, ...]) -> None:
+        # Per-launch reset. ``symbolic_events`` / ``concrete_events`` stay
+        # client-lifetime; the race pipeline slices from these start
+        # indices. ``atomic_symbolic_escape`` is reset HERE, not in
+        # ``finalize()``, so consumers inspecting the detector immediately
+        # after a launch ends still see True.
         self.atomic_symbolic_escape = False
+        self._launch_id += 1
+        self._launch_symbolic_start = len(self.symbolic_events)
+        self._launch_concrete_start = len(self.concrete_events)
+        self._program_seq_by_grid.clear()
+        self._last_candidates = []
+        self._last_reports = []
+        self._last_barrier_addrs = set()
         SymbolicClient.grid_callback(self, grid)
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
@@ -251,6 +294,39 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         if op_type is AtomicRMW:
             return OpCallbacks(
                 op_overrider=self.lock_fn(self._op_atomic_rmw_overrider),
+            )
+        # Plain load/store: stack a concrete before-callback on top of the
+        # symbolic overrider SymbolicClient provides. The before-callback
+        # records a concrete event (lane addresses, active mask, read/write
+        # effect) alongside the symbolic path that keeps producing
+        # SymbolicExpr nodes for downstream analysis.
+        if op_type is Load:
+            base = SymbolicClient.register_op_callback(self, op_type)
+            return OpCallbacks(
+                before_callback=self.lock_fn(self._before_load_concrete),
+                after_callback=base.after_callback,
+                op_overrider=base.op_overrider,
+            )
+        if op_type is RawLoad:
+            base = SymbolicClient.register_op_callback(self, op_type)
+            return OpCallbacks(
+                before_callback=self.lock_fn(self._before_raw_load_concrete),
+                after_callback=base.after_callback,
+                op_overrider=base.op_overrider,
+            )
+        if op_type is Store:
+            base = SymbolicClient.register_op_callback(self, op_type)
+            return OpCallbacks(
+                before_callback=self.lock_fn(self._before_store_concrete),
+                after_callback=base.after_callback,
+                op_overrider=base.op_overrider,
+            )
+        if op_type is RawStore:
+            base = SymbolicClient.register_op_callback(self, op_type)
+            return OpCallbacks(
+                before_callback=self.lock_fn(self._before_raw_store_concrete),
+                after_callback=base.after_callback,
+                op_overrider=base.op_overrider,
             )
         return SymbolicClient.register_op_callback(self, op_type)
 
@@ -446,6 +522,8 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                 atomic_val=val_np,
                 atomic_old=old_np,
                 written_value=written_value,
+                program_seq=self._next_program_seq(grid_idx),
+                launch_id=self._launch_id,
             )
         )
 
@@ -500,10 +578,129 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                 atomic_val=val_np,
                 atomic_old=old_np,
                 written_value=written_value,
+                program_seq=self._next_program_seq(grid_idx),
+                launch_id=self._launch_id,
             )
         )
 
         return _wrap_atomic_old_as_symbolic(ret_handle)
+
+    # ── Concrete plain load / store capture ───────────────────────────────
+    #
+    # Stacked on top of SymbolicClient's symbolic overrider, so the
+    # symbolic pipeline keeps producing SymbolicExpr nodes for Step 1
+    # analysis while the race pipeline gets the concrete lane geometry it
+    # needs. Order in PatchOp.__call__: before → overrider → after.
+    # TensorPointerLoad / TensorPointerStore are NOT captured here — block
+    # pointer element-address extraction is deferred.
+
+    def _before_load_concrete(
+        self,
+        ptr,
+        mask=None,
+        other=None,
+        cache_modifier=None,
+        eviction_policy=None,
+        is_volatile=None,
+    ) -> None:
+        del other, cache_modifier, eviction_policy, is_volatile
+        self._emit_concrete_plain_event(Load, "read", ptr, mask=mask, value=None)
+
+    def _before_raw_load_concrete(
+        self,
+        ptr,
+        cache_modifier=None,
+        eviction_policy=None,
+        is_volatile=None,
+    ) -> None:
+        del cache_modifier, eviction_policy, is_volatile
+        self._emit_concrete_plain_event(RawLoad, "read", ptr, mask=None, value=None)
+
+    def _before_store_concrete(
+        self,
+        ptr,
+        value,
+        mask=None,
+        cache_modifier=None,
+        eviction_policy=None,
+    ) -> None:
+        del cache_modifier, eviction_policy
+        self._emit_concrete_plain_event(Store, "write", ptr, mask=mask, value=value)
+
+    def _before_raw_store_concrete(
+        self,
+        ptr,
+        value,
+        cache_modifier=None,
+        eviction_policy=None,
+    ) -> None:
+        del cache_modifier, eviction_policy
+        self._emit_concrete_plain_event(RawStore, "write", ptr, mask=None, value=value)
+
+    def _emit_concrete_plain_event(
+        self,
+        op_type: type[Op],
+        access_mode: str,  # "read" | "write"
+        ptr: Any,
+        mask: Any = None,
+        value: Any = None,
+    ) -> None:
+        grid_idx = self.grid_idx
+        if grid_idx is None:
+            # Defensive: a plain load/store firing before grid_idx_callback
+            # would mean a client dispatch happened outside the normal
+            # launch lifecycle. Skip rather than crash.
+            return
+
+        c_ptr = maybe_concretize(ptr)
+        c_mask = maybe_concretize(mask)
+        c_value = maybe_concretize(value) if value is not None else None
+
+        try:
+            lane_addrs = flatten_np(c_ptr).astype(np.int64, copy=False)
+        except Exception:
+            # Non-pointer shapes the interpreter handles via symbolic-only
+            # paths — skip concrete capture rather than raise.
+            return
+        nlanes = lane_addrs.shape[0]
+        if nlanes == 0:
+            return
+
+        active = active_mask_for(c_mask, nlanes)
+        try:
+            elem_size = infer_elem_size(c_value, c_ptr)
+        except ValueError:
+            return
+        tensor = resolve_tensor_from_pointer(
+            c_ptr, active, elem_size, self.tensor_addrs
+        )
+
+        if access_mode == "read":
+            read_mask = active.copy()
+            write_mask = np.zeros_like(active)
+        else:
+            read_mask = np.zeros_like(active)
+            write_mask = active.copy()
+
+        self.concrete_events.append(
+            AccessEventRecord(
+                event_id=self._new_event_id(),
+                op_type=op_type,
+                source_location=capture_current_source_location(),
+                grid_idx=grid_idx,
+                tensor=tensor,
+                tensor_name=(
+                    self._get_tensor_name(tensor) if tensor is not None else None
+                ),
+                lane_addrs=lane_addrs,
+                active_mask=active,
+                elem_size=elem_size,
+                read_mask=read_mask,
+                write_mask=write_mask,
+                program_seq=self._next_program_seq(grid_idx),
+                launch_id=self._launch_id,
+            )
+        )
 
 
 class NullRaceDetector(NullSymbolicClient, RaceDetector):

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -224,14 +224,25 @@ def _is_barrier_atomic(event: AccessEventRecord) -> bool:
     return True
 
 
+_PHASE_ADVANCE_WRITER_SEMS: frozenset[str] = frozenset({"release", "acq_rel"})
+
+
 def _is_phase_advancing_write(event: AccessEventRecord, elem_base: int) -> bool:
-    """Did ``event`` change the value at ``elem_base``? Failed CAS
-    (``old != cmp`` path → written_value == old), ``cas(1, 1)`` polling,
-    and ``atomic_add(0)`` all return False — they touch the barrier
-    address but do not advance the phase, so they must not split epochs
-    (upstream #350 same-value ambiguity, consistent with the HB solver's
-    ``_has_ambiguous_writer``).
+    """Did ``event`` move the barrier forward? Must satisfy three things:
+
+    1. ``event.atomic_sem`` is ``release`` or ``acq_rel`` — an acquire-
+       only write that happens to change the value is consumption, not
+       phase advancement; counting it would split epochs even when the
+       producer's release never synchronized.
+    2. ``event`` actually writes the element (``write_mask`` has True
+       on a lane covering ``elem_base``).
+    3. ``written_value != atomic_old`` — failed CAS, ``cas(1, 1)``
+       polling, ``atomic_add(0)`` all have written == old, and must NOT
+       split epochs (upstream #350 same-value ambiguity, mirrored in
+       ``_has_ambiguous_writer``).
     """
+    if event.atomic_sem not in _PHASE_ADVANCE_WRITER_SEMS:
+        return False
     if event.lane_addrs is None:
         return False
     active = (
@@ -242,7 +253,6 @@ def _is_phase_advancing_write(event: AccessEventRecord, elem_base: int) -> bool:
     hit_mask = active & (event.lane_addrs == elem_base)
     if not np.any(hit_mask):
         return False
-    # Must actually write this element's byte range.
     if event.write_mask is None:
         return False
     if not np.any(event.write_mask[hit_mask]):

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -50,6 +50,7 @@ from .data import (
     normalize_sem_scope,
     resolve_tensor_from_pointer,
 )
+from .hb_solver import HBSolver
 from ...utils.traceback_utils import capture_current_source_location
 from ...core.config import config as cfg
 
@@ -172,6 +173,85 @@ def _canonical_pair(
         )
 
     return (a, b) if _key(a) <= _key(b) else (b, a)
+
+
+_BARRIER_ATOMIC_OPS: frozenset[str] = frozenset({"add", "cas", "xchg"})
+_BARRIER_VALID_SCOPES: frozenset[str | None] = frozenset({"gpu", "sys", None})
+
+
+def _iter_element_bases(event: AccessEventRecord):
+    """Per-active-lane element base addresses — mirrors ``hb_solver._iter_element_bases``.
+
+    Duplicated here (rather than imported) to keep module layering simple:
+    race_detector.py already imports HBSolver, but this helper is used by
+    the barrier/epoch driver which shouldn't cross-depend on the solver
+    module's internals.
+    """
+    if event.lane_addrs is None:
+        return
+    active = (
+        event.active_mask
+        if event.active_mask is not None
+        else np.ones_like(event.lane_addrs, dtype=bool)
+    )
+    for idx, hit in enumerate(active):
+        if not hit:
+            continue
+        yield int(event.lane_addrs[idx])
+
+
+def _is_barrier_atomic(event: AccessEventRecord) -> bool:
+    """Identifies *candidate* barrier atomics — addresses to consider as a
+    global phase counter / flag. Not a phase-advance check; don't exclude
+    ``relaxed`` here. The phase-advance gate is ``_is_phase_advancing_write``.
+    """
+    if event.atomic_op not in _BARRIER_ATOMIC_OPS:
+        return False
+    if event.atomic_scope not in _BARRIER_VALID_SCOPES:
+        return False
+    # Needs at least one active lane that reads or writes.
+    active = (
+        event.active_mask
+        if event.active_mask is not None
+        else (
+            np.ones_like(event.lane_addrs, dtype=bool)
+            if event.lane_addrs is not None
+            else None
+        )
+    )
+    if active is None or not np.any(active):
+        return False
+    return True
+
+
+def _is_phase_advancing_write(event: AccessEventRecord, elem_base: int) -> bool:
+    """Did ``event`` change the value at ``elem_base``? Failed CAS
+    (``old != cmp`` path → written_value == old), ``cas(1, 1)`` polling,
+    and ``atomic_add(0)`` all return False — they touch the barrier
+    address but do not advance the phase, so they must not split epochs
+    (upstream #350 same-value ambiguity, consistent with the HB solver's
+    ``_has_ambiguous_writer``).
+    """
+    if event.lane_addrs is None:
+        return False
+    active = (
+        event.active_mask
+        if event.active_mask is not None
+        else np.ones_like(event.lane_addrs, dtype=bool)
+    )
+    hit_mask = active & (event.lane_addrs == elem_base)
+    if not np.any(hit_mask):
+        return False
+    # Must actually write this element's byte range.
+    if event.write_mask is None:
+        return False
+    if not np.any(event.write_mask[hit_mask]):
+        return False
+    if event.atomic_old is None or event.written_value is None:
+        return False
+    old = event.atomic_old[hit_mask]
+    new = event.written_value[hit_mask]
+    return bool(np.any(new != old))
 
 
 def _classify_candidate(
@@ -343,16 +423,41 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         if not launch_events:
             self._last_candidates = []
             self._last_reports = []
+            self._last_barrier_addrs = set()
             return []
 
+        # Step 6: coarse epoch partitioning on phase-advancing barrier writes.
+        total_blocks = 1
+        if self.grid is not None:
+            total_blocks = int(self.grid[0]) * int(self.grid[1]) * int(self.grid[2])
+        barrier_addrs = self._detect_global_barrier_addresses(
+            launch_events, total_blocks
+        )
+        self._assign_concrete_epochs(launch_events, barrier_addrs)
+
+        # Step 4: byte-bucket candidate pairing (now respects per-event epoch).
         candidates = self._find_race_candidates(launch_events)
-        # Step 5 (HBSolver) lands in the next commit. Until then emit every
-        # candidate as an unsuppressed report so the candidate pipeline is
-        # observable end-to-end.
-        reports = [self._candidate_to_report(c) for c in candidates]
+
+        # Step 5: one HBSolver per epoch; drop candidates that po | sw orders.
+        epochs: dict[int, list[AccessEventRecord]] = {}
+        for ev in launch_events:
+            epochs.setdefault(ev.epoch, []).append(ev)
+        solvers = {epoch: HBSolver(evs) for epoch, evs in epochs.items()}
+
+        reports: list[RaceReport] = []
+        for cand in candidates:
+            solver = solvers.get(cand.epoch)
+            if solver is None:
+                reports.append(self._candidate_to_report(cand))
+                continue
+            hb = solver.check_candidate(cand)
+            if hb.ordered:
+                continue
+            reports.append(self._candidate_to_report(cand, hb_reason=hb.reason))
 
         self._last_candidates = candidates
         self._last_reports = reports
+        self._last_barrier_addrs = barrier_addrs
         return reports
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
@@ -836,6 +941,79 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                         )
                     )
         return candidates
+
+    # ── Barrier detection & epoch partitioning (Step 6) ───────────────────
+
+    def _detect_global_barrier_addresses(
+        self, events: list[AccessEventRecord], total_blocks: int
+    ) -> set[int]:
+        """Return element base addresses that qualify as global barrier keys.
+
+        Conservative — an address qualifies only when:
+          * every event on it passes ``_is_barrier_atomic``;
+          * the set of distinct ``grid_idx`` hitting it equals
+            ``total_blocks`` (every block participates);
+          * ``total_blocks >= 2``.
+
+        Over-identifying barrier keys splits phases wrongly and drops real
+        races, so the bar is high — a single non-barrier atomic on the
+        same address disqualifies it.
+        """
+        if total_blocks < 2:
+            return set()
+        # atomic_events_by_addr[addr] = (grids, all_barrier)
+        by_addr: dict[int, tuple[set, bool]] = {}
+        for ev in events:
+            if ev.atomic_op is None or ev.grid_idx is None:
+                continue
+            is_barrier = _is_barrier_atomic(ev)
+            for base in _iter_element_bases(ev):
+                grids, all_barrier = by_addr.get(base, (set(), True))
+                grids.add(ev.grid_idx)
+                all_barrier = all_barrier and is_barrier
+                by_addr[base] = (grids, all_barrier)
+        result: set[int] = set()
+        for addr, (grids, all_barrier) in by_addr.items():
+            if all_barrier and len(grids) == total_blocks:
+                result.add(addr)
+        return result
+
+    def _assign_concrete_epochs(
+        self, events: list[AccessEventRecord], barrier_addrs: set[int]
+    ) -> None:
+        """Walk each grid_idx in program_seq order, bumping the epoch when
+        the current event is a phase-advancing write on a barrier address.
+
+        The barrier event itself stays in the pre-barrier epoch;
+        subsequent events in the same grid get the next epoch. If no
+        barrier addresses were identified, every event stays in epoch 0.
+        """
+        if not barrier_addrs:
+            for ev in events:
+                ev.epoch = 0
+            return
+
+        by_grid: dict[Any, list[AccessEventRecord]] = {}
+        for ev in events:
+            by_grid.setdefault(ev.grid_idx, []).append(ev)
+
+        for grid_events in by_grid.values():
+            grid_events.sort(
+                key=lambda e: (
+                    e.program_seq if e.program_seq is not None else -1,
+                    e.event_id,
+                )
+            )
+            epoch = 0
+            for ev in grid_events:
+                ev.epoch = epoch
+                # Check every active element base of this event.
+                for base in _iter_element_bases(ev):
+                    if base not in barrier_addrs:
+                        continue
+                    if _is_phase_advancing_write(ev, base):
+                        epoch += 1
+                        break
 
     def _candidate_to_report(
         self, cand: RaceCandidate, hb_reason: str | None = None

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -36,10 +36,14 @@ from ..symbolic_engine import (
 )
 from .data import (
     AccessEventRecord,
+    RaceCandidate,
+    RaceReport,
+    RaceType,
     VALID_RMW_OPS,
     active_mask_for,
     apply_rmw,
     broadcast_lane_operand,
+    effects_at_addr,
     flatten_np,
     infer_elem_size,
     maybe_concretize,
@@ -124,6 +128,73 @@ def _wrap_atomic_old_as_symbolic(old_handle: TensorHandle) -> SymbolicExpr:
     branch's contract with no extra wrapping.
     """
     return SymbolicExpr.create("const", old_handle, old_handle.dtype)
+
+
+def _iter_event_bytes(event: AccessEventRecord):
+    """Yield every byte address covered by an active lane of ``event``.
+
+    Byte granularity matches ``effects_at_addr`` (upstream #344 fix):
+    single-lane-only would miss multi-lane writes to the same element.
+    Iteration is per-active-lane because hits are aggregated via
+    ``np.any`` over every lane covering a given byte.
+    """
+    if event.lane_addrs is None or event.elem_size is None:
+        return
+    active = (
+        event.active_mask
+        if event.active_mask is not None
+        else np.ones_like(event.lane_addrs, dtype=bool)
+    )
+    elem_size = int(event.elem_size)
+    for idx, hit in enumerate(active):
+        if not hit:
+            continue
+        base = int(event.lane_addrs[idx])
+        for k in range(elem_size):
+            yield base + k
+
+
+def _canonical_pair(
+    a: AccessEventRecord, b: AccessEventRecord
+) -> tuple[AccessEventRecord, AccessEventRecord]:
+    """Order two conflicting events by ``(grid_idx, program_seq, event_id)``.
+
+    Fixing the direction here (a -> first, b -> second) is what lets Step 4
+    emit *directional* RAW vs. WAR — without a canonical order, upstream's
+    WAR enum stays dead code (#351).
+    """
+
+    def _key(e: AccessEventRecord) -> tuple:
+        return (
+            e.grid_idx if e.grid_idx is not None else (),
+            e.program_seq if e.program_seq is not None else -1,
+            e.event_id,
+        )
+
+    return (a, b) if _key(a) <= _key(b) else (b, a)
+
+
+def _classify_candidate(
+    first: AccessEventRecord,
+    second: AccessEventRecord,
+    byte_addr: int,
+) -> RaceType | None:
+    """Classify a concrete-event pair at ``byte_addr`` via the effect model.
+
+    The classification goes through ``effects_at_addr`` (not op-type
+    hardcoding) so plain load/store, CAS success/failure lanes, and RMW
+    events are all treated uniformly. Upstream #345 explicitly flagged
+    the op-type hardcoding as a correctness bug.
+    """
+    r1, w1 = effects_at_addr(first, byte_addr)
+    r2, w2 = effects_at_addr(second, byte_addr)
+    if w1 and w2:
+        return RaceType.WAW
+    if w1 and r2:
+        return RaceType.RAW
+    if r1 and w2:
+        return RaceType.WAR
+    return None
 
 
 class RaceDetector(Client):
@@ -262,7 +333,27 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # Step 4/5 consumers inspect the detector right after the launch
         # completes and must still see True. The flag is reset at the
         # next launch's grid_callback.
-        return SymbolicClient.finalize(self)
+        SymbolicClient.finalize(self)
+
+        launch_events = [
+            ev
+            for ev in self.concrete_events[self._launch_concrete_start :]
+            if not ev.legacy_atomic
+        ]
+        if not launch_events:
+            self._last_candidates = []
+            self._last_reports = []
+            return []
+
+        candidates = self._find_race_candidates(launch_events)
+        # Step 5 (HBSolver) lands in the next commit. Until then emit every
+        # candidate as an unsuppressed report so the candidate pipeline is
+        # observable end-to-end.
+        reports = [self._candidate_to_report(c) for c in candidates]
+
+        self._last_candidates = candidates
+        self._last_reports = reports
+        return reports
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
         return SymbolicClient.register_for_loop_callback(self)
@@ -331,10 +422,21 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         return SymbolicClient.register_op_callback(self, op_type)
 
     def pre_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.pre_run_callback(self, fn)
+        # Race detection fundamentally needs full-grid coverage — cross-block
+        # conflicts can't be reasoned about if blocks get skipped. Force
+        # every block to run; let SymbolicClient's pre_run still do its
+        # per-block setup.
+        SymbolicClient.pre_run_callback(self, fn)
+        return True
 
     def post_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.post_run_callback(self, fn)
+        # Same reasoning — PatchOp terminates the grid iteration when any
+        # client's post_run returns False (see ``core/patch.py:L488-507``).
+        # SymbolicClient returns False for non-data-dependent launches to
+        # skip redundant blocks; for the race detector every block is
+        # meaningful, so force True and let the base still clean caches.
+        SymbolicClient.post_run_callback(self, fn)
+        return True
 
     # ── Event recording (symbolic) ────────────────────────────────────────
 
@@ -594,47 +696,27 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
     # TensorPointerLoad / TensorPointerStore are NOT captured here — block
     # pointer element-address extraction is deferred.
 
-    def _before_load_concrete(
-        self,
-        ptr,
-        mask=None,
-        other=None,
-        cache_modifier=None,
-        eviction_policy=None,
-        is_volatile=None,
-    ) -> None:
-        del other, cache_modifier, eviction_policy, is_volatile
+    # Adapter-driven signatures (see ``frontends/triton.py``):
+    #   * ``_triton_load_adapter``      -> ``(ptr, mask, keys)``
+    #   * ``_triton_raw_load_adapter``  -> ``(ptr,)``
+    #   * ``_triton_store_adapter``     -> ``(ptr, mask, keys)`` — ``value`` is
+    #                                     stripped by design; elem_size falls
+    #                                     through ``ptr.dtype.element_ty`` in
+    #                                     ``_pointer_elem_size``.
+    #   * ``_triton_raw_store_adapter`` -> ``(ptr, value)``
+
+    def _before_load_concrete(self, ptr, mask=None, keys=None) -> None:
+        del keys
         self._emit_concrete_plain_event(Load, "read", ptr, mask=mask, value=None)
 
-    def _before_raw_load_concrete(
-        self,
-        ptr,
-        cache_modifier=None,
-        eviction_policy=None,
-        is_volatile=None,
-    ) -> None:
-        del cache_modifier, eviction_policy, is_volatile
+    def _before_raw_load_concrete(self, ptr) -> None:
         self._emit_concrete_plain_event(RawLoad, "read", ptr, mask=None, value=None)
 
-    def _before_store_concrete(
-        self,
-        ptr,
-        value,
-        mask=None,
-        cache_modifier=None,
-        eviction_policy=None,
-    ) -> None:
-        del cache_modifier, eviction_policy
-        self._emit_concrete_plain_event(Store, "write", ptr, mask=mask, value=value)
+    def _before_store_concrete(self, ptr, mask=None, keys=None) -> None:
+        del keys
+        self._emit_concrete_plain_event(Store, "write", ptr, mask=mask, value=None)
 
-    def _before_raw_store_concrete(
-        self,
-        ptr,
-        value,
-        cache_modifier=None,
-        eviction_policy=None,
-    ) -> None:
-        del cache_modifier, eviction_policy
+    def _before_raw_store_concrete(self, ptr, value) -> None:
         self._emit_concrete_plain_event(RawStore, "write", ptr, mask=None, value=value)
 
     def _emit_concrete_plain_event(
@@ -700,6 +782,77 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                 program_seq=self._next_program_seq(grid_idx),
                 launch_id=self._launch_id,
             )
+        )
+
+    # ── Candidate finder (Step 4) ─────────────────────────────────────────
+    #
+    # Bucket concrete events by ``(epoch, byte_addr)`` and pair everything
+    # in each bucket. Skip same-grid_idx pairs (intra-block is po-ordered,
+    # not PR3's target) and dedupe on ``(min(event_id), max(event_id))``
+    # so a multi-byte conflict between the same two events emits a single
+    # candidate, not ``elem_size`` copies.
+
+    def _find_race_candidates(
+        self, events: list[AccessEventRecord]
+    ) -> list[RaceCandidate]:
+        addr_buckets: dict[tuple[int, int], list[AccessEventRecord]] = {}
+        for ev in events:
+            for byte_addr in _iter_event_bytes(ev):
+                addr_buckets.setdefault((ev.epoch, byte_addr), []).append(ev)
+
+        candidates: list[RaceCandidate] = []
+        seen_pairs: set[tuple[int, int, int]] = set()
+
+        for (epoch, byte_addr), bucket in addr_buckets.items():
+            n = len(bucket)
+            for i in range(n):
+                ev_a = bucket[i]
+                for j in range(i + 1, n):
+                    ev_b = bucket[j]
+                    if ev_a is ev_b:
+                        continue
+                    if ev_a.grid_idx == ev_b.grid_idx:
+                        # Intra-block is po-ordered — not a race.
+                        continue
+                    key = (
+                        epoch,
+                        min(ev_a.event_id, ev_b.event_id),
+                        max(ev_a.event_id, ev_b.event_id),
+                    )
+                    if key in seen_pairs:
+                        continue
+                    first, second = _canonical_pair(ev_a, ev_b)
+                    race_type = _classify_candidate(first, second, byte_addr)
+                    if race_type is None:
+                        continue
+                    seen_pairs.add(key)
+                    candidates.append(
+                        RaceCandidate(
+                            first=first,
+                            second=second,
+                            race_type=race_type,
+                            witness_addr=byte_addr,
+                            epoch=epoch,
+                        )
+                    )
+        return candidates
+
+    def _candidate_to_report(
+        self, cand: RaceCandidate, hb_reason: str | None = None
+    ) -> RaceReport:
+        """Flatten a RaceCandidate into the public RaceReport shape. HB
+        reason is None until Step 5 (HBSolver) is wired in the next commit."""
+        tensor_name = cand.first.tensor_name or cand.second.tensor_name
+        return RaceReport(
+            race_type=cand.race_type,
+            witness_addr=cand.witness_addr,
+            epoch=cand.epoch,
+            tensor_name=tensor_name,
+            grid_a=cand.first.grid_idx,
+            grid_b=cand.second.grid_idx,
+            source_a=cand.first.source_location,
+            source_b=cand.second.source_location,
+            hb_reason=hb_reason,
         )
 
 


### PR DESCRIPTION
## API-change callout (read first)

\`SymbolicRaceDetector.finalize()\` now returns a \`list[RaceReport]\` instead of \`[]\`. \`ClientManager.finalize()\` does \`self.launch.records += client.finalize()\` (\`core/client.py:L207-213\`), so these reports land in \`launch.records\` mixed with other clients' outputs. Intentional — but any downstream consumer of \`launch.records\` should treat this as a behavior change.

## Summary

Turns PR2's concrete event capture into actual race reports. Concrete-only main line — no symbolic HB, no reshape, no cross-kernel races.

1. **[FIX] atomic concretize-and-execute overrider** — replaces PR2's \`op_overrider=None\` atomic wiring with a race-detector-specific overrider that concretizes symbolic inputs (\`maybe_concretize\` helper, wrapped into \`flatten_np\` / \`active_mask_for\` / \`broadcast_lane_operand\` / \`infer_elem_size\` / \`resolve_tensor_from_pointer\`), runs the real \`interpreter_builder.create_atomic_*\` on concrete values, records the concrete event, and returns a \`const\` \`SymbolicExpr\` wrapping the hardware \`old\` TensorHandle. Deletes \`PendingAtomicEvent\` + \`_pending_atomic_by_grid\` + the dangling-queue assertion. Turns all 5 PR2 strict xfail E2E tests green.
2. **[FEAT] program_seq/launch_id + plain load/store concrete capture** — \`AccessEventRecord\` gains \`program_seq\` / \`launch_id\` / \`epoch\`; atomic overriders stamp them; \`Load\` / \`RawLoad\` / \`Store\` / \`RawStore\` get before-callbacks (adapter-aware signatures — Triton's \`_triton_{load,store}_adapter\` strips \`value\`) alongside SymbolicClient's symbolic overrider; \`_pointer_elem_size\` now also reads \`ptr.dtype.element_ty\` so masked loads work without a value. TensorPointerLoad / TensorPointerStore are deliberately not captured — block-pointer address geometry is a later scope.
3. **[FEAT] concrete candidate finder and RaceReport** — byte-bucket pairing keyed on \`(epoch, byte_addr)\`, skipping same-grid_idx pairs (intra-block is po-ordered), deduping on \`(min_event_id, max_event_id)\`, canonical-ordering by \`(grid_idx, program_seq, event_id)\` so RAW/WAR are both live returns (#351). \`finalize()\` emits \`RaceReport\` objects. \`pre_run_callback\` / \`post_run_callback\` now always return True so every block runs — SymbolicClient's \`need_full_grid\` heuristic drops cross-block races otherwise.
4. **[FEAT] HBSolver + phase-advancing epoch/barrier** — \`po + sw\` reachability, gated on writer-sem ∈ {release, acq_rel}, reader-sem ∈ {acquire, acq_rel}, scope ∈ {gpu, sys} (CTA is block-local, #345), \`reader.atomic_old == writer.written_value\` at a shared element base (reads-from gate, #345), and same-value ambiguous-writer scan that skips \`ri\` itself (\`cas(1,1)\` polling, #347) and \`ri\`'s own future writes (#350). Barrier detection requires every block to participate; epoch bump only on phase-advancing writes with release sem (failed CAS, \`cas(1,1)\`, \`atomic_add(0)\` do not split phases).
5. **[TEST] full regression suite** — 23 new tests: 6 pairing-unit, 10 HB/epoch-unit, 7 E2E; anchors each upstream correctness flag (#345 #346 #347 #350 #351 #352).

## Non-goals (for reviewer scope)

- No real \`SymbolicHBSolver\` suppression (#349 / #352 — symbolic HB can't prove must-alias / reads-from yet).
- No symbolic alias query / cross-program symbolic pairing.
- No reshape / broadcast / trans lane semantics.
- No cross-kernel-launch races.
- No intra-vector-op self-race detection.
- No visualizer / frontend / trace public API changes.

## Test plan
- [x] \`uv run --with pytest --with torch --with triton pytest tests/\` → **285 passed, 5 skipped**.
- [x] 5 PR2 strict xfails at \`tests/unit/test_race_detector.py:691-791\` flipped to passing.
- [x] \`test_num_sms_1_and_2_match_on_release_acquire\` asserts single-SM / multi-SM suppression parity (#352).
- [x] \`test_private_sync_address_per_block_still_reports_race\` guards against #346 ptr-signature-equality unsoundness.
- [x] \`test_spinning_cas_poll_does_not_split_phase\` anchors #350 at the epoch-partitioner level.