### PR TITLE
[FEAT] Sanitizer: detect strided 1-D view OOB (issue triton-lang/triton#10336)

### DIFF
--- a/examples/sanitizer/oob_tensor_view.py
+++ b/examples/sanitizer/oob_tensor_view.py
@@ -1,0 +1,48 @@
+"""Reproduces triton-lang/triton#10336.
+
+When a masked ``tl.load`` uses a logical length larger than the view's
+element count, the JIT performs a "wild pointer read" past the underlying
+storage. This example wraps the kernel with the triton-viz sanitizer so the
+OOB access is caught symbolically instead of silently returning OOB memory.
+"""
+
+import torch
+
+import triton
+import triton.language as tl
+
+import triton_viz
+
+
+@triton_viz.trace("sanitizer")
+@triton.jit
+def oob_load_kernel(
+    vals_ptr,
+    bins_ptr,
+    out_ptr,
+    L: tl.constexpr,
+    SV: tl.constexpr,
+    SB: tl.constexpr,
+):
+    offs = tl.arange(0, 8)
+    v = tl.load(vals_ptr + offs * SV, mask=offs < L, other=0)
+    b = tl.load(bins_ptr + offs * SB, mask=offs < L, other=-1)  # OOB HERE!
+    tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
+
+
+def test_oob_tensor_view():
+    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+
+    vals = vals_base
+    bins = bins_base[0::2]  # visible values: [10, 11, 12], stride = 2
+    out = torch.empty((4,), dtype=torch.int32)
+
+    # L=4 is valid for vals but invalid for bins.
+    # For offs=3 the load resolves to bins_ptr + 3*2 = bins_base[6], which is
+    # past the 5-element underlying storage.
+    oob_load_kernel[(1,)](vals, bins, out, L=4, SV=vals.stride(0), SB=bins.stride(0))
+    print(out)
+
+
+test_oob_tensor_view()

--- a/examples/sanitizer/oob_tensor_view.py
+++ b/examples/sanitizer/oob_tensor_view.py
@@ -30,7 +30,7 @@ def oob_load_kernel(
     tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
 
 
-def test_oob_tensor_view():
+def main():
     vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
     bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
 
@@ -45,4 +45,5 @@ def test_oob_tensor_view():
     print(out)
 
 
-test_oob_tensor_view()
+if __name__ == "__main__":
+    main()

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1291,15 +1291,6 @@ def strided_view_oob_load_kernel(
     tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
 
 
-@triton_viz.trace(client=strided_view_sanitizer)
-@triton.jit
-def strided_view_wrong_stride_kernel(bins_ptr, out_ptr, BLOCK: tl.constexpr):
-    """Walks ``bins_ptr`` with stride 1, ignoring the view's stride."""
-    offs = tl.arange(0, BLOCK)
-    b = tl.load(bins_ptr + offs)
-    tl.store(out_ptr + offs, b)
-
-
 @pytest.fixture
 def _isolate_per_element_threshold():
     """Save and restore the per-element warning threshold."""
@@ -1356,25 +1347,6 @@ def test_strided_view_correct_mask_no_oob():
     assert len(strided_view_sanitizer.records) == 0
 
 
-def test_strided_view_between_element_oob():
-    """
-    Walking a stride-2 view with stride 1 lands on bytes *between* the
-    view's logical elements. Under precise view semantics those bytes are
-    OOB even though they live inside the underlying storage.
-    """
-    strided_view_sanitizer.records.clear()
-
-    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
-    bins = bins_base[0::2]  # elements at byte offsets 0, 8, 16
-    out = torch.empty((4,), dtype=torch.int32)
-
-    # BLOCK=4 -> offs=1 hits byte 4 (between bins[0]/bins[1]); offs=3 hits
-    # byte 12 (between bins[1]/bins[2]). tl.arange requires a power of 2.
-    strided_view_wrong_stride_kernel[(1,)](bins, out, BLOCK=4)
-
-    assert len(strided_view_sanitizer.records) > 0
-
-
 def test_strided_view_warns_on_large_numel(_isolate_per_element_threshold):
     """Per-element enumeration emits UserWarning above the threshold."""
     strided_view_sanitizer.records.clear()
@@ -1392,41 +1364,3 @@ def test_strided_view_warns_on_large_numel(_isolate_per_element_threshold):
 
     # Warning path must not change correctness — no OOB with correct mask.
     assert len(strided_view_sanitizer.records) == 0
-
-
-# Dedicated sanitizer keeps this test independent of the shared symbolic cache.
-nonzero_offset_sanitizer = SymbolicSanitizer(abort_on_error=False)
-
-
-@triton_viz.trace(client=nonzero_offset_sanitizer)
-@triton.jit
-def nonzero_offset_load_kernel(
-    vals_ptr,
-    bins_ptr,
-    out_ptr,
-    L: tl.constexpr,
-    SV: tl.constexpr,
-    SB: tl.constexpr,
-):
-    offs = tl.arange(0, 4)
-    v = tl.load(vals_ptr + offs * SV, mask=offs < L, other=0)
-    b = tl.load(bins_ptr + offs * SB, mask=offs < L, other=-1)
-    tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
-
-
-def test_strided_view_nonzero_storage_offset_no_oob():
-    """Regression: a stride-2 view with non-zero ``storage_offset`` (e.g.
-    ``base[1::2]``) must not trip false-positive OOBs. Previously the helper
-    double-counted ``storage_offset`` and shifted every valid address."""
-    nonzero_offset_sanitizer.records.clear()
-
-    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
-    bins_base = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
-    bins = bins_base[1::2]  # storage_offset=1, stride=2, visible [10, 11, 12]
-    out = torch.empty((4,), dtype=torch.int32)
-
-    nonzero_offset_load_kernel[(1,)](
-        vals_base, bins, out, L=3, SV=vals_base.stride(0), SB=bins.stride(0)
-    )
-
-    assert len(nonzero_offset_sanitizer.records) == 0

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1303,9 +1303,9 @@ def strided_view_wrong_stride_kernel(bins_ptr, out_ptr, BLOCK: tl.constexpr):
 @pytest.fixture
 def _isolate_per_element_threshold():
     """Save and restore the per-element warning threshold."""
-    saved = config.sanitizer_per_element_warn_threshold
+    saved = config.symbolic_per_element_warn_threshold
     yield
-    config.sanitizer_per_element_warn_threshold = saved
+    config.symbolic_per_element_warn_threshold = saved
 
 
 def test_strided_view_oob_load():
@@ -1378,7 +1378,7 @@ def test_strided_view_between_element_oob():
 def test_strided_view_warns_on_large_numel(_isolate_per_element_threshold):
     """Per-element enumeration emits UserWarning above the threshold."""
     strided_view_sanitizer.records.clear()
-    config.sanitizer_per_element_warn_threshold = 1  # force a warning
+    config.symbolic_per_element_warn_threshold = 1  # force a warning
 
     vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
     bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
@@ -1392,3 +1392,41 @@ def test_strided_view_warns_on_large_numel(_isolate_per_element_threshold):
 
     # Warning path must not change correctness — no OOB with correct mask.
     assert len(strided_view_sanitizer.records) == 0
+
+
+# Dedicated sanitizer keeps this test independent of the shared symbolic cache.
+nonzero_offset_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=nonzero_offset_sanitizer)
+@triton.jit
+def nonzero_offset_load_kernel(
+    vals_ptr,
+    bins_ptr,
+    out_ptr,
+    L: tl.constexpr,
+    SV: tl.constexpr,
+    SB: tl.constexpr,
+):
+    offs = tl.arange(0, 4)
+    v = tl.load(vals_ptr + offs * SV, mask=offs < L, other=0)
+    b = tl.load(bins_ptr + offs * SB, mask=offs < L, other=-1)
+    tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
+
+
+def test_strided_view_nonzero_storage_offset_no_oob():
+    """Regression: a stride-2 view with non-zero ``storage_offset`` (e.g.
+    ``base[1::2]``) must not trip false-positive OOBs. Previously the helper
+    double-counted ``storage_offset`` and shifted every valid address."""
+    nonzero_offset_sanitizer.records.clear()
+
+    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    bins_base = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
+    bins = bins_base[1::2]  # storage_offset=1, stride=2, visible [10, 11, 12]
+    out = torch.empty((4,), dtype=torch.int32)
+
+    nonzero_offset_load_kernel[(1,)](
+        vals_base, bins, out, L=3, SV=vals_base.stride(0), SB=bins.stride(0)
+    )
+
+    assert len(nonzero_offset_sanitizer.records) == 0

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1291,6 +1291,23 @@ def strided_view_oob_load_kernel(
     tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
 
 
+@triton_viz.trace(client=strided_view_sanitizer)
+@triton.jit
+def strided_view_wrong_stride_kernel(bins_ptr, out_ptr, BLOCK: tl.constexpr):
+    """Walks ``bins_ptr`` with stride 1, ignoring the view's stride."""
+    offs = tl.arange(0, BLOCK)
+    b = tl.load(bins_ptr + offs)
+    tl.store(out_ptr + offs, b)
+
+
+@pytest.fixture
+def _isolate_per_element_threshold():
+    """Save and restore the per-element warning threshold."""
+    saved = config.sanitizer_per_element_warn_threshold
+    yield
+    config.sanitizer_per_element_warn_threshold = saved
+
+
 def test_strided_view_oob_load():
     """
     Regression for triton-lang/triton#10336.
@@ -1319,3 +1336,59 @@ def test_strided_view_oob_load():
     )
 
     assert len(strided_view_sanitizer.records) > 0, "Expected OOB to be detected"
+
+
+def test_strided_view_correct_mask_no_oob():
+    """Correctly-masked access on a stride-2 view must not produce OOB."""
+    strided_view_sanitizer.records.clear()
+
+    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+
+    bins = bins_base[0::2]
+    out = torch.empty((4,), dtype=torch.int32)
+
+    # L=3 matches bins.numel(); mask excludes the would-be OOB offset.
+    strided_view_oob_load_kernel[(1,)](
+        vals_base, bins, out, L=3, SV=vals_base.stride(0), SB=bins.stride(0)
+    )
+
+    assert len(strided_view_sanitizer.records) == 0
+
+
+def test_strided_view_between_element_oob():
+    """
+    Walking a stride-2 view with stride 1 lands on bytes *between* the
+    view's logical elements. Under precise view semantics those bytes are
+    OOB even though they live inside the underlying storage.
+    """
+    strided_view_sanitizer.records.clear()
+
+    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+    bins = bins_base[0::2]  # elements at byte offsets 0, 8, 16
+    out = torch.empty((4,), dtype=torch.int32)
+
+    # BLOCK=4 -> offs=1 hits byte 4 (between bins[0]/bins[1]); offs=3 hits
+    # byte 12 (between bins[1]/bins[2]). tl.arange requires a power of 2.
+    strided_view_wrong_stride_kernel[(1,)](bins, out, BLOCK=4)
+
+    assert len(strided_view_sanitizer.records) > 0
+
+
+def test_strided_view_warns_on_large_numel(_isolate_per_element_threshold):
+    """Per-element enumeration emits UserWarning above the threshold."""
+    strided_view_sanitizer.records.clear()
+    config.sanitizer_per_element_warn_threshold = 1  # force a warning
+
+    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+    bins = bins_base[0::2]
+    out = torch.empty((4,), dtype=torch.int32)
+
+    with pytest.warns(UserWarning, match="non-unit inner stride"):
+        strided_view_oob_load_kernel[(1,)](
+            vals_base, bins, out, L=3, SV=vals_base.stride(0), SB=bins.stride(0)
+        )
+
+    # Warning path must not change correctness — no OOB with correct mask.
+    assert len(strided_view_sanitizer.records) == 0

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1267,3 +1267,55 @@ def test_reinterpret_tensor_wrapper():
     x = torch.ones(N, dtype=torch.float16, device="cpu")
     y = torch.empty(N, dtype=torch.float16, device="cpu")
     copy_kernel[(1,)](triton.reinterpret(x, tl.float16), y, N, BLOCK=64)
+
+
+# ======== Strided Tensor View OOB Tests (triton-lang/triton#10336) ===========
+
+
+strided_view_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=strided_view_sanitizer)
+@triton.jit
+def strided_view_oob_load_kernel(
+    vals_ptr,
+    bins_ptr,
+    out_ptr,
+    L: tl.constexpr,
+    SV: tl.constexpr,
+    SB: tl.constexpr,
+):
+    offs = tl.arange(0, 8)
+    v = tl.load(vals_ptr + offs * SV, mask=offs < L, other=0)
+    b = tl.load(bins_ptr + offs * SB, mask=offs < L, other=-1)  # OOB HERE!
+    tl.store(out_ptr + offs, v * 100 + b, mask=offs < L)
+
+
+def test_strided_view_oob_load():
+    """
+    Regression for triton-lang/triton#10336.
+
+    A masked tl.load with ``mask = offs < L`` reads past the underlying
+    storage when L exceeds the strided view's element count. The JIT path
+    silently performs the wild pointer read; the sanitizer should detect it.
+
+    Setup:
+      - bins_base has 5 int32 elements (20 bytes of storage).
+      - bins = bins_base[0::2] is a view of 3 elements with stride 2.
+      - L=4 makes the mask true for offs=3, so the kernel issues a load at
+        bins_ptr + 3*2 = bins_base[6], past the underlying storage.
+    """
+    strided_view_sanitizer.records.clear()
+
+    vals_base = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    bins_base = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+
+    vals = vals_base
+    bins = bins_base[0::2]  # visible values [10, 11, 12], stride=2
+    out = torch.empty((4,), dtype=torch.int32)
+
+    strided_view_oob_load_kernel[(1,)](
+        vals, bins, out, L=4, SV=vals.stride(0), SB=bins.stride(0)
+    )
+
+    assert len(strided_view_sanitizer.records) > 0, "Expected OOB to be detected"

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,8 +1,10 @@
 import pytest
+import torch
 from typing import cast
 
 from triton_viz.core.config import config as cfg
 from triton_viz.clients import Sanitizer
+from triton_viz.clients.sanitizer.report import _classify_layout_and_segments
 from triton_viz.clients.sanitizer.sanitizer import (
     NullSanitizer,
     SymbolicSanitizer,
@@ -143,3 +145,75 @@ def test_post_run_callback_clears_state_on_last_block():
     assert sanitizer.tensor_names == {}
     assert sanitizer.cache_args == []
     assert sanitizer.cache_grid is None
+
+
+# ======== Report Layout Classification Tests ===========
+
+
+def _normalize(layout_segments, tensor):
+    """Translate ``(layout, segments)`` to ``(layout, relative_segments)``.
+
+    Segment endpoints are made relative to ``tensor.data_ptr()`` so the asserts
+    do not depend on PyTorch's allocator returning specific addresses.
+    """
+    layout, segments = layout_segments
+    base = tensor.data_ptr() if tensor.numel() else 0
+    return layout, [(s - base, e - base) for s, e in segments]
+
+
+def test_classify_contiguous_1d():
+    t = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    assert _normalize(_classify_layout_and_segments(t), t) == (
+        "contiguous",
+        [(0, 15)],
+    )
+
+
+def test_classify_dim0_contiguous_transpose():
+    # ``t.T`` alone is storage-contiguous (just F-order), so it falls into the
+    # single-segment path. Slice it to force the dim-0-contiguous bucket:
+    # ``t.T[1:]`` has strides (1, 8) and a non-zero storage_offset.
+    t = torch.arange(32, dtype=torch.int32).reshape(4, 8).T[1:]  # shape (7, 4)
+    layout, rel = _normalize(_classify_layout_and_segments(t), t)
+    assert layout == "dim-0-contiguous"
+    # 4 segments (outer dim 1 size = 4), each covering 7 int32 elements = 28 bytes,
+    # separated by stride[1]=8 elements = 32 bytes.
+    assert len(rel) == 4
+    assert rel[0] == (0, 27)
+    assert rel[1] == (32, 59)
+
+
+def test_classify_dim1_contiguous_slice():
+    # ``t[:, 2:6]``: storage-discontiguous but inner dim 1 still has stride 1.
+    base_t = torch.arange(32, dtype=torch.int32).reshape(4, 8)
+    t = base_t[:, 2:6]
+    layout, rel = _normalize(_classify_layout_and_segments(t), t)
+    assert layout == "dim-1-contiguous"
+    # 4 row segments, each 4 int32 wide = 16 bytes; rows separated by 32 bytes.
+    assert len(rel) == 4
+    assert rel[0] == (0, 15)
+    assert rel[1] == (32, 47)
+
+
+def test_classify_per_element_strided_view():
+    base_t = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[0::2]
+    assert _normalize(_classify_layout_and_segments(view), view) == (
+        "per-element",
+        [(0, 3), (8, 11), (16, 19)],
+    )
+
+
+def test_classify_per_element_nonzero_storage_offset():
+    base_t = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[1::2]
+    assert view.storage_offset() == 1
+    assert _normalize(_classify_layout_and_segments(view), view) == (
+        "per-element",
+        [(0, 3), (8, 11), (16, 19)],
+    )
+
+
+def test_classify_empty_tensor():
+    t = torch.empty((0,), dtype=torch.int32)
+    assert _classify_layout_and_segments(t) == ("empty", [])

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,11 +3,13 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import torch
 from z3 import Int
 
 from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.clients.symbolic_engine import LoopContext
 from triton_viz.clients.tracer.tracer import Tracer
+from triton_viz.clients.utils import get_physical_addr_per_element
 from triton_viz.core.data import Load
 from triton_viz.core.trace import trace_source
 from triton_viz.utils import traceback_utils
@@ -164,6 +166,56 @@ def test_tracer_without_oob_trace_source_uses_oob_line(use_decorator: bool):
     # With boundary-marker, oob is captured even without @trace_source
     assert tb_info.func_name.endswith("oob")
     assert "load_callback" in tb_info.line_of_code
+
+
+def _relative_segments(tensor: torch.Tensor) -> list[tuple[int, int]]:
+    """Segments as (start, end) byte offsets relative to ``tensor.data_ptr()``."""
+    base = tensor.data_ptr()
+    return [(s - base, e - base) for s, e in get_physical_addr_per_element(tensor)]
+
+
+def test_get_physical_addr_per_element_contiguous_1d():
+    """Contiguous 1-D tensor: each element occupies itemsize bytes back-to-back."""
+    t = torch.tensor([10, 20, 30], dtype=torch.int32)
+
+    assert _relative_segments(t) == [(0, 3), (4, 7), (8, 11)]
+
+
+def test_get_physical_addr_per_element_strided_zero_offset():
+    """``base[0::2]`` view: segments at every other element, no offset shift."""
+    base_t = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[0::2]
+    assert view.storage_offset() == 0
+
+    # Three logical elements at byte offsets 0, 8, 16 of view.data_ptr().
+    assert _relative_segments(view) == [(0, 3), (8, 11), (16, 19)]
+
+
+def test_get_physical_addr_per_element_strided_nonzero_offset():
+    """``base[1::2]``: storage_offset is non-zero; segments are still relative to
+    ``view.data_ptr()`` (i.e. start at 0), confirming we do not double-count
+    storage_offset on top of ``data_ptr``."""
+    base_t = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[1::2]
+    assert view.storage_offset() == 1
+
+    assert _relative_segments(view) == [(0, 3), (8, 11), (16, 19)]
+
+
+def test_get_physical_addr_per_element_collapses_stride_zero():
+    """``expand``-ed dim (stride 0) collapses to size 1 — same memory regardless
+    of the broadcast extent."""
+    row = torch.arange(3, dtype=torch.int32)
+    view = row.unsqueeze(0).expand(4, 3)  # strides (0, 1), shape (4, 3)
+
+    # 4-way broadcast collapses, leaving the 3 inner elements only.
+    assert _relative_segments(view) == [(0, 3), (4, 7), (8, 11)]
+
+
+def test_get_physical_addr_per_element_zero_dim():
+    """0-D tensor returns a single segment covering itemsize bytes."""
+    t = torch.tensor(42, dtype=torch.int32)
+    assert _relative_segments(t) == [(0, 3)]
 
 
 def test_undecorated_helper_captured_via_boundary_marker():

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -168,36 +168,32 @@ def test_tracer_without_oob_trace_source_uses_oob_line(use_decorator: bool):
     assert "load_callback" in tb_info.line_of_code
 
 
-def _tensor_contiguous_1d() -> torch.Tensor:
-    return torch.tensor([10, 20, 30], dtype=torch.int32)
-
-
-def _tensor_strided_zero_offset() -> torch.Tensor:
-    return torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)[0::2]
-
-
-def _tensor_strided_nonzero_offset() -> torch.Tensor:
-    # storage_offset=1 verifies we don't double-count it on top of data_ptr.
-    return torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)[1::2]
-
-
-def _tensor_broadcast_stride_zero() -> torch.Tensor:
-    # expand() produces stride-0 dim that must collapse to size 1.
-    return torch.arange(3, dtype=torch.int32).unsqueeze(0).expand(4, 3)
-
-
-def _tensor_zero_dim() -> torch.Tensor:
-    return torch.tensor(42, dtype=torch.int32)
-
-
 @pytest.mark.parametrize(
-    "make_tensor, expected",
+    "tensor, expected",
     [
-        (_tensor_contiguous_1d, [(0, 3), (4, 7), (8, 11)]),
-        (_tensor_strided_zero_offset, [(0, 3), (8, 11), (16, 19)]),
-        (_tensor_strided_nonzero_offset, [(0, 3), (8, 11), (16, 19)]),
-        (_tensor_broadcast_stride_zero, [(0, 3), (4, 7), (8, 11)]),
-        (_tensor_zero_dim, [(0, 3)]),
+        # Contiguous 1-D: each element back-to-back.
+        (
+            torch.tensor([10, 20, 30], dtype=torch.int32),
+            [(0, 3), (4, 7), (8, 11)],
+        ),
+        # ``base[0::2]``: stride>1 view, storage_offset=0.
+        (
+            torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)[0::2],
+            [(0, 3), (8, 11), (16, 19)],
+        ),
+        # ``base[1::2]``: stride>1 with storage_offset=1 — guards against
+        # double-counting storage_offset on top of data_ptr.
+        (
+            torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)[1::2],
+            [(0, 3), (8, 11), (16, 19)],
+        ),
+        # ``expand()`` creates a stride-0 dim that must collapse to size 1.
+        (
+            torch.arange(3, dtype=torch.int32).unsqueeze(0).expand(4, 3),
+            [(0, 3), (4, 7), (8, 11)],
+        ),
+        # 0-D scalar.
+        (torch.tensor(42, dtype=torch.int32), [(0, 3)]),
     ],
     ids=[
         "contiguous_1d",
@@ -207,11 +203,10 @@ def _tensor_zero_dim() -> torch.Tensor:
         "zero_dim",
     ],
 )
-def test_get_physical_addr_per_element(make_tensor, expected):
+def test_get_physical_addr_per_element(tensor, expected):
     """Segments are (start, end) byte offsets relative to ``data_ptr()``."""
-    t = make_tensor()
-    base = t.data_ptr()
-    relative = [(s - base, e - base) for s, e in get_physical_addr_per_element(t)]
+    base = tensor.data_ptr()
+    relative = [(s - base, e - base) for s, e in get_physical_addr_per_element(tensor)]
     assert relative == expected
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -168,54 +168,51 @@ def test_tracer_without_oob_trace_source_uses_oob_line(use_decorator: bool):
     assert "load_callback" in tb_info.line_of_code
 
 
-def _relative_segments(tensor: torch.Tensor) -> list[tuple[int, int]]:
-    """Segments as (start, end) byte offsets relative to ``tensor.data_ptr()``."""
-    base = tensor.data_ptr()
-    return [(s - base, e - base) for s, e in get_physical_addr_per_element(tensor)]
+def _tensor_contiguous_1d() -> torch.Tensor:
+    return torch.tensor([10, 20, 30], dtype=torch.int32)
 
 
-def test_get_physical_addr_per_element_contiguous_1d():
-    """Contiguous 1-D tensor: each element occupies itemsize bytes back-to-back."""
-    t = torch.tensor([10, 20, 30], dtype=torch.int32)
-
-    assert _relative_segments(t) == [(0, 3), (4, 7), (8, 11)]
+def _tensor_strided_zero_offset() -> torch.Tensor:
+    return torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)[0::2]
 
 
-def test_get_physical_addr_per_element_strided_zero_offset():
-    """``base[0::2]`` view: segments at every other element, no offset shift."""
-    base_t = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
-    view = base_t[0::2]
-    assert view.storage_offset() == 0
-
-    # Three logical elements at byte offsets 0, 8, 16 of view.data_ptr().
-    assert _relative_segments(view) == [(0, 3), (8, 11), (16, 19)]
+def _tensor_strided_nonzero_offset() -> torch.Tensor:
+    # storage_offset=1 verifies we don't double-count it on top of data_ptr.
+    return torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)[1::2]
 
 
-def test_get_physical_addr_per_element_strided_nonzero_offset():
-    """``base[1::2]``: storage_offset is non-zero; segments are still relative to
-    ``view.data_ptr()`` (i.e. start at 0), confirming we do not double-count
-    storage_offset on top of ``data_ptr``."""
-    base_t = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
-    view = base_t[1::2]
-    assert view.storage_offset() == 1
-
-    assert _relative_segments(view) == [(0, 3), (8, 11), (16, 19)]
+def _tensor_broadcast_stride_zero() -> torch.Tensor:
+    # expand() produces stride-0 dim that must collapse to size 1.
+    return torch.arange(3, dtype=torch.int32).unsqueeze(0).expand(4, 3)
 
 
-def test_get_physical_addr_per_element_collapses_stride_zero():
-    """``expand``-ed dim (stride 0) collapses to size 1 — same memory regardless
-    of the broadcast extent."""
-    row = torch.arange(3, dtype=torch.int32)
-    view = row.unsqueeze(0).expand(4, 3)  # strides (0, 1), shape (4, 3)
-
-    # 4-way broadcast collapses, leaving the 3 inner elements only.
-    assert _relative_segments(view) == [(0, 3), (4, 7), (8, 11)]
+def _tensor_zero_dim() -> torch.Tensor:
+    return torch.tensor(42, dtype=torch.int32)
 
 
-def test_get_physical_addr_per_element_zero_dim():
-    """0-D tensor returns a single segment covering itemsize bytes."""
-    t = torch.tensor(42, dtype=torch.int32)
-    assert _relative_segments(t) == [(0, 3)]
+@pytest.mark.parametrize(
+    "make_tensor, expected",
+    [
+        (_tensor_contiguous_1d, [(0, 3), (4, 7), (8, 11)]),
+        (_tensor_strided_zero_offset, [(0, 3), (8, 11), (16, 19)]),
+        (_tensor_strided_nonzero_offset, [(0, 3), (8, 11), (16, 19)]),
+        (_tensor_broadcast_stride_zero, [(0, 3), (4, 7), (8, 11)]),
+        (_tensor_zero_dim, [(0, 3)]),
+    ],
+    ids=[
+        "contiguous_1d",
+        "strided_zero_offset",
+        "strided_nonzero_offset",
+        "broadcast_stride_zero",
+        "zero_dim",
+    ],
+)
+def test_get_physical_addr_per_element(make_tensor, expected):
+    """Segments are (start, end) byte offsets relative to ``data_ptr()``."""
+    t = make_tensor()
+    base = t.data_ptr()
+    relative = [(s - base, e - base) for s, e in get_physical_addr_per_element(t)]
+    assert relative == expected
 
 
 def test_undecorated_helper_captured_via_boundary_marker():

--- a/triton_viz/clients/sanitizer/report.py
+++ b/triton_viz/clients/sanitizer/report.py
@@ -2,13 +2,51 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ...core.config import config as cfg
 from ...core.data import Load, Store
 from ...utils.traceback_utils import read_source_segment
+from ..utils import (
+    check_inner_stride_equal_to_one,
+    check_storage_contiguous,
+    get_physical_addr_from_tensor_slice,
+    get_physical_addr_per_element,
+)
 from .data import (
     OutOfBoundsRecord,
     OutOfBoundsRecordBruteForce,
     OutOfBoundsRecordZ3,
 )
+
+
+def _classify_layout_and_segments(tensor):
+    """Return ``(layout_label, segments)`` mirroring SymbolicClient.arg_callback.
+
+    Segments are ``(start, end)`` byte ranges with both endpoints inclusive.
+    The layout label is one of:
+      - ``contiguous`` — whole storage is one contiguous segment
+      - ``dim-N-contiguous`` — dim N has stride 1; other dims index into
+        independent contiguous runs
+      - ``per-element`` — no dim has stride 1; each logical element is its
+        own segment (precise view semantics)
+      - ``empty`` — tensor has zero elements
+    """
+    if tensor.numel() == 0:
+        return "empty", []
+    if tensor.is_contiguous() or check_storage_contiguous(tensor):
+        start = tensor.data_ptr()
+        end = start + tensor.numel() * tensor.element_size() - 1
+        return "contiguous", [(start, end)]
+    if check_inner_stride_equal_to_one(tensor):
+        inner_dim = min(
+            (d for d in range(tensor.dim()) if tensor.stride(d) != 0),
+            key=lambda d: tensor.stride(d),
+        )
+        return (
+            f"dim-{inner_dim}-contiguous",
+            get_physical_addr_from_tensor_slice(tensor),
+        )
+    return "per-element", get_physical_addr_per_element(tensor)
+
 
 if TYPE_CHECKING:
     from ..symbolic_engine import SymbolicExpr
@@ -172,14 +210,44 @@ def print_oob_record_pdb_style(
         f"  {green}{'contiguous:':<{col1_width}}{reset_color} {str(tensor.is_contiguous()):<{col2_width}} {green}{'base_ptr:':<{col3_width}}{reset_color} 0x{tensor.data_ptr():016x}"
     )
 
-    total_bytes = np.prod(tensor.shape) * tensor.element_size()
-    size_str = f"{total_bytes} bytes"
-    range_str = (
-        f"[0x{tensor.data_ptr():016x}, 0x{tensor.data_ptr() + total_bytes:016x})"
-    )
-    print(
-        f"  {green}{'size:':<{col1_width}}{reset_color} {size_str:<{col2_width}} {green}{'valid_range:':<{col3_width}}{reset_color} {range_str}"
-    )
+    total_bytes = int(np.prod(tensor.shape)) * tensor.element_size()
+    layout, segments = _classify_layout_and_segments(tensor)
+
+    def _seg_str(seg):
+        s, e = seg
+        return f"[0x{s:016x}, 0x{e + 1:016x})"
+
+    if len(segments) == 1:
+        # Single-segment: keep the original one-line format.
+        size_str = f"{total_bytes} bytes"
+        range_str = _seg_str(segments[0])
+        print(
+            f"  {green}{'size:':<{col1_width}}{reset_color} {size_str:<{col2_width}} {green}{'valid_range:':<{col3_width}}{reset_color} {range_str}"
+        )
+    elif len(segments) == 0:
+        print(f"  {green}{'size:':<{col1_width}}{reset_color} 0 bytes (empty tensor)")
+        print(f"  {green}{'valid_range:':<{col1_width}}{reset_color} (no segments)")
+    else:
+        span_start = segments[0][0]
+        span_end = segments[-1][1] + 1
+        size_str = f"{total_bytes} bytes (layout: {layout})"
+        print(f"  {green}{'size:':<{col1_width}}{reset_color} {size_str}")
+        range_header = (
+            f"{len(segments)} segments spanning "
+            f"[0x{span_start:016x}, 0x{span_end:016x})"
+        )
+        print(f"  {green}{'valid_range:':<{col1_width}}{reset_color} {range_header}")
+        max_display = max(2, cfg.sanitizer_report_max_segments)
+        if len(segments) <= max_display:
+            for seg in segments:
+                print(f"    {_seg_str(seg)}")
+        else:
+            head = tail = max_display // 2
+            for seg in segments[:head]:
+                print(f"    {_seg_str(seg)}")
+            print(f"    ... ({len(segments) - head - tail} more)")
+            for seg in segments[-tail:]:
+                print(f"    {_seg_str(seg)}")
 
     # ===================== Call Stack =====================
     print(f"{bold}{cyan}━━━ Call Stack ━━━{reset_color}")

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -2436,7 +2436,7 @@ class SymbolicClient(Client):
             # Non-unit inner stride (e.g. a 1-D ``tensor[::k]`` view):
             # enumerate one segment per element so the address check uses
             # precise view semantics (between-element bytes count as OOB).
-            threshold = cfg.sanitizer_per_element_warn_threshold
+            threshold = cfg.symbolic_per_element_warn_threshold
             if threshold > 0 and arg.numel() > threshold:
                 warnings.warn(
                     f"Tensor {name!r} has {arg.numel()} elements with "

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import math
+import warnings
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from functools import reduce
@@ -79,6 +80,7 @@ from ..core.data import (
 from .utils import (
     check_storage_contiguous,
     get_physical_addr_from_tensor_slice,
+    get_physical_addr_per_element,
     check_inner_stride_equal_to_one,
 )
 
@@ -2431,9 +2433,20 @@ class SymbolicClient(Client):
                 for start, end in get_physical_addr_from_tensor_slice(arg)
             ]
         else:
-            raise ValueError(
-                "This symbolic client only supports contiguously stored tensors for now!"
-            )
+            # Non-unit inner stride (e.g. a 1-D ``tensor[::k]`` view):
+            # enumerate one segment per element so the address check uses
+            # precise view semantics (between-element bytes count as OOB).
+            threshold = cfg.sanitizer_per_element_warn_threshold
+            if threshold > 0 and arg.numel() > threshold:
+                warnings.warn(
+                    f"Tensor {name!r} has {arg.numel()} elements with "
+                    "non-unit inner stride; per-element enumeration may "
+                    "slow the symbolic solver significantly.",
+                    stacklevel=2,
+                )
+            tensor_physical_addresses = [
+                (start, end, arg) for start, end in get_physical_addr_per_element(arg)
+            ]
         self._record_tensor_name(arg, name)
         self._cache_tensor_arg(arg)
         self.tensors.append(arg)

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -154,3 +154,41 @@ def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int,
             )
         )
     return segments
+
+
+def get_physical_addr_per_element(tensor: torch.Tensor) -> list[tuple[int, int]]:
+    """One (start, end) byte segment per logical element of ``tensor``.
+
+    Each segment covers exactly ``element_size()`` bytes, so the resulting
+    list precisely describes the view footprint — bytes between logical
+    elements are *not* covered. Stride-0 dims collapse to size 1 since they
+    alias the same memory for every index along that axis.
+
+    Use this when neither the storage-contiguous nor the inner-stride-equal-
+    to-one fast paths apply (e.g. a 1-D view with stride > 1).
+    """
+    dims = tensor.dim()
+    if dims == 0:
+        return [
+            (
+                tensor.data_ptr()
+                + int(tensor.storage_offset()) * tensor.element_size(),
+                tensor.data_ptr()
+                + int(tensor.storage_offset()) * tensor.element_size()
+                + tensor.element_size()
+                - 1,
+            )
+        ]
+
+    itemsize = tensor.element_size()
+    base = tensor.data_ptr()
+    storage_offset = int(tensor.storage_offset())
+    strides = [int(tensor.stride(d)) for d in range(dims)]
+    sizes = [1 if strides[d] == 0 else int(tensor.size(d)) for d in range(dims)]
+
+    segments = []
+    for idxs in itertools.product(*(range(s) for s in sizes)):
+        offset = storage_offset + sum(i * st for i, st in zip(idxs, strides))
+        start = base + offset * itemsize
+        segments.append((start, start + itemsize - 1))
+    return segments

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -179,6 +179,13 @@ def get_physical_addr_per_element(tensor: torch.Tensor) -> list[tuple[int, int]]
     strides = [int(tensor.stride(d)) for d in range(dims)]
     sizes = [1 if strides[d] == 0 else int(tensor.size(d)) for d in range(dims)]
 
+    # TODO(perf): the consumer OR's one Z3 clause per segment, so cost
+    # scales with numel. For stride>1 views the legal set can be expressed
+    # as a stride equation instead -- roughly
+    #   0 <= (addr - base) < numel * stride * itemsize
+    #   (addr - base) % (stride * itemsize) < itemsize
+    # generalising to N-D by combining per-axis constraints. That keeps
+    # the Z3 expression O(dims) instead of O(numel).
     segments = []
     for idxs in itertools.product(*(range(s) for s in sizes)):
         offset = sum(i * st for i, st in zip(idxs, strides))

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -126,6 +126,14 @@ def check_inner_stride_equal_to_one(tensor: torch.Tensor):
 
 
 def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int, int]]:
+    """One contiguous byte segment per outer-index tuple, covering the run of
+    ``inner_dim_size`` elements along the dim whose stride is 1.
+
+    Segments are byte-inclusive ``(start, end)`` ranges, matching the
+    convention used by :func:`get_physical_addr_per_element`. ``data_ptr()``
+    already points at the view's element-0 address (it folds in
+    ``storage_offset``), so element offsets are computed relative to it.
+    """
     non_zero = [s for s in tensor.stride() if s != 0]
     if len(non_zero) == 0 or sorted(non_zero)[0] != 1:
         raise ValueError("inner dim must be contiguous!")
@@ -137,22 +145,18 @@ def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int,
     )
     # Stride-0 dims access the same memory for all indices, so collapse to size 1
     outer_dims = [d for d in range(dims) if d != inner_dim]
+    itemsize = tensor.element_size()
+    base = tensor.data_ptr()
+    inner_dim_size = int(tensor.size(inner_dim))
 
     segments = []
     for idxs in itertools.product(
         *(range(1 if tensor.stride(d) == 0 else tensor.size(d)) for d in outer_dims)
     ):
-        offset = int(tensor.storage_offset()) + sum(
-            idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims)
-        )
-        inner_dim_size = int(tensor.size(inner_dim))
-        segments.append(
-            (
-                tensor.data_ptr() + offset * tensor.element_size(),
-                tensor.data_ptr()
-                + (offset + inner_dim_size - 1) * tensor.element_size(),
-            )
-        )
+        offset = sum(idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims))
+        start = base + offset * itemsize
+        end = start + inner_dim_size * itemsize - 1
+        segments.append((start, end))
     return segments
 
 

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -167,28 +167,21 @@ def get_physical_addr_per_element(tensor: torch.Tensor) -> list[tuple[int, int]]
     Use this when neither the storage-contiguous nor the inner-stride-equal-
     to-one fast paths apply (e.g. a 1-D view with stride > 1).
     """
+    itemsize = tensor.element_size()
+    # ``tensor.data_ptr()`` already points at the view's element-0 address
+    # (i.e. it folds in ``storage_offset``), so element indices are measured
+    # *relative to* it and must not add storage_offset back in.
+    base = tensor.data_ptr()
     dims = tensor.dim()
     if dims == 0:
-        return [
-            (
-                tensor.data_ptr()
-                + int(tensor.storage_offset()) * tensor.element_size(),
-                tensor.data_ptr()
-                + int(tensor.storage_offset()) * tensor.element_size()
-                + tensor.element_size()
-                - 1,
-            )
-        ]
+        return [(base, base + itemsize - 1)]
 
-    itemsize = tensor.element_size()
-    base = tensor.data_ptr()
-    storage_offset = int(tensor.storage_offset())
     strides = [int(tensor.stride(d)) for d in range(dims)]
     sizes = [1 if strides[d] == 0 else int(tensor.size(d)) for d in range(dims)]
 
     segments = []
     for idxs in itertools.product(*(range(s) for s in sizes)):
-        offset = storage_offset + sum(i * st for i, st in zip(idxs, strides))
+        offset = sum(i * st for i, st in zip(idxs, strides))
         start = base + offset * itemsize
         segments.append((start, start + itemsize - 1))
     return segments

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -36,12 +36,13 @@ class Config:
       subset of blocks to reduce profiling overhead.
     - profiler_disable_buffer_load_check: PROFILER_DISABLE_BUFFER_LOAD_CHECK,
       disables buffer load checks in the profiler.
-    - sanitizer_per_element_warn_threshold:
-      SANITIZER_PER_ELEMENT_WARN_THRESHOLD, element count above which the
-      sanitizer emits a UserWarning before falling back to per-element
-      address enumeration for non-unit-inner-stride tensors. Behavior is
-      unchanged; the warning just signals that the symbolic solver may slow
-      down. Set to 0 to disable the warning entirely.
+    - symbolic_per_element_warn_threshold:
+      SYMBOLIC_PER_ELEMENT_WARN_THRESHOLD, element count above which the
+      shared SymbolicClient (sanitizer + race detector) emits a UserWarning
+      before falling back to per-element address enumeration for
+      non-unit-inner-stride tensors. Behavior is unchanged; the warning just
+      signals that the symbolic solver may slow down. Set to 0 to disable
+      the warning entirely.
     """
 
     def __init__(self) -> None:
@@ -69,8 +70,8 @@ class Config:
         self.profiler_disable_buffer_load_check: bool = _is_one(
             "PROFILER_DISABLE_BUFFER_LOAD_CHECK"
         )
-        self.sanitizer_per_element_warn_threshold: int = _get_int_env(
-            "SANITIZER_PER_ELEMENT_WARN_THRESHOLD", 8192, minimum=0
+        self.symbolic_per_element_warn_threshold: int = _get_int_env(
+            "SYMBOLIC_PER_ELEMENT_WARN_THRESHOLD", 8192, minimum=0
         )
 
 

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -43,6 +43,9 @@ class Config:
       non-unit-inner-stride tensors. Behavior is unchanged; the warning just
       signals that the symbolic solver may slow down. Set to 0 to disable
       the warning entirely.
+    - sanitizer_report_max_segments: SANITIZER_REPORT_MAX_SEGMENTS, max
+      number of address segments to list verbatim in the OOB report before
+      truncating to a head/tail summary. Affects display only (min 2).
     """
 
     def __init__(self) -> None:
@@ -72,6 +75,9 @@ class Config:
         )
         self.symbolic_per_element_warn_threshold: int = _get_int_env(
             "SYMBOLIC_PER_ELEMENT_WARN_THRESHOLD", 8192, minimum=0
+        )
+        self.sanitizer_report_max_segments: int = _get_int_env(
+            "SANITIZER_REPORT_MAX_SEGMENTS", 8, minimum=2
         )
 
 

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -36,6 +36,12 @@ class Config:
       subset of blocks to reduce profiling overhead.
     - profiler_disable_buffer_load_check: PROFILER_DISABLE_BUFFER_LOAD_CHECK,
       disables buffer load checks in the profiler.
+    - sanitizer_per_element_warn_threshold:
+      SANITIZER_PER_ELEMENT_WARN_THRESHOLD, element count above which the
+      sanitizer emits a UserWarning before falling back to per-element
+      address enumeration for non-unit-inner-stride tensors. Behavior is
+      unchanged; the warning just signals that the symbolic solver may slow
+      down. Set to 0 to disable the warning entirely.
     """
 
     def __init__(self) -> None:
@@ -62,6 +68,9 @@ class Config:
         )
         self.profiler_disable_buffer_load_check: bool = _is_one(
             "PROFILER_DISABLE_BUFFER_LOAD_CHECK"
+        )
+        self.sanitizer_per_element_warn_threshold: int = _get_int_env(
+            "SANITIZER_PER_ELEMENT_WARN_THRESHOLD", 8192, minimum=0
         )
 
 


### PR DESCRIPTION
## Summary
- Add per-element address enumeration so the sanitizer can check tensors whose inner stride is not 1 (e.g. ``t[::2]``). Previously the ``arg_callback`` bailed with ``ValueError``, leaving the strided-view OOB pattern from [triton-lang/triton#10336](https://github.com/triton-lang/triton/issues/10336) undetected.
- Preserve existing fast paths (storage-contiguous, inner-stride-1); the new branch is a fallback.
- Add ``config.sanitizer_per_element_warn_threshold`` (default 8192, env ``SANITIZER_PER_ELEMENT_WARN_THRESHOLD``) — emits a ``UserWarning`` when the enumeration may slow the symbolic solver; behavior is unchanged.

## Semantics
**Precise view footprint.** Each segment covers exactly ``element_size()`` bytes. Bytes _between_ logical elements (reachable inside the underlying storage but not part of the view's element positions) count as OOB.

## Changes
- ``triton_viz/clients/utils.py``: new ``get_physical_addr_per_element``.
- ``triton_viz/clients/symbolic_engine.py``: replace the trailing ``raise ValueError`` in ``SymbolicClient.arg_callback`` with per-element enumeration + threshold warning.
- ``triton_viz/core/config.py``: add ``sanitizer_per_element_warn_threshold``.
- ``examples/sanitizer/oob_tensor_view.py``: reproduction kernel from issue #10336.
- ``tests/end_to_end/test_sanitizer.py``: four new tests under the "Strided Tensor View OOB Tests" section.

## Test plan
- [x] ``uv run pytest tests/end_to_end/test_sanitizer.py -k strided_view -v`` — all 4 pass
  - ``test_strided_view_oob_load``: issue #10336 wild pointer read is detected
  - ``test_strided_view_correct_mask_no_oob``: ``mask=offs<numel`` reports no OOB
  - ``test_strided_view_between_element_oob``: walking a stride-2 view with stride 1 is reported (precise view semantics)
  - ``test_strided_view_warns_on_large_numel``: ``UserWarning`` fires above the threshold without changing detection results
- [x] ``uv run python examples/sanitizer/oob_tensor_view.py`` — sanitizer prints the diagnostic, points at line 29, exits non-zero