### PR TITLE
[FIX] Support symbolic ashr checks

### DIFF
--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -1150,6 +1150,27 @@ def test_sanitizer_supports_data_dependent_cumsum_index():
     assert len(cumsum_sanitizer.records) == 0
 
 
+ashr_index_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=ashr_index_sanitizer)
+@triton.jit
+def ashr_index_store_kernel(out_ptr, BLOCK: tl.constexpr):
+    offs = tl.arange(0, BLOCK)
+    write_idx = offs >> 1
+    tl.store(out_ptr + write_idx, offs)
+
+
+def test_sanitizer_supports_ashr_in_symbolic_address():
+    ashr_index_sanitizer.records.clear()
+
+    out = torch.empty((4,), dtype=torch.int32)
+
+    ashr_index_store_kernel[(1,)](out, BLOCK=out.numel())
+
+    assert len(ashr_index_sanitizer.records) == 0
+
+
 # ======== Data-Dependent Loop Bound (Integer Division) Tests ===========
 
 

--- a/tests/unit/test_symbolic_client.py
+++ b/tests/unit/test_symbolic_client.py
@@ -11,9 +11,7 @@ tests live next to their respective clients.
 import pytest
 from typing import cast
 
-import numpy as np
 import triton.language as tl
-from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.clients.symbolic_engine import (
     SymbolicClient,

--- a/tests/unit/test_symbolic_client.py
+++ b/tests/unit/test_symbolic_client.py
@@ -11,7 +11,9 @@ tests live next to their respective clients.
 import pytest
 from typing import cast
 
+import numpy as np
 import triton.language as tl
+from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.clients.symbolic_engine import (
     SymbolicClient,
@@ -182,6 +184,17 @@ def test_binary_expr_eval(op: str, lhs: int, rhs: int, expected):
         assert str(result) == str(expected)
     else:
         assert cast(IntNumRef, result).as_long() == expected
+    assert constraints is None
+
+
+def test_ashr_expr_eval_scalar_constants():
+    lhs = SymbolicExpr.create("const", -8, tl.int32)
+    rhs = SymbolicExpr.create("const", 1, tl.int32)
+    expr = SymbolicExpr.create("ashr", lhs, rhs)
+
+    result, constraints = expr.eval(simplify_constraints=False)
+
+    assert cast(IntNumRef, result).as_long() == -4
     assert constraints is None
 
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -974,22 +974,30 @@ class BinarySymbolicExpr(SymbolicExpr):
             raise NotImplementedError(f"Eval for op {self.op} is not implemented")
         return handler(self, lhs, rhs), constraints
 
+    def _to_tensor_handle(self, value: Any) -> TensorHandle:
+        if isinstance(value, TensorHandle):
+            return value
+        return TensorHandle(
+            np.asarray(value, dtype=_get_np_dtype(self.dtype)), self.dtype
+        )
+
     def concretize(self) -> Any:
         lhs_concrete = self.lhs.concretize()
         rhs_concrete = self.rhs.concretize()
         np_op = self._NUMPY_OPS.get(self.op, None)
-        # Most ops (add, sub, mul, …) have a numpy mapping and are called
-        # with concrete_fn(lhs, rhs, np_op).  Some ops like "idiv" have
+        # Most ops (add, sub, mul, ...) have a NumPy mapping and are called
+        # with concrete_fn(lhs, rhs, np_op). Some ops like "idiv" have
         # their own concrete_fn that handles the computation internally
-        # (e.g. InterpreterBuilder.create_idiv) and only takes (lhs, rhs).
-        # Fall through to the 2-arg call for those.
+        # and only takes (lhs, rhs). Fall through to the 2-arg call for those.
         if np_op is not None:
-            return self.concrete_fn(lhs_concrete, rhs_concrete, np_op)  # type: ignore
+            return self._to_tensor_handle(
+                self.concrete_fn(lhs_concrete, rhs_concrete, np_op)  # type: ignore
+            )
         if self.concrete_fn is None:
             raise NotImplementedError(
                 f"Concretize for binary op '{self.op}' is not implemented"
             )
-        return self.concrete_fn(lhs_concrete, rhs_concrete)  # type: ignore
+        return self._to_tensor_handle(self.concrete_fn(lhs_concrete, rhs_concrete))  # type: ignore
 
     @staticmethod
     def _apply_binop(op_func, left, right):
@@ -1125,7 +1133,18 @@ class BinarySymbolicExpr(SymbolicExpr):
         return self._apply_binop(_bit_xor, lhs, rhs)
 
     def _op_ashr(self, lhs, rhs):
-        raise NotImplementedError("Arithmetic shift right is not implemented in Z3")
+        bitwidth = (
+            self._infer_bitwidth(self)
+            or self._infer_bitwidth(self.lhs)
+            or self._infer_bitwidth(self.rhs)
+            or 64
+        )
+
+        def _ashr(a, b):
+            shifted = self._to_bv(a, bitwidth) >> self._to_bv(b, bitwidth)
+            return BV2Int(shifted, is_signed=True)
+
+        return self._apply_binop(_ashr, lhs, rhs)
 
     _NUMPY_OPS: ClassVar[dict[str, Callable[[Any, Any], Any]]] = {
         "add": np.add,
@@ -1145,6 +1164,7 @@ class BinarySymbolicExpr(SymbolicExpr):
         "bitwise_or": np.bitwise_or,
         "bitwise_xor": np.bitwise_xor,
         "right_shift": np.right_shift,
+        "ashr": np.right_shift,
         "left_shift": np.left_shift,
     }
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -266,9 +266,7 @@ class PatchOp:
                             "create_masked_store"
                         ]
                     elif self.op_type == Ashr:
-                        ret.concrete_fn = original_ops[interpreter_builder][
-                            "binary_op"
-                        ]
+                        ret.concrete_fn = original_ops[interpreter_builder]["binary_op"]
                     else:
                         ret.concrete_fn = self.op
         else:

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -14,6 +14,7 @@ from .config import config as cfg
 from .callbacks import OpCallbacks
 
 from .data import (
+    Ashr,
     Op,
     RawLoad,
     RawStore,
@@ -263,6 +264,10 @@ class PatchOp:
                     elif self.op_type == RawStore:
                         ret.concrete_fn = original_ops[interpreter_builder][
                             "create_masked_store"
+                        ]
+                    elif self.op_type == Ashr:
+                        ret.concrete_fn = original_ops[interpreter_builder][
+                            "binary_op"
                         ]
                     else:
                         ret.concrete_fn = self.op


### PR DESCRIPTION
## Summary

Adds sanitizer support for arithmetic shift-right (`ashr`) when symbolic addresses are materialized.

## Scope

- Adds `ashr` to the binary symbolic NumPy mapping with `np.right_shift`.
- Evaluates symbolic `ashr` through bit-vector arithmetic for Z3 checks.
- Wires Triton interpreter `Ashr` through the normal binary concrete function path.
- Adds focused unit coverage and a Triton sanitizer E2E where `ashr` contributes to a checked address.

## Validation

- `python -m pytest tests/unit/test_symbolic_client.py::test_ashr_expr_eval_scalar_constants tests/unit/test_symbolic_client.py::test_where_expr_concretize_scalar_constants tests/unit/test_sanitizer.py::test_range_check_uses_per_lane_mask_constraints tests/unit/test_patch_scope.py tests/end_to_end/test_sanitizer.py::test_sanitizer_supports_ashr_in_symbolic_address tests/end_to_end/test_sanitizer.py::test_sanitizer_supports_where_in_symbolic_address -q --tb=short` -> 11 passed
- `python -m py_compile triton_viz/clients/symbolic_engine.py triton_viz/clients/sanitizer/sanitizer.py triton_viz/core/patch.py tests/unit/test_symbolic_client.py tests/unit/test_sanitizer.py tests/unit/test_patch_scope.py tests/end_to_end/test_sanitizer.py tests/end_to_end/test_triton_kernels.py`
- `git diff --check`

## Stack

Base branch: `main`

1. #385 `[FIX] Support symbolic ashr checks` -> this PR
2. #386 `[FIX] Support symbolic where materialization`
3. #387 `[FIX] Materialize loaded sanitizer checks`
4. #388 `[FIX] Add triton kernels masked compaction sanitizer test`