### PR TITLE
[FEAT] Add triton-race-detector CLI entry point

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ homepage = "https://github.com/Deep-Learning-Profiling-Tools/triton-viz"
 [project.scripts]
 triton-sanitizer = "triton_viz.wrapper:apply_sanitizer"
 triton-profiler = "triton_viz.wrapper:apply_profiler"
+triton-race-detector = "triton_viz.wrapper:apply_race_detector"
 triton-visualizer = "triton_viz.visualizer_cli:main"
 
 [project.optional-dependencies]

--- a/tests/end_to_end/test_wrapper.py
+++ b/tests/end_to_end/test_wrapper.py
@@ -5,7 +5,11 @@ import subprocess
 from pathlib import Path
 from string import Template
 import shutil
-from triton_viz.wrapper import SANITIZER_COMMAND, PROFILER_COMMAND
+from triton_viz.wrapper import (
+    SANITIZER_COMMAND,
+    PROFILER_COMMAND,
+    RACE_DETECTOR_COMMAND,
+)
 
 
 TEMPLATE_DIR = Path(__file__).parent / "templates"
@@ -150,6 +154,82 @@ def test_triton_profiler_injects_trace_outermost(tmp_path: Path, monkeypatch):
         print("STDOUT:\n", proc.stdout)
         print("STDERR:\n", proc.stderr)
     assert proc.returncode == 0, f"{PROFILER_COMMAND} run failed"
+
+    # 6) Read trace records
+    assert (
+        trace_log.exists()
+    ), "trace log not generated (sitecustomize may not have taken effect)"
+    records = json.loads(trace_log.read_text(encoding="utf-8"))
+
+    # Build counter by function name
+    from collections import Counter
+
+    counts = Counter(rec["name"] for rec in records)
+
+    # Assertion: the 2 kernel names defined in our script should each appear exactly once
+    for expected in ["k1", "k2"]:
+        assert counts[expected] == 1, (
+            f"{expected} should be traced 1 time, actual count is {counts[expected]}; "
+            "may have missing or duplicate injection"
+        )
+
+
+def test_triton_race_detector_injects_trace_outermost(tmp_path: Path, monkeypatch):
+    """
+    Black-box verification for triton-race-detector:
+    - Pure @triton.jit kernels have exactly one @triton_viz.trace at the outermost layer;
+    - @triton.autotune + @triton.jit kernels: trace is only added at the autotune outer
+      layer, inner jit should not be traced again.
+    Implementation approach:
+      Use sitecustomize to monkey-patch triton_viz.trace at subprocess startup,
+      record each trace decorator application target (function name/type),
+      write to JSON on exit.
+    """
+    # 1) Write sitecustomize: takes effect at interpreter startup
+    trace_log = tmp_path / "trace_log.json"
+    sitecustomize = tmp_path / "sitecustomize.py"
+    sitecustomize.write_text(
+        load_template(
+            "sitecustomize_spy_trace.py.template",
+            log_path=json.dumps(str(trace_log)),
+        ),
+        encoding="utf-8",
+    )
+
+    # 2) Write a minimal test script: two kernels (k1: pure jit, k2: autotune + jit)
+    my_program = tmp_path / "my_program.py"
+    my_program.write_text(
+        load_template("kernel_jit_autotune.py.template"),
+        encoding="utf-8",
+    )
+
+    # 3) Assemble subprocess environment: ensure our sitecustomize is found first
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(tmp_path) + os.pathsep + env.get("PYTHONPATH", "")
+
+    # 4) Find triton-race-detector executable - fail if not found
+    exe = shutil.which(RACE_DETECTOR_COMMAND)
+    assert exe is not None, (
+        f"{RACE_DETECTOR_COMMAND} command not found. "
+        "Please ensure the package is properly installed."
+    )
+    cmd = [exe, str(my_program)]
+
+    # 5) Run subprocess
+    proc = subprocess.run(
+        cmd,
+        cwd=str(tmp_path),
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    # Optional debug output (easier to locate on failure)
+    if proc.returncode != 0:
+        print("STDOUT:\n", proc.stdout)
+        print("STDERR:\n", proc.stderr)
+    assert proc.returncode == 0, f"{RACE_DETECTOR_COMMAND} run failed"
 
     # 6) Read trace records
     assert (

--- a/triton_viz/wrapper.py
+++ b/triton_viz/wrapper.py
@@ -5,13 +5,14 @@ import sys
 import pytest
 import triton
 import triton_viz
-from triton_viz.clients import Sanitizer, Profiler
+from triton_viz.clients import Sanitizer, Profiler, RaceDetector
 from triton_viz.core.config import config as cfg
 
 
 # Command names
 SANITIZER_COMMAND = "triton-sanitizer"
 PROFILER_COMMAND = "triton-profiler"
+RACE_DETECTOR_COMMAND = "triton-race-detector"
 
 # store the original triton.jit
 _original_jit = triton.jit
@@ -26,6 +27,11 @@ def sanitizer_wrapper(kernel):
 
 def profiler_wrapper(kernel):
     tracer = triton_viz.trace(client=Profiler())
+    return tracer(kernel)
+
+
+def race_detector_wrapper(kernel):
+    tracer = triton_viz.trace(client=RaceDetector())
     return tracer(kernel)
 
 
@@ -136,4 +142,15 @@ def apply_profiler():
         profiler_wrapper,
         PROFILER_COMMAND,
         f"Usage: {PROFILER_COMMAND} <script.py> [args...]",
+    )
+
+
+def apply_race_detector():
+    """
+    Apply the race detector wrapper to triton.jit and run the user script.
+    """
+    _apply_wrapper(
+        race_detector_wrapper,
+        RACE_DETECTOR_COMMAND,
+        f"Usage: {RACE_DETECTOR_COMMAND} <script.py> [args...]",
     )


### PR DESCRIPTION
## Summary

Adds a ``triton-race-detector`` CLI command so users can run an existing kernel script under the race detector without modifying source:

```
triton-race-detector my_kernel.py
```

Mirrors the existing ``triton-sanitizer`` / ``triton-profiler`` plumbing exactly — same ``_apply_wrapper`` path, same ``triton.jit`` / ``triton.autotune`` patching.

## Changes

- ``triton_viz/wrapper.py``
  - import ``RaceDetector``
  - new constant ``RACE_DETECTOR_COMMAND = ""triton-race-detector""``
  - new ``race_detector_wrapper(kernel)`` mirroring ``profiler_wrapper`` / ``sanitizer_wrapper``
  - new ``apply_race_detector()`` that delegates to the shared ``_apply_wrapper``
- ``pyproject.toml``
  - register ``triton-race-detector = ""triton_viz.wrapper:apply_race_detector""`` under ``[project.scripts]``

## Background

This change was previously made on the ``feat/race-detector-cli`` branch and merged into the ``feature/race_detector`` integration branch (PR #319), but it never reached ``main``. Now that the race detector client is on ``main``, the CLI entry point can land directly.

## Test plan

- [x] ``uv run python -c ""from triton_viz.wrapper import race_detector_wrapper, apply_race_detector, RACE_DETECTOR_COMMAND""`` succeeds.
- [x] Pre-commit hooks (ruff, ruff-format, mypy) all pass.
- [ ] After install, ``triton-race-detector <script.py>`` runs the script with race detection enabled (manual smoke).