### PR TITLE
[FEAT] Sanitizer report: layout-aware sparse valid_range display

### DIFF
--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,8 +1,10 @@
 import pytest
+import torch
 from typing import cast
 
 from triton_viz.core.config import config as cfg
 from triton_viz.clients import Sanitizer
+from triton_viz.clients.sanitizer.report import _classify_layout_and_segments
 from triton_viz.clients.sanitizer.sanitizer import (
     NullSanitizer,
     SymbolicSanitizer,
@@ -143,3 +145,75 @@ def test_post_run_callback_clears_state_on_last_block():
     assert sanitizer.tensor_names == {}
     assert sanitizer.cache_args == []
     assert sanitizer.cache_grid is None
+
+
+# ======== Report Layout Classification Tests ===========
+
+
+def _normalize(layout_segments, tensor):
+    """Translate ``(layout, segments)`` to ``(layout, relative_segments)``.
+
+    Segment endpoints are made relative to ``tensor.data_ptr()`` so the asserts
+    do not depend on PyTorch's allocator returning specific addresses.
+    """
+    layout, segments = layout_segments
+    base = tensor.data_ptr() if tensor.numel() else 0
+    return layout, [(s - base, e - base) for s, e in segments]
+
+
+def test_classify_contiguous_1d():
+    t = torch.tensor([1, 2, 3, 4], dtype=torch.int32)
+    assert _normalize(_classify_layout_and_segments(t), t) == (
+        "contiguous",
+        [(0, 15)],
+    )
+
+
+def test_classify_dim0_contiguous_transpose():
+    # ``t.T`` alone is storage-contiguous (just F-order), so it falls into the
+    # single-segment path. Slice it to force the dim-0-contiguous bucket:
+    # ``t.T[1:]`` has strides (1, 8) and a non-zero storage_offset.
+    t = torch.arange(32, dtype=torch.int32).reshape(4, 8).T[1:]  # shape (7, 4)
+    layout, rel = _normalize(_classify_layout_and_segments(t), t)
+    assert layout == "dim-0-contiguous"
+    # 4 segments (outer dim 1 size = 4), each covering 7 int32 elements = 28 bytes,
+    # separated by stride[1]=8 elements = 32 bytes.
+    assert len(rel) == 4
+    assert rel[0] == (0, 27)
+    assert rel[1] == (32, 59)
+
+
+def test_classify_dim1_contiguous_slice():
+    # ``t[:, 2:6]``: storage-discontiguous but inner dim 1 still has stride 1.
+    base_t = torch.arange(32, dtype=torch.int32).reshape(4, 8)
+    t = base_t[:, 2:6]
+    layout, rel = _normalize(_classify_layout_and_segments(t), t)
+    assert layout == "dim-1-contiguous"
+    # 4 row segments, each 4 int32 wide = 16 bytes; rows separated by 32 bytes.
+    assert len(rel) == 4
+    assert rel[0] == (0, 15)
+    assert rel[1] == (32, 47)
+
+
+def test_classify_per_element_strided_view():
+    base_t = torch.tensor([10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[0::2]
+    assert _normalize(_classify_layout_and_segments(view), view) == (
+        "per-element",
+        [(0, 3), (8, 11), (16, 19)],
+    )
+
+
+def test_classify_per_element_nonzero_storage_offset():
+    base_t = torch.tensor([99, 10, 99, 11, 99, 12], dtype=torch.int32)
+    view = base_t[1::2]
+    assert view.storage_offset() == 1
+    assert _normalize(_classify_layout_and_segments(view), view) == (
+        "per-element",
+        [(0, 3), (8, 11), (16, 19)],
+    )
+
+
+def test_classify_empty_tensor():
+    t = torch.empty((0,), dtype=torch.int32)
+    assert _classify_layout_and_segments(t) == ("empty", [])

--- a/triton_viz/clients/sanitizer/report.py
+++ b/triton_viz/clients/sanitizer/report.py
@@ -2,13 +2,51 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 
+from ...core.config import config as cfg
 from ...core.data import Load, Store
 from ...utils.traceback_utils import read_source_segment
+from ..utils import (
+    check_inner_stride_equal_to_one,
+    check_storage_contiguous,
+    get_physical_addr_from_tensor_slice,
+    get_physical_addr_per_element,
+)
 from .data import (
     OutOfBoundsRecord,
     OutOfBoundsRecordBruteForce,
     OutOfBoundsRecordZ3,
 )
+
+
+def _classify_layout_and_segments(tensor):
+    """Return ``(layout_label, segments)`` mirroring SymbolicClient.arg_callback.
+
+    Segments are ``(start, end)`` byte ranges with both endpoints inclusive.
+    The layout label is one of:
+      - ``contiguous`` — whole storage is one contiguous segment
+      - ``dim-N-contiguous`` — dim N has stride 1; other dims index into
+        independent contiguous runs
+      - ``per-element`` — no dim has stride 1; each logical element is its
+        own segment (precise view semantics)
+      - ``empty`` — tensor has zero elements
+    """
+    if tensor.numel() == 0:
+        return "empty", []
+    if tensor.is_contiguous() or check_storage_contiguous(tensor):
+        start = tensor.data_ptr()
+        end = start + tensor.numel() * tensor.element_size() - 1
+        return "contiguous", [(start, end)]
+    if check_inner_stride_equal_to_one(tensor):
+        inner_dim = min(
+            (d for d in range(tensor.dim()) if tensor.stride(d) != 0),
+            key=lambda d: tensor.stride(d),
+        )
+        return (
+            f"dim-{inner_dim}-contiguous",
+            get_physical_addr_from_tensor_slice(tensor),
+        )
+    return "per-element", get_physical_addr_per_element(tensor)
+
 
 if TYPE_CHECKING:
     from ..symbolic_engine import SymbolicExpr
@@ -172,14 +210,44 @@ def print_oob_record_pdb_style(
         f"  {green}{'contiguous:':<{col1_width}}{reset_color} {str(tensor.is_contiguous()):<{col2_width}} {green}{'base_ptr:':<{col3_width}}{reset_color} 0x{tensor.data_ptr():016x}"
     )
 
-    total_bytes = np.prod(tensor.shape) * tensor.element_size()
-    size_str = f"{total_bytes} bytes"
-    range_str = (
-        f"[0x{tensor.data_ptr():016x}, 0x{tensor.data_ptr() + total_bytes:016x})"
-    )
-    print(
-        f"  {green}{'size:':<{col1_width}}{reset_color} {size_str:<{col2_width}} {green}{'valid_range:':<{col3_width}}{reset_color} {range_str}"
-    )
+    total_bytes = int(np.prod(tensor.shape)) * tensor.element_size()
+    layout, segments = _classify_layout_and_segments(tensor)
+
+    def _seg_str(seg):
+        s, e = seg
+        return f"[0x{s:016x}, 0x{e + 1:016x})"
+
+    if len(segments) == 1:
+        # Single-segment: keep the original one-line format.
+        size_str = f"{total_bytes} bytes"
+        range_str = _seg_str(segments[0])
+        print(
+            f"  {green}{'size:':<{col1_width}}{reset_color} {size_str:<{col2_width}} {green}{'valid_range:':<{col3_width}}{reset_color} {range_str}"
+        )
+    elif len(segments) == 0:
+        print(f"  {green}{'size:':<{col1_width}}{reset_color} 0 bytes (empty tensor)")
+        print(f"  {green}{'valid_range:':<{col1_width}}{reset_color} (no segments)")
+    else:
+        span_start = segments[0][0]
+        span_end = segments[-1][1] + 1
+        size_str = f"{total_bytes} bytes (layout: {layout})"
+        print(f"  {green}{'size:':<{col1_width}}{reset_color} {size_str}")
+        range_header = (
+            f"{len(segments)} segments spanning "
+            f"[0x{span_start:016x}, 0x{span_end:016x})"
+        )
+        print(f"  {green}{'valid_range:':<{col1_width}}{reset_color} {range_header}")
+        max_display = max(2, cfg.sanitizer_report_max_segments)
+        if len(segments) <= max_display:
+            for seg in segments:
+                print(f"    {_seg_str(seg)}")
+        else:
+            head = tail = max_display // 2
+            for seg in segments[:head]:
+                print(f"    {_seg_str(seg)}")
+            print(f"    ... ({len(segments) - head - tail} more)")
+            for seg in segments[-tail:]:
+                print(f"    {_seg_str(seg)}")
 
     # ===================== Call Stack =====================
     print(f"{bold}{cyan}━━━ Call Stack ━━━{reset_color}")

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -126,6 +126,14 @@ def check_inner_stride_equal_to_one(tensor: torch.Tensor):
 
 
 def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int, int]]:
+    """One contiguous byte segment per outer-index tuple, covering the run of
+    ``inner_dim_size`` elements along the dim whose stride is 1.
+
+    Segments are byte-inclusive ``(start, end)`` ranges, matching the
+    convention used by :func:`get_physical_addr_per_element`. ``data_ptr()``
+    already points at the view's element-0 address (it folds in
+    ``storage_offset``), so element offsets are computed relative to it.
+    """
     non_zero = [s for s in tensor.stride() if s != 0]
     if len(non_zero) == 0 or sorted(non_zero)[0] != 1:
         raise ValueError("inner dim must be contiguous!")
@@ -137,22 +145,18 @@ def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int,
     )
     # Stride-0 dims access the same memory for all indices, so collapse to size 1
     outer_dims = [d for d in range(dims) if d != inner_dim]
