### PR TITLE
[FIX] get_physical_addr_from_tensor_slice: do not double-count storage_offset

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1027,6 +1027,39 @@ def test_non_contiguous_expanded_tensor():
     read_expanded_kernel[(M,)](x, out, x.stride(0), x.stride(1), M, N, BLOCK_N=8)
 
 
+# ======== Sliced View with Nonzero storage_offset Regression Test ===========
+
+
+inner_stride1_offset_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=inner_stride1_offset_sanitizer)
+@triton.jit
+def inner_stride1_offset_no_oob_kernel(x_ptr, out_ptr, L: tl.constexpr):
+    offs = tl.arange(0, 4)
+    x = tl.load(x_ptr + offs, mask=offs < L, other=0)
+    tl.store(out_ptr + offs, x, mask=offs < L)
+
+
+def test_inner_stride1_nonzero_storage_offset_no_oob():
+    """Sliced view with inner-stride 1 and nonzero storage_offset: reading
+    the inner-contiguous first row is legal and must not be reported as OOB.
+    Regression for get_physical_addr_from_tensor_slice() double-counting
+    storage_offset."""
+    inner_stride1_offset_sanitizer.records.clear()
+
+    base = torch.arange(20, dtype=torch.int32).reshape(4, 5)
+    x = base[1:3, 1:4]
+    # shape=(2, 3), stride=(5, 1), storage_offset=6
+    # First row is physically contiguous: x_ptr + {0, 1, 2}
+
+    out = torch.empty((4,), dtype=torch.int32)
+
+    inner_stride1_offset_no_oob_kernel[(1,)](x, out, L=3)
+
+    assert len(inner_stride1_offset_sanitizer.records) == 0
+
+
 # ======== Data-Dependent Loop Bound (Integer Division) Tests ===========
 
 

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -3,11 +3,17 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+import torch
 from z3 import Int
 
 from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.clients.symbolic_engine import LoopContext
 from triton_viz.clients.tracer.tracer import Tracer
+from triton_viz.clients.utils import (
+    check_inner_stride_equal_to_one,
+    check_storage_contiguous,
+    get_physical_addr_from_tensor_slice,
+)
 from triton_viz.core.data import Load
 from triton_viz.core.trace import trace_source
 from triton_viz.utils import traceback_utils
@@ -190,3 +196,35 @@ def test_undecorated_helper_captured_via_boundary_marker():
     assert any("my_kernel" in fn for fn in func_names)
     assert any("helper_a" in fn for fn in func_names)
     assert any("helper_b" in fn for fn in func_names)
+
+
+def _relative_slice_segments(tensor: torch.Tensor) -> list[tuple[int, int]]:
+    base = tensor.data_ptr()
+    return [
+        (s - base, e - base) for s, e in get_physical_addr_from_tensor_slice(tensor)
+    ]
+
+
+def test_get_physical_addr_from_tensor_slice_nonzero_storage_offset():
+    """Sliced view with nonzero storage_offset: segments must be relative to
+    tensor.data_ptr() (which already accounts for storage_offset), not double-counted."""
+    base = torch.arange(20, dtype=torch.int32).reshape(4, 5)
+    view = base[1:3, 1:4]
+    # visible:
+    # [[ 6,  7,  8],
+    #  [11, 12, 13]]
+
+    assert view.shape == (2, 3)
+    assert view.stride() == (5, 1)
+    assert view.storage_offset() == 6
+
+    # Ensure this goes through get_physical_addr_from_tensor_slice().
+    assert not view.is_contiguous()
+    assert not check_storage_contiguous(view)
+    assert check_inner_stride_equal_to_one(view)
+
+    # Helper convention: end is the address of the last element start,
+    # matching the existing contiguous / slice fast paths.
+    # itemsize = 4 bytes; row stride = 5 elements = 20 bytes; inner size = 3 elements.
+    # Row 0 covers bytes [0, 8]; row 1 covers bytes [20, 28], all relative to data_ptr().
+    assert _relative_slice_segments(view) == [(0, 8), (20, 28)]

--- a/triton_viz/clients/utils.py
+++ b/triton_viz/clients/utils.py
@@ -138,19 +138,21 @@ def get_physical_addr_from_tensor_slice(tensor: torch.Tensor) -> list[tuple[int,
     # Stride-0 dims access the same memory for all indices, so collapse to size 1
     outer_dims = [d for d in range(dims) if d != inner_dim]
 
+    itemsize = tensor.element_size()
+    base = tensor.data_ptr()
+    inner_dim_size = int(tensor.size(inner_dim))
+
     segments = []
     for idxs in itertools.product(
         *(range(1 if tensor.stride(d) == 0 else tensor.size(d)) for d in outer_dims)
     ):
-        offset = int(tensor.storage_offset()) + sum(
-            idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims)
-        )
-        inner_dim_size = int(tensor.size(inner_dim))
+        # tensor.data_ptr() already accounts for storage_offset, so offsets here
+        # are measured relative to data_ptr() — adding storage_offset would double-count.
+        offset = sum(idx * int(tensor.stride(d)) for idx, d in zip(idxs, outer_dims))
         segments.append(
             (
-                tensor.data_ptr() + offset * tensor.element_size(),
-                tensor.data_ptr()
-                + (offset + inner_dim_size - 1) * tensor.element_size(),
+                base + offset * itemsize,
+                base + (offset + inner_dim_size - 1) * itemsize,
             )
         )
     return segments


### PR DESCRIPTION
## Summary
- `get_physical_addr_from_tensor_slice()` adds `tensor.storage_offset()` into `offset` before multiplying by `itemsize` and adding `tensor.data_ptr()`. But `data_ptr()` already incorporates `storage_offset * itemsize`, so every registered segment is shifted by an extra `storage_offset * itemsize` bytes.
- For a sliced view like `base[1:3, 1:4]` (`shape=(2,3)`, `stride=(5,1)`, `storage_offset=6`), the helper returned segments at bytes `[24..32]` and `[44..52]` relative to `data_ptr()` instead of the correct `[0..8]` and `[20..28]`. The sanitizer then false-alarmed on legal loads of the inner-contiguous row.
- Fix: drop the extra `storage_offset` term so offsets are computed strictly relative to `data_ptr()`. Hoisted `itemsize` / `base` / `inner_dim_size` out of the loop while there.

## Reproducer
```python
base = torch.arange(20, dtype=torch.int32).reshape(4, 5)
view = base[1:3, 1:4]   # storage_offset=6, stride=(5,1)
# Before: [(24, 32), (44, 52)] relative to data_ptr()
# After:  [(0, 8), (20, 28)]
```

## Tests
- `tests/unit/test_utils.py::test_get_physical_addr_from_tensor_slice_nonzero_storage_offset` — exercises the helper directly on `base[1:3, 1:4]` and asserts the relative segments.
- `tests/end_to_end/test_sanitizer.py::test_inner_stride1_nonzero_storage_offset_no_oob` — runs a Triton kernel that loads only the inner-contiguous first row of the view; asserts the sanitizer records no OOB.

## Test plan
- [ ] CI: `uv run pytest tests/unit/test_utils.py -k storage_offset -q`
- [ ] CI: `uv run pytest tests/end_to_end/test_sanitizer.py -k inner_stride1_nonzero_storage_offset -q`
- [ ] CI: full sanitizer e2e suite stays green