### PR TITLE
[FIX] Patch Triton extra builtins in trace mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Triton-Viz is a Python package with a TypeScript frontend. Core code lives in `triton_viz/`: `core/` handles tracing and client lifecycle, `clients/` contains visualizer/profiler/sanitizer logic, and `frontends/`, `transformers/`, and `visualizer/` cover DSL integration, AST rewrites, and visualizer APIs. Frontend source is in `frontend/`; built assets are copied into `triton_viz/static/` and `triton_viz/templates/`. Tests live in `tests/unit/`, `tests/end_to_end/`, `tests/frontend/`, and `tests/nki/`. Examples are in `examples/`; site docs are in `docs/`.
+
+## Build, Test, and Development Commands
+
+- `uv sync --extra test`: install Python test dependencies.
+- `uv sync --extra nki --extra test`: install NKI plus test dependencies; specify all extras in one command.
+- `uv run pytest tests/`: run the default Python suite, excluding tests marked `nki`.
+- `uv run pytest tests/ -m ""`: run all Python tests, including NKI tests when dependencies are installed.
+- `npm install`: install frontend tooling.
+- `npm run build:frontend`: compile TypeScript and copy frontend package assets.
+- `npm run test:frontend`: build the frontend and run Node-based frontend tests.
+
+## Coding Style & Naming Conventions
+
+Use Python 3.10+ and TypeScript modules. Follow file-local style: 4-space indentation for Python and descriptive snake_case names for functions, variables, and test helpers. Python tests are discovered from `*.py`, classes ending in `Test`, and functions named `test_*`. Ruff is configured in `pyproject.toml` with `E731` ignored; run pre-commit when available. Keep generated package assets in sync when editing `frontend/`.
+
+## Testing Guidelines
+
+Prefer focused tests near the behavior being changed: unit tests in `tests/unit/`, kernel or CLI-visible behavior in `tests/end_to_end/`, and frontend tests in `tests/frontend/*.mjs`. Default pytest skips NKI tests; use `-m nki` for only NKI tests or `-m ""` for the full suite. For sanitizer work, cover records, reports, CLI behavior, and launch lifecycle where applicable.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use concise imperative summaries, often with prefixes such as `[FIX]`, `[FEAT]`, or `[REFACTOR]`, and PR numbers added by GitHub, for example `[FIX] Handle stride-0 expanded tensors in sanitizer (#327)`. Keep commits scoped to one logical change. Pull requests should explain the user-visible change, list test commands run, link related issues, and include screenshots or trace examples when frontend or visualizer output changes.
+
+## Security & Configuration Tips
+
+Do not commit local traces, credentials, or generated debug artifacts. Runtime behavior is controlled by environment variables such as `TRITON_VIZ_VERBOSE`, `TRITON_VIZ_PORT`, `ENABLE_SANITIZER`, `ENABLE_PROFILER`, and `SANITIZER_ENABLE_FAKE_TENSOR`; document any new variables in `README.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
   "setuptools",
-  "triton>=3.4.0",
+  "triton>=3.6.0",
   "pyarrow",
   "pre-commit",
   "z3-solver==4.15.3.0",

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -76,9 +76,7 @@ def test_trace_patches_extra_cuda_builtins():
 
     out = torch.empty((128,), dtype=torch.int32)
     extra_cuda_builtin_kernel[(1,)](out, num_warps=4)
-    torch.testing.assert_close(
-        out, torch.arange(128, dtype=torch.int32)
-    )
+    torch.testing.assert_close(out, torch.arange(128, dtype=torch.int32))
 
 
 # ======== Nested JIT Call Tests =========

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -67,6 +67,25 @@ def test_unpatch_lang_restores_builtins():
         dummy_kernel[grid](x, BLOCK_SIZE=block_size)
 
 
+def test_trace_patches_extra_cuda_builtins():
+    if not torch.cuda.is_available():
+        pytest.skip("cuda required for triton kernel execution")
+
+    @triton_viz.trace("sanitizer")
+    @triton.jit
+    def extra_cuda_builtin_kernel(out):
+        offs = tl.arange(0, tl.extra.cuda.num_threads())
+        tl.store(out + offs, offs)
+
+    out = torch.empty((128,), device="cuda", dtype=torch.int32)
+    extra_cuda_builtin_kernel[(1,)](out, num_warps=4)
+    if extra_cuda_builtin_kernel.jit_fn is not None:
+        extra_cuda_builtin_kernel.jit_fn[(1,)](out, num_warps=4)
+        torch.testing.assert_close(
+            out, torch.arange(128, device="cuda", dtype=torch.int32)
+        )
+
+
 # ======== Nested JIT Call Tests =========
 @triton_viz.trace(client=Sanitizer(abort_on_error=True))
 @triton.jit

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -68,22 +68,17 @@ def test_unpatch_lang_restores_builtins():
 
 
 def test_trace_patches_extra_cuda_builtins():
-    if not torch.cuda.is_available():
-        pytest.skip("cuda required for triton kernel execution")
-
     @triton_viz.trace("sanitizer")
     @triton.jit
     def extra_cuda_builtin_kernel(out):
         offs = tl.arange(0, tl.extra.cuda.num_threads())
         tl.store(out + offs, offs)
 
-    out = torch.empty((128,), device="cuda", dtype=torch.int32)
+    out = torch.empty((128,), dtype=torch.int32)
     extra_cuda_builtin_kernel[(1,)](out, num_warps=4)
-    if extra_cuda_builtin_kernel.jit_fn is not None:
-        extra_cuda_builtin_kernel.jit_fn[(1,)](out, num_warps=4)
-        torch.testing.assert_close(
-            out, torch.arange(128, device="cuda", dtype=torch.int32)
-        )
+    torch.testing.assert_close(
+        out, torch.arange(128, dtype=torch.int32)
+    )
 
 
 # ======== Nested JIT Call Tests =========

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -68,7 +68,7 @@ def test_unpatch_lang_restores_builtins():
 
 
 def test_trace_patches_extra_cuda_builtins():
-    @triton_viz.trace("sanitizer")
+    @triton_viz.trace("tracer")
     @triton.jit
     def extra_cuda_builtin_kernel(out):
         offs = tl.arange(0, tl.extra.cuda.num_threads())

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -22,6 +22,7 @@ from triton.runtime.interpreter import (
     GridExecutor,
     _implicit_cvt,
     interpreter_builder,
+    _patch_builtin,
 )
 from triton.runtime.interpreter import _patch_lang as triton_patch_lang
 from triton.runtime.interpreter import ASTTransformer as _OrigASTTransformer
@@ -114,6 +115,18 @@ def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
         _capture_builtin_attrs(scope, tl.core.tensor_descriptor_base)
 
     return scope
+
+
+def _triton_extra_builtin_modules() -> tuple[Any, ...]:
+    modules = []
+    extra = getattr(tl, "extra", None)
+    if extra is None:
+        return ()
+    for name in ("cuda", "hip"):
+        module = getattr(extra, name, None)
+        if module is not None:
+            modules.append(module)
+    return tuple(modules)
 
 
 def _pop_lang_patch_scope(backend: str) -> Any | None:
@@ -325,6 +338,8 @@ def patch_lang(fn, backend, client_manager=None):
     if backend == "triton":
         scope = _triton_snapshot_scope(fn)
         triton_patch_lang(fn)
+        for module in _triton_extra_builtin_modules():
+            _patch_builtin(module, interpreter_builder, scope)
     elif backend == "nki":
         from triton_viz.core.nki import nki_patch_lang
 
@@ -423,6 +438,7 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
         return
 
     builder = OPERATION_REGISTRY[backend].builder
+    launch_num_warps = kwargs.get("num_warps", 4)
 
     # Removes not used reserved keywords from kwargs
     # Triton doesn't support keyword-only, variable positional or variable keyword arguments
@@ -511,10 +527,18 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
 
         start_time = time.time()
 
-    if max_workers == 1:
-        run_grid_loops_1thread(grid)
-    else:
-        run_grid_loops(grid)
+    old_num_warps = getattr(builder.options, "num_warps", _MISSING)
+    object.__setattr__(builder.options, "num_warps", launch_num_warps)
+    try:
+        if max_workers == 1:
+            run_grid_loops_1thread(grid)
+        else:
+            run_grid_loops(grid)
+    finally:
+        if old_num_warps is _MISSING:
+            object.__delattr__(builder.options, "num_warps")
+        else:
+            object.__setattr__(builder.options, "num_warps", old_num_warps)
 
     if cfg.enable_timing:
         end_time = time.time()


### PR DESCRIPTION
## Summary

Patches Triton `tl.extra.cuda` / `tl.extra.hip` builtins in trace mode and propagates launch `num_warps` into interpreter builder options during traced execution.

## Validation

- `python -m pytest tests/end_to_end/test_core.py::test_trace_patches_extra_cuda_builtins`
- Stack tip validation: `python -m pytest tests/` passed

## Stack

Generated from local open PR branches; each PR after the first targets the previous PR's head branch.

1. [#372](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/372) [FIX] Patch Triton extra builtins in trace mode -> **YOU ARE HERE**
1. [#379](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/379) [FIX] Support inline asm in traced kernels
1. [#373](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/373) [FIX] Support symbolic sort in traced kernels
1. [#374](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/374) [FIX] Normalize symbolic reduction axes
1. [#375](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/375) [REFACTOR] Simplify sanitizer tensor address ranges
1. [#376](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/376) [FIX] Support pointer tuples in sanitizer
1. [#377](https://github.com/Deep-Learning-Profiling-Tools/triton-viz/pull/377) [FIX] Support cumsum-derived sanitizer indexes