+    itemsize = tensor.element_size()
+    base = tensor.data_ptr()
+    inner_dim_size = int(tensor.size(inner_dim))
 
     segments = []
     for idxs in itertools.product(
         *(range(1 if tensor.stride(d) == 0 else tensor.size(d)) for d in outer_dims)
     ):
-        offset = int(tensor.storage_offset()) + sum(
-            idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims)
-        )
-        inner_dim_size = int(tensor.size(inner_dim))
-        segments.append(
-            (
-                tensor.data_ptr() + offset * tensor.element_size(),
-                tensor.data_ptr()
-                + (offset + inner_dim_size - 1) * tensor.element_size(),
-            )
-        )
+        offset = sum(idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims))
+        start = base + offset * itemsize
+        end = start + inner_dim_size * itemsize - 1
+        segments.append((start, end))
     return segments
 
 

--- a/triton_viz/core/config.py
+++ b/triton_viz/core/config.py
@@ -43,6 +43,9 @@ class Config:
       non-unit-inner-stride tensors. Behavior is unchanged; the warning just
       signals that the symbolic solver may slow down. Set to 0 to disable
       the warning entirely.
+    - sanitizer_report_max_segments: SANITIZER_REPORT_MAX_SEGMENTS, max
+      number of address segments to list verbatim in the OOB report before
+      truncating to a head/tail summary. Affects display only (min 2).
     """
 
     def __init__(self) -> None:
@@ -72,6 +75,9 @@ class Config:
         )
         self.symbolic_per_element_warn_threshold: int = _get_int_env(
             "SYMBOLIC_PER_ELEMENT_WARN_THRESHOLD", 8192, minimum=0
+        )
+        self.sanitizer_report_max_segments: int = _get_int_env(
+            "SANITIZER_REPORT_MAX_SEGMENTS", 8, minimum=2
         )
 
 


### PR DESCRIPTION
Stacked on top of #368.

## Summary
- The sanitizer's OOB report used ``numel * itemsize`` plus a single contiguous byte range for ``size`` and ``valid_range``, which is misleading for non-contiguous views. For the [triton-lang/triton#10336](https://github.com/triton-lang/triton/issues/10336) pattern (``bins_base[0::2]``) the previous output reported ``valid_range: [base, base + 12)``, hiding that the actual valid bytes are sparse with stride-induced gaps.
- New ``_classify_layout_and_segments`` mirrors the dispatch in ``SymbolicClient.arg_callback`` and tags each tensor as ``contiguous`` / ``dim-N-contiguous`` / ``per-element`` / ``empty``. Multi-segment tensors now list each byte segment in the report.
- Drive-by fix: ``get_physical_addr_from_tensor_slice`` had the same ``storage_offset`` double-count bug as ``get_physical_addr_per_element`` (which #368 already corrected) and reported ends at the start of the last element rather than its last byte. Both now use the same byte-inclusive convention.

## Example (issue 10336 repro)

Before:
```
size:        12 bytes
valid_range: [0x...780, 0x...78c)
Violation address: 0x...798
```

After:
```
size:        12 bytes (layout: per-element)
valid_range: 3 segments spanning [0x...29c0, 0x...29d4)
    [0x...29c0, 0x...29c4)
    [0x...29c8, 0x...29cc)
    [0x...29d0, 0x...29d4)
Violation address: 0x...29d8
```

<img width="782" height="593" alt="image" src="https://github.com/user-attachments/assets/9a97abd0-ac82-48ef-bc2a-1c3745d459d0" />

## Changes
- ``triton_viz/clients/sanitizer/report.py``: ``_classify_layout_and_segments`` helper + layout-aware ``size``/``valid_range`` rendering with head/tail truncation above the threshold.
- ``triton_viz/clients/utils.py``: ``get_physical_addr_from_tensor_slice`` no longer double-counts ``storage_offset``; segment ends are now byte-inclusive matching ``get_physical_addr_per_element``.
- ``triton_viz/core/config.py``: ``sanitizer_report_max_segments`` (env ``SANITIZER_REPORT_MAX_SEGMENTS``, default 8, min 2) controls display truncation only.
- ``tests/unit/test_sanitizer.py``: six unit tests on ``_classify_layout_and_segments`` (contiguous 1-D, dim-0-contiguous transpose, dim-1-contiguous slice, per-element view with zero and non-zero storage_offset, empty tensor).

## Test plan
- [x] ``uv run pytest tests/unit/test_sanitizer.py tests/unit/test_utils.py tests/end_to_end/test_sanitizer.py`` — 60/60 pass.
- [x] Ran ``/tmp/issue_10336_repro.py`` against the new code; the sanitizer report shows the three per-element segments and the violation address falls outside all three.