### PR TITLE
[FIX] Tighten loop iterator bound for post-update loop-carried pointers

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1066,6 +1066,87 @@ def test_data_dependent_loop_bound_div():
     ), f"Expected no OOB records, got {len(data_dep_div_sanitizer.records)}"
 
 
+# ======== Loop-Carried Post-Load Pointer Update Tests ===========
+
+
+post_load_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=post_load_sanitizer)
+@triton.jit
+def post_load_matmul_kernel(
+    a_ptr,
+    b_ptr,
+    c_ptr,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offs_m = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
+    offs_n = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
+    offs_k = tl.arange(0, BLOCK_SIZE_K)
+    a_ptrs = a_ptr + offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak
+    b_ptrs = b_ptr + offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn
+    acc = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+    for k in range(0, K // BLOCK_SIZE_K):
+        a = tl.load(a_ptrs)
+        b = tl.load(b_ptrs)
+        acc += tl.dot(a, b)
+        a_ptrs = a_ptrs + BLOCK_SIZE_K * stride_ak
+        # Post-load b_ptrs update: address for "next" iteration computed at the
+        # end of this one. On the last iteration the value is dead, so it must
+        # not be flagged OOB even though `k + 1 == K // BLOCK_SIZE_K`.
+        b_ptrs = (
+            b_ptr
+            + (offs_k[:, None] + (k + 1) * BLOCK_SIZE_K) * stride_bk
+            + offs_n[None, :] * stride_bn
+        )
+    c_ptrs = c_ptr + offs_m[:, None] * stride_cm + offs_n[None, :] * stride_cn
+    tl.store(c_ptrs, acc)
+
+
+def test_post_load_pointer_update_no_false_positive():
+    post_load_sanitizer.records.clear()
+    M = N = K = 32
+    BLOCK_M = BLOCK_N = 16
+    BLOCK_K = 16  # 2 K-iterations
+    a = torch.randn(M, K, dtype=torch.float32)
+    b = torch.randn(K, N, dtype=torch.float32)
+    c = torch.empty(M, N, dtype=torch.float32)
+    grid = (M // BLOCK_M, N // BLOCK_N)
+    post_load_matmul_kernel[grid](
+        a,
+        b,
+        c,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        c.stride(0),
+        c.stride(1),
+        BLOCK_SIZE_M=BLOCK_M,
+        BLOCK_SIZE_N=BLOCK_N,
+        BLOCK_SIZE_K=BLOCK_K,
+    )
+    assert (
+        len(post_load_sanitizer.records) == 0
+    ), f"Expected no OOB records, got {len(post_load_sanitizer.records)}"
+
+
 # ======== Data-Dependent Loop Bound (tl.cdiv) Tests ===========
 
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -151,6 +151,62 @@ def _range_to_iterator_constraint(
     return And(bounds, (var - start) % abs_step == 0)
 
 
+def _max_loop_idx_offset(expr: "SymbolicExpr", idx_z3: ArithRef) -> int | None:
+    """Largest ``c_max`` such that every occurrence of ``idx_z3`` in ``expr``
+    appears as ``add(idx_z3, c)`` with ``c >= c_max`` (a bare reference counts
+    as ``c = 0``).
+
+    Returns ``None`` if ``idx_z3`` does not appear in ``expr``.
+
+    Used by ``_loop_hook_after`` to tighten the iterator bound for loop-carried
+    state: a value of the form ``idx_z3 + c`` can only be observed at the load
+    site if some real iteration produced it, i.e. ``idx_z3 + c < stop``. The
+    walker is conservative — any occurrence in an unrecognized shape (mul, sub,
+    add with non-int sibling, etc.) contributes ``0``, so the resulting bound
+    never relaxes a real OOB.
+    """
+    offsets: list[int] = []
+
+    def _is_idx_leaf(node: "SymbolicExpr | None") -> bool:
+        return (
+            node is not None
+            and node.op == "const"
+            and node.loop_ctx is not None
+            and node.loop_ctx.idx_z3 is idx_z3
+        )
+
+    def _nonneg_int_const(node: "SymbolicExpr | None") -> int | None:
+        if node is None or node.op != "const" or node.loop_ctx is not None:
+            return None
+        value = getattr(node, "value", None)
+        if isinstance(value, bool) or not isinstance(value, int):
+            return None
+        return value if value >= 0 else None
+
+    def walk(node: "SymbolicExpr | None") -> None:
+        if node is None:
+            return
+        if _is_idx_leaf(node):
+            offsets.append(0)
+            return
+        if node.op == "add":
+            lhs = node.children.get("lhs")
+            rhs = node.children.get("rhs")
+            for idx_child, other_child in ((lhs, rhs), (rhs, lhs)):
+                if _is_idx_leaf(idx_child):
+                    c = _nonneg_int_const(other_child)
+                    offsets.append(c if c is not None else 0)
+                    walk(other_child)
+                    return
+        for child in node.children.values():
+            walk(child)
+
+    walk(expr)
+    if not offsets:
+        return None
+    return min(offsets)
+
+
 @dataclass
 class PendingCheck:
     symbolic_expr: SymbolicExpr
@@ -2205,7 +2261,24 @@ class SymbolicClient(Client):
                     f" with iterator constraints: {all_iterator_constraints} ",
                     f" and expression-related constraints: {pending.constraints} ",
                 )
-            self._process_pending_check(ctx, pending, all_iterator_constraints)
+
+            # A load that touches state of the form (idx_z3 + c) is only
+            # reachable when some real iteration produced that state, i.e.
+            # idx_z3 + c < stop. Without this tightening, Z3 picks the largest
+            # idx_z3 in [start, stop) and reports the post-update dead value as
+            # OOB (false positive on loop-carried pointer advances).
+            extra_pushed = False
+            if ctx.step > 0:
+                c_max = _max_loop_idx_offset(pending.symbolic_expr, ctx.idx_z3)
+                if c_max is not None and c_max > 0:
+                    solver.push()
+                    solver.add(ctx.idx_z3 + c_max < ctx.stop)
+                    extra_pushed = True
+            try:
+                self._process_pending_check(ctx, pending, all_iterator_constraints)
+            finally:
+                if extra_pushed:
+                    solver.pop()
 
         if ctx.pending_checks:
             solver.pop()


### PR DESCRIPTION
## Summary
- Sanitizer was reporting a false positive at `tl.load(b_ptrs, ...)` for kernels that re-assign a loop-carried pointer *after* the load (e.g. `b_ptrs = b_ptr + (k + 1) * BLOCK_SIZE_K * stride_bk`). The engine reuses a single Z3 variable `loop_i_<lineno>` over the whole loop body with bound `[start, stop)`, so Z3 picks `loop_i = N - 1` and flags the dead post-update on the last iteration as OOB. Same root cause as #150 — engine bug, not kernel bug.
- For a load to actually execute on state of the form `idx + c`, some real iteration `idx + c` must have produced it, i.e. `idx + c < stop`. The fix applies that necessary condition per-pending-check inside `_loop_hook_after`.
- New module-level helper `_max_loop_idx_offset(expr, idx_z3)` walks the `SymbolicExpr` and returns the minimum per-occurrence add-offset (or `None` if the loop idx does not appear). The walk is conservative — multiplication, subtraction, and other unrecognized shapes contribute `0` — so the tightening can only restrict the search space, never relax it. Real OOBs still trip.
- When `c_max > 0` and the loop step is positive, the existing per-loop `solver.push()` / `solver.pop()` bracket is augmented with a per-check `solver.push() / add(idx + c_max < stop) / solver.pop()`. Both consumers — `Sanitizer._check_range_satisfiable` (already does its own inner push/pop per address) and `RaceDetector._record_access_event` (snapshots `solver.assertions()`) — handle the wrapping correctly.

## Test plan
- [x] New regression test `test_post_load_pointer_update_no_false_positive` in `tests/end_to_end/test_sanitizer.py`: minimal matmul, `M=N=K=32`, `BLOCK_K=16` (2 K-iterations), post-load `b_ptrs` update. Asserts `len(records) == 0`.
- [x] Soundness — these still trip OOB after the change:
  - [x] `test_block_tensor_loop_advance_oob`
  - [x] `test_loop_oob_reports_correct_line_number`
- [x] Full suite: `TRITON_INTERPRET=1 uv run --with pytest --with torch pytest tests/ -x -q --ignore=tests/nki` → `243 passed, 2 skipped`.
- [ ] Manual TritonBench reproducer (`iv_dependent_matmul.py`, kernel types `post_load`, `post_pre_mixed`, `post_load_two_iters`, `post_load_three_iters`) — to be confirmed locally.