### PR TITLE
[FIX] Support vector symbolic expressions

### DIFF
--- a/tests/unit/test_symbolic_client.py
+++ b/tests/unit/test_symbolic_client.py
@@ -11,7 +11,9 @@ tests live next to their respective clients.
 import pytest
 from typing import cast
 
+import numpy as np
 import triton.language as tl
+from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.clients.symbolic_engine import (
     SymbolicClient,
@@ -100,6 +102,25 @@ def test_basic_expr_const_eval(value):
     assert constraints is None
 
 
+def test_tensorhandle_vector_const_concretize_and_eval():
+    handle = TensorHandle(np.array([1, 2, 3], dtype=np.int32), tl.int32)
+
+    expr = SymbolicExpr.from_value(handle)
+
+    assert isinstance(expr, SymbolicExpr)
+    assert expr.to_py() == [1, 2, 3]
+    concrete = expr.concretize()
+    assert isinstance(concrete, TensorHandle)
+    np.testing.assert_array_equal(concrete.data, handle.data)
+    result, constraints = expr.eval(simplify_constraints=False)
+    assert [cast(IntNumRef, value).as_long() for value in cast(list, result)] == [
+        1,
+        2,
+        3,
+    ]
+    assert constraints is None
+
+
 @pytest.mark.parametrize(
     "axis,expected_pid",
     [
@@ -185,6 +206,56 @@ def test_binary_expr_eval(op: str, lhs: int, rhs: int, expected):
     assert constraints is None
 
 
+def test_binary_expr_eval_broadcasts_singleton_vector_operand():
+    lhs_expr = SymbolicExpr.create("const", (1, 2, 3), tl.int32)
+    rhs_expr = SymbolicExpr.create("const", (10,), tl.int32)
+    expr = SymbolicExpr.create("add", lhs_expr, rhs_expr)
+
+    result, constraints = expr.eval(simplify_constraints=False)
+
+    assert [cast(IntNumRef, value).as_long() for value in cast(list, result)] == [
+        11,
+        12,
+        13,
+    ]
+    assert constraints is None
+
+
+def test_binary_expr_concretize_vector_tensorhandles():
+    lhs = TensorHandle(np.array([8, 4, 2], dtype=np.int32), tl.int32)
+    rhs = TensorHandle(np.array([1, 2, 3], dtype=np.int32), tl.int32)
+    expr = SymbolicExpr.create("add", SymbolicExpr.from_value(lhs), SymbolicExpr.from_value(rhs))
+
+    concrete = expr.concretize()
+
+    assert isinstance(concrete, TensorHandle)
+    np.testing.assert_array_equal(concrete.data, np.array([9, 6, 5], dtype=np.int32))
+
+
+def test_ashr_expr_eval_and_concretize_vector_tensorhandles():
+    lhs = SymbolicExpr.create("const", (8, 4, 2), tl.int32)
+    rhs = SymbolicExpr.create("const", (1,), tl.int32)
+    expr = SymbolicExpr.create("ashr", lhs, rhs)
+
+    result, constraints = expr.eval(simplify_constraints=False)
+
+    assert [cast(IntNumRef, value).as_long() for value in cast(list, result)] == [
+        4,
+        2,
+        1,
+    ]
+    assert constraints is None
+
+    lhs_handle = TensorHandle(np.array([8, 4, 2], dtype=np.int32), tl.int32)
+    rhs_handle = TensorHandle(np.array([1, 1, 1], dtype=np.int32), tl.int32)
+    concrete_expr = SymbolicExpr.create(
+        "ashr", SymbolicExpr.from_value(lhs_handle), SymbolicExpr.from_value(rhs_handle)
+    )
+    concrete = concrete_expr.concretize()
+    assert isinstance(concrete, TensorHandle)
+    np.testing.assert_array_equal(concrete.data, np.array([4, 2, 1], dtype=np.int32))
+
+
 def test_bitwise_bool_expr_eval():
     """
     Test short circuiting behavior of bitwise_and and bitwise_or operators which do not
@@ -219,6 +290,23 @@ def test_bitwise_bool_expr_eval():
     assert constraints is None
 
 
+def test_where_expr_concretize_vector_tensorhandles():
+    cond = TensorHandle(np.array([True, False, True], dtype=bool), tl.int1)
+    lhs = TensorHandle(np.array([10, 20, 30], dtype=np.int32), tl.int32)
+    rhs = TensorHandle(np.array([-1, -2, -3], dtype=np.int32), tl.int32)
+    expr = SymbolicExpr.create(
+        "where",
+        SymbolicExpr.from_value(cond),
+        SymbolicExpr.from_value(lhs),
+        SymbolicExpr.from_value(rhs),
+    )
+
+    concrete = expr.concretize()
+
+    assert isinstance(concrete, TensorHandle)
+    np.testing.assert_array_equal(concrete.data, np.array([10, -2, 30], dtype=np.int32))
+
+
 # ======== Pointer Symbolic Expr Operations Tests =========
 
 
@@ -229,6 +317,24 @@ def test_pointer_expr_addptr_eval():
     expr = SymbolicExpr.create("addptr", base, offset)
     result, constraints = expr.eval(simplify_constraints=False)
     assert cast(IntNumRef, result).as_long() == 112
+    assert constraints is None
+
+
+def test_pointer_expr_addptr_broadcasts_singleton_pointer_base():
+    base_handle = TensorHandle(
+        np.array([100], dtype=np.uint64), tl.pointer_type(tl.int32)
+    )
+    base = SymbolicExpr.from_value(base_handle)
+    offset = SymbolicExpr.create("const", (0, 1, 2), tl.int32)
+    expr = SymbolicExpr.create("addptr", base, offset)
+
+    result, constraints = expr.eval(simplify_constraints=False)
+
+    assert [cast(IntNumRef, value).as_long() for value in cast(list, result)] == [
+        100,
+        104,
+        108,
+    ]
     assert constraints is None
 
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -503,10 +503,6 @@ class SymbolicExpr:
         if isinstance(var, tl.core.tensor):
             var = var.handle
         if isinstance(var, TensorHandle):
-            if len(var.data) != 1:
-                raise ValueError(
-                    f"Unsupported var.data: {var.data} with length more than one!"
-                )
             if var.dtype in SymbolicExpr.triton_scala_dtypes:  # if an immediate
                 return var.dtype
             if isinstance(var.dtype, tl.pointer_type):  # if a pointer
@@ -554,11 +550,7 @@ class SymbolicExpr:
         dtype = SymbolicExpr._infer_literal_dtype(var)  # get the triton dtype
 
         if isinstance(var, TensorHandle):  # if a TensorHandle
-            if len(var.data) != 1:
-                raise ValueError(
-                    "SymbolicExpr.from_value only supports scalar TensorHandle!"
-                )
-            return cls.create("const", var.data.item(), dtype)
+            return cls.create("const", var, dtype)
         if isinstance(
             var, SymbolicExpr.builtin_scala_types
         ):  # if a python builtin type
@@ -622,6 +614,11 @@ class SymbolicExpr:
                 for child in self.children.values()
             )
         ):
+            if self.op == "const" and isinstance(
+                getattr(self, "value", None),
+                (tl.core.dtype, tl.pointer_type, tl.block_type),
+            ):
+                return self
             concrete = self.concretize()
             if not isinstance(concrete, TensorHandle):
                 raise TypeError(f"Unexpected dtype: {type(concrete)}!")
@@ -944,15 +941,37 @@ class BinarySymbolicExpr(SymbolicExpr):
         return handler(self, lhs, rhs), constraints
 
     def concretize(self) -> Any:
+        np_op = self._NUMPY_OPS.get(self.op, None)
+        if np_op is not None and self.lhs.op == "const" and self.rhs.op == "const":
+            lhs_value = getattr(self.lhs, "value", None)
+            rhs_value = getattr(self.rhs, "value", None)
+            if isinstance(lhs_value, TensorHandle) and isinstance(
+                rhs_value, TensorHandle
+            ):
+                data = np_op(lhs_value.data, rhs_value.data)
+                return TensorHandle(
+                    np.asarray(data, dtype=_get_np_dtype(self.dtype)), self.dtype
+                )
+
         lhs_concrete = self.lhs.concretize()
         rhs_concrete = self.rhs.concretize()
-        np_op = self._NUMPY_OPS.get(self.op, None)
+        if isinstance(lhs_concrete, SymbolicExpr):
+            lhs_concrete = lhs_concrete.concretize()
+        if isinstance(rhs_concrete, SymbolicExpr):
+            rhs_concrete = rhs_concrete.concretize()
         # Most ops (add, sub, mul, …) have a numpy mapping and are called
         # with concrete_fn(lhs, rhs, np_op).  Some ops like "idiv" have
         # their own concrete_fn that handles the computation internally
         # (e.g. InterpreterBuilder.create_idiv) and only takes (lhs, rhs).
         # Fall through to the 2-arg call for those.
         if np_op is not None:
+            if isinstance(lhs_concrete, TensorHandle) and isinstance(
+                rhs_concrete, TensorHandle
+            ):
+                data = np_op(lhs_concrete.data, rhs_concrete.data)
+                return TensorHandle(
+                    np.asarray(data, dtype=_get_np_dtype(self.dtype)), self.dtype
+                )
             return self.concrete_fn(lhs_concrete, rhs_concrete, np_op)  # type: ignore
         if self.concrete_fn is None:
             raise NotImplementedError(
@@ -965,6 +984,10 @@ class BinarySymbolicExpr(SymbolicExpr):
         lhs_is_list = isinstance(left, list)
         rhs_is_list = isinstance(right, list)
         if lhs_is_list and rhs_is_list:
+            if len(left) == 1 and len(right) != 1:
+                return [op_func(left[0], ri) for ri in right]
+            if len(right) == 1 and len(left) != 1:
+                return [op_func(li, right[0]) for li in left]
             if len(left) != len(right):
                 raise ValueError(
                     f"List operands must have same length: {len(left)} vs {len(right)}"
@@ -1094,7 +1117,18 @@ class BinarySymbolicExpr(SymbolicExpr):
         return self._apply_binop(_bit_xor, lhs, rhs)
 
     def _op_ashr(self, lhs, rhs):
-        raise NotImplementedError("Arithmetic shift right is not implemented in Z3")
+        bitwidth = (
+            self._infer_bitwidth(self)
+            or self._infer_bitwidth(self.lhs)
+            or self._infer_bitwidth(self.rhs)
+            or 64
+        )
+
+        def _ashr(a, b):
+            shifted = self._to_bv(a, bitwidth) >> self._to_bv(b, bitwidth)
+            return BV2Int(shifted, is_signed=True)
+
+        return self._apply_binop(_ashr, lhs, rhs)
 
     _NUMPY_OPS: ClassVar[dict[str, Callable[[Any, Any], Any]]] = {
         "add": np.add,
@@ -1114,6 +1148,7 @@ class BinarySymbolicExpr(SymbolicExpr):
         "bitwise_or": np.bitwise_or,
         "bitwise_xor": np.bitwise_xor,
         "right_shift": np.right_shift,
+        "ashr": np.right_shift,
         "left_shift": np.left_shift,
     }
 
@@ -1158,6 +1193,27 @@ class WhereSymbolicExpr(SymbolicExpr):
         if handler is None:
             raise NotImplementedError(f"Eval for op {self.op} is not implemented")
         return handler(self)
+
+    def concretize(self) -> Any:
+        cond = self.cond.concretize()
+        lhs = self.lhs.concretize()
+        rhs = self.rhs.concretize()
+        if isinstance(cond, SymbolicExpr):
+            cond = cond.concretize()
+        if isinstance(lhs, SymbolicExpr):
+            lhs = lhs.concretize()
+        if isinstance(rhs, SymbolicExpr):
+            rhs = rhs.concretize()
+        if not (
+            isinstance(cond, TensorHandle)
+            and isinstance(lhs, TensorHandle)
+            and isinstance(rhs, TensorHandle)
+        ):
+            raise TypeError(
+                "where concretization expects TensorHandle condition and values"
+            )
+        data = np.where(cond.data.astype(bool), lhs.data, rhs.data)
+        return TensorHandle(np.asarray(data, dtype=_get_np_dtype(self.dtype)), self.dtype)
 
     def _where(self) -> tuple[Z3Expr, ConstraintConjunction]:
         def _normalize(expr):
@@ -1412,11 +1468,18 @@ class AddPtrSymbolicExpr(SymbolicExpr):
         if not isinstance(ptr_z3, list) and not isinstance(offset_z3, list):  # hot path
             z3_expr = ptr_z3 + offset_z3 * element_bytewidth
         elif isinstance(ptr_z3, list) and isinstance(offset_z3, list):
-            if len(ptr_z3) != len(offset_z3):
+            if len(ptr_z3) == 1 and len(offset_z3) != 1:
+                z3_expr = [ptr_z3[0] + o * element_bytewidth for o in offset_z3]
+            elif len(offset_z3) == 1 and len(ptr_z3) != 1:
+                z3_expr = [p + offset_z3[0] * element_bytewidth for p in ptr_z3]
+            elif len(ptr_z3) != len(offset_z3):
                 raise ValueError(
                     f"ptr {ptr_z3} and offset {offset_z3} don't have the same length!"
                 )
-            z3_expr = [p + o * element_bytewidth for p, o in zip(ptr_z3, offset_z3)]
+            else:
+                z3_expr = [
+                    p + o * element_bytewidth for p, o in zip(ptr_z3, offset_z3)
+                ]
         elif isinstance(ptr_z3, list):
             z3_expr = [p + offset_z3 * element_bytewidth for p in ptr_z3]
         else:  # isinstance(offset_z3, list):


### PR DESCRIPTION
## Summary

Adds vector-aware symbolic expression support needed by sanitizer checks over cumsum-derived lane values.

## Details

- Allows vector `TensorHandle` values to become symbolic constants.
- Adds concrete vector handling for binary ops and `where`.
- Adds singleton-list broadcasting for binary Z3 ops and `addptr`.
- Implements arithmetic-shift-right (`ashr`) for Z3 evaluation and concrete materialization.

## Validation

- `python -m pytest -q tests/unit/test_symbolic_client.py tests/unit/test_sanitizer.py`