### PR TITLE
[FEAT] [RACE DETECTOR] Add atomic CAS race detector capture and E2E tests

### DIFF
--- a/tests/end_to_end/test_race_detector_atomic_cas.py
+++ b/tests/end_to_end/test_race_detector_atomic_cas.py
@@ -1,0 +1,264 @@
+import inspect
+
+import pytest
+import torch
+
+import triton
+import triton.language as tl
+
+import triton_viz
+from triton_viz.clients.race_detector.hb_solver import RaceReport
+from triton_viz.clients.race_detector.race_detector import SymbolicRaceDetector
+from triton_viz.core.config import config as cfg
+from triton_viz.core.trace import launches
+
+
+@pytest.fixture
+def _isolate_race_detector_atomic_cfg():
+    saved_enable = cfg.enable_race_detector
+    saved_num_sms = cfg.num_sms
+    cfg.enable_race_detector = True
+    cfg.num_sms = 1
+    triton_viz.clear()
+    yield
+    triton_viz.clear()
+    cfg.enable_race_detector = saved_enable
+    cfg.num_sms = saved_num_sms
+
+
+@triton.jit
+def _plain_cross_grid_smoke_kernel(data_ptr, out_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    is_cons = pid == 1
+
+    tl.store(data_ptr, 1, mask=is_prod)
+    x = tl.load(data_ptr, mask=is_cons, other=0)
+    tl.store(out_ptr + pid, x, mask=is_cons)
+
+
+@triton.jit
+def _cas_acq_rel_unguarded_kernel(flag_ptr, data_ptr, out_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    is_cons = pid == 1
+
+    tl.store(data_ptr, 1, mask=is_prod)
+    cmp = tl.where(is_prod, 0, 1)
+    _old = tl.atomic_cas(flag_ptr, cmp, 1, sem="acq_rel", scope="gpu")
+    x = tl.load(data_ptr, mask=is_cons, other=0)
+    tl.store(out_ptr + pid, x, mask=is_cons)
+
+
+@triton.jit
+def _cas_acq_rel_guarded_kernel(flag_ptr, data_ptr, out_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    is_cons = pid == 1
+
+    tl.store(data_ptr, 1, mask=is_prod)
+    cmp = tl.where(is_prod, 0, 1)
+    old = tl.atomic_cas(flag_ptr, cmp, 1, sem="acq_rel", scope="gpu")
+    cons_mask = is_cons & (old == 1)
+    x = tl.load(data_ptr, mask=cons_mask, other=0)
+    tl.store(out_ptr + pid, x, mask=cons_mask)
+
+
+@triton.jit
+def _cas_relaxed_guarded_kernel(flag_ptr, data_ptr, out_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    is_cons = pid == 1
+
+    tl.store(data_ptr, 1, mask=is_prod)
+    cmp = tl.where(is_prod, 0, 1)
+    old = tl.atomic_cas(flag_ptr, cmp, 1, sem="relaxed", scope="gpu")
+    cons_mask = is_cons & (old == 1)
+    x = tl.load(data_ptr, mask=cons_mask, other=0)
+    tl.store(out_ptr + pid, x, mask=cons_mask)
+
+
+@triton.jit
+def _cas_cta_guarded_kernel(flag_ptr, data_ptr, out_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    is_cons = pid == 1
+
+    tl.store(data_ptr, 1, mask=is_prod)
+    cmp = tl.where(is_prod, 0, 1)
+    old = tl.atomic_cas(flag_ptr, cmp, 1, sem="acq_rel", scope="cta")
+    cons_mask = is_cons & (old == 1)
+    x = tl.load(data_ptr, mask=cons_mask, other=0)
+    tl.store(out_ptr + pid, x, mask=cons_mask)
+
+
+@triton.jit
+def _cas_single_program_order_kernel(flag_ptr, data_ptr, out_ptr):
+    tl.store(data_ptr, 1)
+    _old = tl.atomic_cas(flag_ptr, 0, 1, sem="acq_rel", scope="gpu")
+    x = tl.load(data_ptr)
+    tl.store(out_ptr, x)
+
+
+@triton.jit
+def _atomic_only_competing_updates_kernel(flag_ptr):
+    pid = tl.program_id(0)
+    is_prod = pid == 0
+    cmp = tl.where(is_prod, 0, 1)
+    tl.atomic_cas(flag_ptr, cmp, 1, sem="acq_rel", scope="gpu")
+
+
+def _run_detector(kernel, grid, *args, **kwargs):
+    triton_viz.clear()
+    detector = SymbolicRaceDetector()
+    traced = triton_viz.trace(client=detector)(kernel)
+    traced[grid](*args, **kwargs)
+    return detector
+
+
+def _line_no(kernel, needle: str) -> int:
+    source_fn = kernel.fn if hasattr(kernel, "fn") else kernel
+    lines, start = inspect.getsourcelines(source_fn)
+    for idx, line in enumerate(lines):
+        if needle in line:
+            return start + idx
+    raise AssertionError(f"Could not find source line containing: {needle}")
+
+
+def _assert_report_lines(report: RaceReport, kernel, needles: tuple[str, str]) -> None:
+    actual_lines = {
+        report.first.record.source_location[1],
+        report.second.record.source_location[1],
+    }
+    expected_lines = {_line_no(kernel, needle) for needle in needles}
+    assert actual_lines == expected_lines
+
+
+def _assert_launch_reports(detector: SymbolicRaceDetector) -> None:
+    assert launches, "expected at least one traced launch"
+    assert launches[-1].records == detector.last_reports
+    assert all(isinstance(report, RaceReport) for report in launches[-1].records)
+
+
+def _assert_atomic_records(
+    detector: SymbolicRaceDetector, *, sem: str, scope: str
+) -> None:
+    atomic_records = [record for record in detector.records if record.is_atomic]
+    assert atomic_records, "expected atomic_cas events to be captured"
+    assert all(record.atomic_kind == "cas" for record in atomic_records)
+    assert {record.sem for record in atomic_records} == {sem}
+    assert {record.scope for record in atomic_records} == {scope}
+    assert all(record.old_value is not None for record in atomic_records)
+    assert all(record.written_value is not None for record in atomic_records)
+
+
+def test_plain_cross_grid_smoke_reports_race(_isolate_race_detector_atomic_cfg):
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+
+    detector = _run_detector(_plain_cross_grid_smoke_kernel, (2,), data, out)
+
+    assert len(detector.last_reports) == 1
+    _assert_launch_reports(detector)
+    _assert_report_lines(
+        detector.last_reports[0],
+        _plain_cross_grid_smoke_kernel,
+        (
+            "tl.store(data_ptr, 1, mask=is_prod)",
+            "x = tl.load(data_ptr, mask=is_cons, other=0)",
+        ),
+    )
+
+
+def test_cas_acq_rel_unguarded_reports_race(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+
+    detector = _run_detector(_cas_acq_rel_unguarded_kernel, (2,), flag, data, out)
+
+    assert len(detector.last_reports) == 1
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="acq_rel", scope="gpu")
+    _assert_report_lines(
+        detector.last_reports[0],
+        _cas_acq_rel_unguarded_kernel,
+        (
+            "tl.store(data_ptr, 1, mask=is_prod)",
+            "x = tl.load(data_ptr, mask=is_cons, other=0)",
+        ),
+    )
+
+
+def test_cas_acq_rel_guarded_is_not_racy(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+
+    detector = _run_detector(_cas_acq_rel_guarded_kernel, (2,), flag, data, out)
+
+    assert detector.last_reports == []
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="acq_rel", scope="gpu")
+
+
+def test_cas_relaxed_guarded_reports_race(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+
+    detector = _run_detector(_cas_relaxed_guarded_kernel, (2,), flag, data, out)
+
+    assert len(detector.last_reports) == 1
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="relaxed", scope="gpu")
+    _assert_report_lines(
+        detector.last_reports[0],
+        _cas_relaxed_guarded_kernel,
+        (
+            "tl.store(data_ptr, 1, mask=is_prod)",
+            "x = tl.load(data_ptr, mask=cons_mask, other=0)",
+        ),
+    )
+
+
+def test_cas_cta_guarded_cross_grid_reports_race(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(2, dtype=torch.int32)
+
+    detector = _run_detector(_cas_cta_guarded_kernel, (2,), flag, data, out)
+
+    assert len(detector.last_reports) == 1
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="acq_rel", scope="cta")
+    _assert_report_lines(
+        detector.last_reports[0],
+        _cas_cta_guarded_kernel,
+        (
+            "tl.store(data_ptr, 1, mask=is_prod)",
+            "x = tl.load(data_ptr, mask=cons_mask, other=0)",
+        ),
+    )
+
+
+def test_single_program_order_is_not_racy(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+    data = torch.zeros(1, dtype=torch.int32)
+    out = torch.zeros(1, dtype=torch.int32)
+
+    detector = _run_detector(_cas_single_program_order_kernel, (1,), flag, data, out)
+
+    assert detector.last_reports == []
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="acq_rel", scope="gpu")
+
+
+def test_atomic_only_competing_updates_is_not_racy(_isolate_race_detector_atomic_cfg):
+    flag = torch.zeros(1, dtype=torch.int32)
+
+    detector = _run_detector(_atomic_only_competing_updates_kernel, (2,), flag)
+
+    assert detector.last_reports == []
+    _assert_launch_reports(detector)
+    _assert_atomic_records(detector, sem="acq_rel", scope="gpu")

--- a/triton_viz/clients/race_detector/hb_solver.py
+++ b/triton_viz/clients/race_detector/hb_solver.py
@@ -5,7 +5,7 @@ from itertools import combinations
 from typing import Any, Iterable
 
 from z3 import And, BoolVal, IntVal, Not, Or, Solver, sat
-from z3.z3 import BoolRef, ModelRef
+from z3.z3 import BoolRef, IntNumRef, ModelRef
 
 from .data import AccessEventRecord
 
@@ -114,7 +114,16 @@ class HBSolver:
             addrs = self._iter_addrs(record.addr_expr)
 
             for lane, addr in enumerate(addrs):
-                active = self._as_bool(self._lane_value(record.active, lane))
+                active_terms = [
+                    self._as_bool(self._lane_value(record.active, lane)),
+                    *(
+                        self._as_bool(constraint)
+                        for constraint in self._iter_constraints(
+                            record.local_constraints
+                        )
+                    ),
+                ]
+                active = And(*active_terms)
 
                 raw_reads = self._lane_value(record.reads, lane)
                 if raw_reads is None:
@@ -245,6 +254,39 @@ class HBSolver:
             self._minimal_atomic_read_from(writer, reader),
         )
 
+    def _initial_atomic_value(self, event: ScalarMemoryEvent) -> Any:
+        tensor = event.record.tensor
+        if tensor is None or event.old_value is None:
+            return None
+        try:
+            if tensor.numel() != 1:
+                return None
+            addr = event.addr
+            if isinstance(addr, IntNumRef):
+                addr = addr.as_long()
+            if not isinstance(addr, int) or addr != tensor.data_ptr():
+                return None
+            return IntVal(int(tensor.item()))
+        except Exception:
+            return None
+
+    def _atomic_old_value_has_source(self, reader: ScalarMemoryEvent) -> BoolRef:
+        if not reader.is_atomic or reader.old_value is None:
+            return BoolVal(True)
+
+        initial_value = self._initial_atomic_value(reader)
+        if initial_value is None:
+            return BoolVal(True)
+
+        candidate_sources = [
+            self._minimal_atomic_read_from(writer, reader)
+            for writer in self.events
+            if writer.idx != reader.idx
+        ]
+        if candidate_sources:
+            return Or(reader.old_value == initial_value, *candidate_sources)
+        return reader.old_value == initial_value
+
     def _edge(self, first: ScalarMemoryEvent, second: ScalarMemoryEvent) -> BoolRef:
         if first.idx == second.idx:
             return BoolVal(False)
@@ -306,8 +348,9 @@ class HBSolver:
         for record in self.records:
             for constraint in self._iter_constraints(record.premises):
                 solver.add(self._as_bool(constraint))
-            for constraint in self._iter_constraints(record.local_constraints):
-                solver.add(self._as_bool(constraint))
+
+        for event in self.events:
+            solver.add(self._atomic_old_value_has_source(event))
 
         return solver
 

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass
+from math import prod
 from typing import (
     Any,
     ClassVar,
@@ -7,16 +8,19 @@ from typing import (
     cast,
 )
 
+from z3 import If, IntVal, substitute
 from z3.z3 import BoolRef
 
 from ...core.client import Client
 from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import (
     Op,
+    AtomicCas,
     Load,
 )
 from ..symbolic_engine import (
     SymbolicExpr,
+    AtomicCasSymbolicExpr,
     SymbolicClient,
     NullSymbolicClient,
     PendingCheck,
@@ -25,7 +29,8 @@ from ..symbolic_engine import (
     ConstraintConjunction,
     AccessMode,
 )
-from .data import AccessEventRecord
+from .data import AccessEventRecord, MemorySem
+from .hb_solver import HBSolver
 from ...utils.traceback_utils import capture_current_source_location
 from ...core.config import config as cfg
 
@@ -131,6 +136,10 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
     def __init__(self, abort_on_error: bool = False):
         super().__init__(abort_on_error=abort_on_error)
         self.records: list[AccessEventRecord] = []
+        self.last_reports: list[Any] = []
+        self._program_seq: int = 0
+        self._expected_blocks: int = 0
+        self._completed_blocks: int = 0
 
     # Explicit forwarders to SymbolicClient: the RaceDetector factory
     # carries concrete stubs (NotImplementedError or ``return True``) to
@@ -138,9 +147,13 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
     # otherwise shadow SymbolicClient's impls in the subclass MRO.
     def grid_idx_callback(self, grid_idx: tuple[int, ...]) -> None:
         SymbolicClient.grid_idx_callback(self, grid_idx)
+        self._program_seq = 0
 
     def finalize(self) -> list:
-        return SymbolicClient.finalize(self)
+        reports = HBSolver(self.records).find_races()
+        self.last_reports = reports
+        self._clear_launch_runtime()
+        return reports
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
         return SymbolicClient.register_for_loop_callback(self)
@@ -149,18 +162,126 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         SymbolicClient.arg_callback(self, name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int, ...]) -> None:
+        self.records = []
+        self.last_reports = []
+        self._program_seq = 0
+        self._expected_blocks = prod(int(dim) for dim in grid)
+        self._completed_blocks = 0
         SymbolicClient.grid_callback(self, grid)
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
         return SymbolicClient.register_op_callback(self, op_type)
 
     def pre_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.pre_run_callback(self, fn)
+        del fn
+        # v1 guarantees standalone race-detector semantics only: always run the
+        # full launch grid instead of relying on SymbolicClient's lazy sampling.
+        return True
 
     def post_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.post_run_callback(self, fn)
+        del fn
+        self._completed_blocks += 1
+        return True
 
     # ── Event recording ───────────────────────────────────────────────────
+
+    def _clear_launch_runtime(self) -> None:
+        self._clear_cache()
+        self._clear_symbolic_launch_state()
+        self.need_full_grid = None
+        self.solver = None
+        self.addr_ok = None
+        self.pid_ok = None
+        self.addr_sym = None
+        self.grid = None
+        self.grid_idx = None
+        self.last_grid = None
+        self._program_seq = 0
+        self._expected_blocks = 0
+        self._completed_blocks = 0
+
+    @staticmethod
+    def _normalize_constraints(
+        constraints: ConstraintConjunction,
+    ) -> tuple[Any, ...]:
+        if constraints is None:
+            return ()
+        if isinstance(constraints, (list, tuple)):
+            return tuple(constraints)
+        return (constraints,)
+
+    def _pid_substitutions(self) -> tuple[tuple[Any, Any], ...]:
+        if self.grid_idx is None:
+            return ()
+        return (
+            (SymbolicExpr.PID0, IntVal(int(self.grid_idx[0]))),
+            (SymbolicExpr.PID1, IntVal(int(self.grid_idx[1]))),
+            (SymbolicExpr.PID2, IntVal(int(self.grid_idx[2]))),
+        )
+
+    def _concretize_value(self, value: Any) -> Any:
+        if value is None or isinstance(value, (bool, int, float, str)):
+            return value
+        if isinstance(value, list):
+            return [self._concretize_value(item) for item in value]
+        if isinstance(value, tuple):
+            return tuple(self._concretize_value(item) for item in value)
+
+        substitutions = self._pid_substitutions()
+        if not substitutions:
+            return value
+        return substitute(value, *substitutions)
+
+    @staticmethod
+    def _debug_name(
+        op_type: type[Op],
+        source_location: tuple[str, int, str] | None,
+    ) -> str:
+        base = getattr(op_type, "name", op_type.__name__.lower())
+        if source_location is None:
+            return base
+        _, lineno, func_name = source_location
+        if func_name:
+            return f"{func_name}:{lineno}:{base}"
+        return f"{base}:{lineno}"
+
+    def _next_program_seq(self) -> int:
+        seq = self._program_seq
+        self._program_seq += 1
+        return seq
+
+    @staticmethod
+    def _zip_lanes(*values: Any) -> list[tuple[Any, ...]] | None:
+        lane_values = [value for value in values if isinstance(value, (list, tuple))]
+        if not lane_values:
+            return None
+        lane_count = len(lane_values[0])
+        if any(len(value) != lane_count for value in lane_values):
+            raise ValueError("Lane-wise atomic_cas values must have matching lengths")
+
+        def lane_value(value: Any, lane: int) -> Any:
+            if isinstance(value, (list, tuple)):
+                return value[lane]
+            return value
+
+        return [
+            tuple(lane_value(value, lane) for value in values)
+            for lane in range(lane_count)
+        ]
+
+    @classmethod
+    def _eq_by_lane(cls, lhs: Any, rhs: Any) -> Any:
+        lanes = cls._zip_lanes(lhs, rhs)
+        if lanes is None:
+            return lhs == rhs
+        return [left == right for left, right in lanes]
+
+    @classmethod
+    def _if_by_lane(cls, cond: Any, on_true: Any, on_false: Any) -> Any:
+        lanes = cls._zip_lanes(cond, on_true, on_false)
+        if lanes is None:
+            return If(cond, on_true, on_false)
+        return [If(c, t, f) for c, t, f in lanes]
 
     def _record_access_event(
         self,
@@ -183,12 +304,12 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         solver_snapshot: tuple[Any, ...] = (
             tuple(self.solver.assertions()) if self.solver is not None else ()
         )
-        if expr_constraints is None:
-            local: tuple[Any, ...] = ()
-        elif isinstance(expr_constraints, (list, tuple)):
-            local = tuple(expr_constraints)
-        else:
-            local = (expr_constraints,)
+        local = self._normalize_constraints(expr_constraints)
+        access_addr = self._concretize_value(access_addr)
+        solver_snapshot = tuple(
+            self._concretize_value(item) for item in solver_snapshot
+        )
+        local = tuple(self._concretize_value(item) for item in local)
 
         self.records.append(
             AccessEventRecord(
@@ -198,10 +319,103 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                 tensor_name=tensor_name,
                 symbolic_expr=symbolic_expr,
                 addr_expr=access_addr,
-                premises=solver_snapshot + local,
+                premises=solver_snapshot,
                 local_constraints=local,
                 source_location=source_location,
                 grid_idx=self.grid_idx,
+                program_seq=self._next_program_seq(),
+                debug_name=self._debug_name(op_type, source_location),
+                active=True,
+                reads=access_mode == "read",
+                writes=access_mode == "write",
+            )
+        )
+
+    @staticmethod
+    def _normalize_sem(sem: str | None) -> MemorySem:
+        if sem is None:
+            return "acq_rel"
+        name = getattr(sem, "name", sem)
+        normalized = str(name).lower()
+        if normalized == "relaxed":
+            return "relaxed"
+        if normalized == "acquire":
+            return "acquire"
+        if normalized == "release":
+            return "release"
+        if normalized in ("acquire_release", "acq_rel"):
+            return "acq_rel"
+        if normalized == "plain":
+            return "plain"
+        return cast(MemorySem, normalized)
+
+    @staticmethod
+    def _normalize_scope(scope: str | None) -> str:
+        if scope is None:
+            return "gpu"
+        name = getattr(scope, "name", scope)
+        normalized = str(name).lower()
+        return {
+            "gpu": "gpu",
+            "cta": "cta",
+            "system": "sys",
+            "sys": "sys",
+        }.get(normalized, normalized)
+
+    def _record_atomic_cas_event(
+        self,
+        symbolic_expr: SymbolicExpr,
+        addr_expr: Z3Expr,
+        expr_constraints: ConstraintConjunction,
+        cmp_value: Any,
+        value: Any,
+        old_value: Any,
+        sem: str | None,
+        scope: str | None,
+        source_location: tuple[str, int, str] | None = None,
+    ) -> None:
+        tensor = self._resolve_tensor(symbolic_expr)
+        tensor_name = self._get_tensor_name(tensor) if tensor is not None else None
+        solver_snapshot: tuple[Any, ...] = (
+            tuple(self.solver.assertions()) if self.solver is not None else ()
+        )
+        local = self._normalize_constraints(expr_constraints)
+
+        addr_expr = self._concretize_value(addr_expr)
+        cmp_value = self._concretize_value(cmp_value)
+        value = self._concretize_value(value)
+        old_value = self._concretize_value(old_value)
+        solver_snapshot = tuple(
+            self._concretize_value(item) for item in solver_snapshot
+        )
+        local = tuple(self._concretize_value(item) for item in local)
+
+        success = self._eq_by_lane(old_value, cmp_value)
+        written_value = self._if_by_lane(success, value, old_value)
+
+        self.records.append(
+            AccessEventRecord(
+                op_type=AtomicCas,
+                access_mode="read",
+                tensor=tensor,
+                tensor_name=tensor_name,
+                symbolic_expr=symbolic_expr,
+                addr_expr=addr_expr,
+                premises=solver_snapshot,
+                local_constraints=local,
+                source_location=source_location,
+                grid_idx=self.grid_idx,
+                program_seq=self._next_program_seq(),
+                debug_name=self._debug_name(AtomicCas, source_location),
+                active=True,
+                reads=True,
+                writes=success,
+                is_atomic=True,
+                atomic_kind="cas",
+                sem=self._normalize_sem(sem),
+                scope=self._normalize_scope(scope),
+                old_value=old_value,
+                written_value=written_value,
             )
         )
 
@@ -251,6 +465,55 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         else:
             if cfg.verbose:
                 print(f"[{self.LOG_TAG}]  ↪ skip duplicated addr in loop")
+
+    def _handle_atomic_cas_check(
+        self,
+        expr: SymbolicExpr,
+        sem: str | None,
+        scope: str | None,
+    ) -> None:
+        expr_atomic = cast(AtomicCasSymbolicExpr, expr)
+        old_value, expr_constraints = expr.eval()
+        addr_expr, _ = expr_atomic.ptr.eval()
+        cmp_value, _ = expr_atomic.cmp.eval()
+        value, _ = expr_atomic.val.eval()
+        source_location = capture_current_source_location()
+
+        if self.loop_stack and cfg.verbose:
+            print(
+                f"[{self.LOG_TAG}] atomic_cas inside loops is recorded eagerly; "
+                "loop dedupe is not supported yet"
+            )
+
+        self._record_atomic_cas_event(
+            symbolic_expr=expr,
+            addr_expr=addr_expr,
+            expr_constraints=expr_constraints,
+            cmp_value=cmp_value,
+            value=value,
+            old_value=old_value,
+            sem=sem,
+            scope=scope,
+            source_location=source_location,
+        )
+
+    def _op_atomic_cas_overrider(
+        self,
+        ptr: Any,
+        cmp: Any,
+        val: Any,
+        sem: str | None = None,
+        scope: str | None = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> SymbolicExpr:
+        del args, kwargs
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        cmp_sym = SymbolicExpr.from_value(cmp)
+        val_sym = SymbolicExpr.from_value(val)
+        ret = SymbolicExpr.create("atomic_cas", ptr_sym, cmp_sym, val_sym)
+        self._handle_atomic_cas_check(ret, sem=sem, scope=scope)
+        return ret
 
     # ── Per-pending handler invoked from SymbolicClient's loop template
 

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -173,13 +173,11 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         return SymbolicClient.register_op_callback(self, op_type)
 
     def pre_run_callback(self, fn: Callable) -> bool:
-        del fn
         # v1 guarantees standalone race-detector semantics only: always run the
         # full launch grid instead of relying on SymbolicClient's lazy sampling.
         return True
 
     def post_run_callback(self, fn: Callable) -> bool:
-        del fn
         self._completed_blocks += 1
         return True
 
@@ -507,7 +505,6 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         *args: Any,
         **kwargs: Any,
     ) -> SymbolicExpr:
-        del args, kwargs
         ptr_sym = SymbolicExpr.from_value(ptr)
         cmp_sym = SymbolicExpr.from_value(cmp)
         val_sym = SymbolicExpr.from_value(val)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -1564,7 +1564,23 @@ class AtomicCasSymbolicExpr(SymbolicExpr):
         self.shape = self.val.shape
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
-        raise NotImplementedError("atomic_cas operation is not implemented yet")
+        ptr_z3, constraints_ptr = self.ptr._to_z3()
+        cmp_z3, constraints_cmp = self.cmp._to_z3()
+        val_z3, constraints_val = self.val._to_z3()
+        constraints = _and_constraints(
+            constraints_ptr, constraints_cmp, constraints_val
+        )
+
+        del cmp_z3, val_z3
+
+        if isinstance(ptr_z3, list):
+            z3_expr = [
+                Int(f"atomic_cas_old_{id(self)}_{idx}") for idx in range(len(ptr_z3))
+            ]
+        else:
+            z3_expr = Int(f"atomic_cas_old_{id(self)}")
+
+        return z3_expr, constraints
 
 
 class AtomicRmwSymbolicExpr(SymbolicExpr):
@@ -1976,7 +1992,10 @@ class SymbolicClient(Client):
             ptr, value, None, cache_modifier, eviction_policy
         )
 
-    def _op_atomic_cas_overrider(self, ptr, cmp, val, sem, scope):
+    def _op_atomic_cas_overrider(
+        self, ptr, cmp, val, sem=None, scope=None, *args, **kwargs
+    ):
+        del args, kwargs
         ptr_sym = SymbolicExpr.from_value(ptr)
         cmp_sym = SymbolicExpr.from_value(cmp)
         val_sym = SymbolicExpr.from_value(val)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -1995,7 +1995,6 @@ class SymbolicClient(Client):
     def _op_atomic_cas_overrider(
         self, ptr, cmp, val, sem=None, scope=None, *args, **kwargs
     ):
-        del args, kwargs
         ptr_sym = SymbolicExpr.from_value(ptr)
         cmp_sym = SymbolicExpr.from_value(cmp)
         val_sym = SymbolicExpr.from_value(val)


### PR DESCRIPTION
## Summary
- add full-grid standalone race-detector capture with real `finalize() -> HBSolver -> RaceReport` reporting
- capture `atomic_cas` events end-to-end, including PID concretization, program ordering, and HB metadata
- add real Triton end-to-end coverage for plain cross-grid races and atomic CAS handoff scenarios

## What Changed
- updated `SymbolicRaceDetector` to record HB fields for plain load/store, concretize PID symbols at capture time, and return `RaceReport` objects from `finalize()`
- extended the symbolic engine so `atomic_cas` produces a stable symbolic old-value that is reused by race-detector capture
- adjusted `HBSolver` so local constraints are treated as event-local guards and added a minimal scalar atomic old-value source rule for real guarded CAS handoff cases
- added `tests/end_to_end/test_race_detector_atomic_cas.py` covering:
  - plain cross-grid smoke race
  - `acq_rel` CAS with guarded / unguarded load
  - `relaxed` CAS guarded load
  - `cta` scope guarded load across grid
  - single-program-order suppression
  - atomic-only negative case

## Validation
- `./.venv/bin/python -m pytest -q tests/unit/test_race_detector.py tests/end_to_end/test_race_detector.py tests/end_to_end/test_race_detector_atomic_cas.py`
