### PR TITLE
[SUPERSEDED] Add topk sanitizer e2e cases

### DIFF
--- a/tests/end_to_end/test_triton_kernels.py
+++ b/tests/end_to_end/test_triton_kernels.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pytest
 import torch
 
@@ -17,6 +19,28 @@ RAGGED_METADATA_N_SLICES = [1, 7, 33, 911, 1025]
 REMAP_RAGGED_METADATA_N_SLICES = [9, 32, 911, 1025]
 
 
+TOPK_FORWARD_CASES = [
+    (n_rows, n_cols, 8, apply_softmax, dtype, use_provided_indx)
+    for n_rows, n_cols, apply_softmax, dtype, use_provided_indx in itertools.product(
+        [1, 7, 256, 300],
+        [13, 32, 128, 200],
+        [True, False],
+        ["float16", "bfloat16", "float32"],
+        [False],
+    )
+]
+TOPK_BACKWARD_CASES = [
+    (n_rows, n_cols, 8, apply_softmax, dtype, n_rows_arg)
+    for n_rows, n_cols, apply_softmax, dtype, n_rows_arg in itertools.product(
+        [1, 7, 256, 300],
+        [13, 32, 128, 200],
+        [True, False],
+        ["float16", "bfloat16", "float32"],
+        ["tensor"],
+    )
+]
+
+
 def _require_cuda(device):
     if device != "cuda" or not torch.cuda.is_available():
         pytest.skip("triton-viz sanitizer cases require CUDA")
@@ -26,6 +50,18 @@ def _new_sanitizer():
     pytest.importorskip("triton_viz")
     sanitizer_mod = pytest.importorskip("triton_viz.clients.sanitizer.sanitizer")
     return sanitizer_mod.SymbolicSanitizer(abort_on_error=True)
+
+
+def _clear_sanitizer_fn_cache():
+    sanitizer_mod = pytest.importorskip("triton_viz.clients.sanitizer.sanitizer")
+    sanitizer_mod._fn_symbolic_cache_set.clear()
+
+
+def _clear_module_jit_caches(module):
+    for value in module.__dict__.values():
+        device_caches = getattr(value, "device_caches", None)
+        if device_caches is not None:
+            device_caches.clear()
 
 
 def _trace_kernel(monkeypatch, module, name, sanitizer):
@@ -159,3 +195,103 @@ def test_triton_viz_sanitizer_remap_ragged_tensor_metadata(
     tri_metadata = ragged_mod.make_ragged_tensor_metadata(slice_sizes, n_total_rows)
     ragged_mod.remap_ragged_tensor_metadata(tri_metadata, slice_map)
     assert len(sanitizer.records) == 0
+
+
+@pytest.mark.parametrize(
+    ("n_rows", "n_cols", "k", "apply_softmax", "dtype", "use_provided_indx"),
+    TOPK_FORWARD_CASES,
+)
+@pytest.mark.parametrize("device", ["cuda"], indirect=True)
+def test_triton_viz_sanitizer_topk_forward(
+    monkeypatch, device, n_rows, n_cols, k, apply_softmax, dtype, use_provided_indx
+):
+    _require_cuda(device)
+
+    topk_mod = pytest.importorskip("triton_kernels.topk")
+    _clear_sanitizer_fn_cache()
+    _clear_module_jit_caches(topk_mod)
+
+    torch.manual_seed(0)
+    x = torch.randn((n_rows, n_cols), dtype=getattr(torch, dtype), device=device)
+    y_indx = None
+    if use_provided_indx:
+        y_indx = torch.sort(
+            torch.rand(n_rows, n_cols, device=device).argsort(dim=1).int()[:, :k],
+            dim=1,
+        )[0]
+
+    sparse_tri = topk_mod.topk(x, k, apply_softmax=apply_softmax, y_indx=y_indx)
+    sparse_ref = topk_mod.topk_torch(x, k, apply_softmax=apply_softmax)
+    if use_provided_indx:
+        selected = torch.gather(x, 1, y_indx.long())
+        if apply_softmax:
+            selected = torch.softmax(selected.float(), dim=1).to(x.dtype)
+        assert torch.allclose(
+            sparse_tri.vals.float(), selected.float(), atol=1e-3, rtol=1e-3
+        )
+        assert_equal(sparse_tri.indx, y_indx)
+    else:
+        assert torch.allclose(
+            sparse_tri.vals.float(),
+            sparse_ref.vals.float(),
+            atol=1e-3,
+            rtol=1e-3,
+        )
+        assert_equal(sparse_tri.indx, sparse_ref.indx)
+        assert_equal(sparse_tri.mask.storage.data, sparse_ref.mask.storage.data)
+        assert (
+            sparse_tri.mask.storage.data.stride()
+            == sparse_ref.mask.storage.data.stride()
+        )
+        assert sparse_tri.mask.storage.data.shape == sparse_ref.mask.storage.data.shape
+
+    sanitizer = _new_sanitizer()
+    _trace_kernel(monkeypatch, topk_mod, "_topk_forward", sanitizer)
+    topk_mod.topk_forward(x, k, apply_softmax=apply_softmax, y_indx=y_indx)
+    assert len(sanitizer.records) == 0
+    _clear_sanitizer_fn_cache()
+    _clear_module_jit_caches(topk_mod)
+
+
+@pytest.mark.parametrize(
+    ("n_rows", "n_cols", "k", "apply_softmax", "dtype", "n_rows_arg"),
+    TOPK_BACKWARD_CASES,
+)
+@pytest.mark.parametrize("device", ["cuda"], indirect=True)
+def test_triton_viz_sanitizer_topk_backward(
+    monkeypatch, device, n_rows, n_cols, k, apply_softmax, dtype, n_rows_arg
+):
+    _require_cuda(device)
+
+    topk_mod = pytest.importorskip("triton_kernels.topk")
+    _clear_sanitizer_fn_cache()
+    _clear_module_jit_caches(topk_mod)
+
+    torch.manual_seed(0)
+    x = torch.randn((n_rows, n_cols), device=device, dtype=getattr(torch, dtype))
+    y_indx = torch.sort(
+        torch.rand(n_rows, n_cols, device=device).argsort(dim=1).int()[:, :k],
+        dim=1,
+    )[0].to(torch.int16)
+    dy_vals = torch.randn((n_rows, k), device=device, dtype=getattr(torch, dtype))
+    active = max(1, n_rows // 2)
+    active_rows = (
+        active
+        if n_rows_arg == "int"
+        else torch.tensor(active, device=device, dtype=torch.int32)
+    )
+
+    dx = topk_mod.topk_backward(
+        x, y_indx, dy_vals, k=k, n_rows=active_rows, apply_softmax=apply_softmax
+    )
+    torch.cuda.synchronize()
+    assert dx.shape == x.shape
+
+    sanitizer = _new_sanitizer()
+    _trace_kernel(monkeypatch, topk_mod, "_topk_backward", sanitizer)
+    topk_mod.topk_backward(
+        x, y_indx, dy_vals, k=k, n_rows=active_rows, apply_softmax=apply_softmax
+    )
+    assert len(sanitizer.records) == 0
+    _clear_sanitizer_fn_cache()
+    _clear_module_jit_caches(topk_mod)

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -122,9 +122,29 @@ def _make_signature(
     else:
         addr_hash = hash(addr_expr)
 
-    constr_hash = 0 if constraints is None else hash(constraints)
+    if constraints is None:
+        constr_hash = 0
+    elif isinstance(constraints, list):
+        constr_hash = hash(tuple(0 if c is None else hash(c) for c in constraints))
+    else:
+        constr_hash = hash(constraints)
 
     return hash((addr_hash, constr_hash))
+
+
+def _broadcast_constraints(
+    constraints: ConstraintConjunction,
+    lane_count: int,
+) -> list[BoolRef | None]:
+    if not isinstance(constraints, list):
+        return [constraints] * lane_count
+    if len(constraints) == lane_count:
+        return constraints
+    if len(constraints) == 1:
+        return constraints * lane_count
+    raise ValueError(
+        f"Cannot pair {len(constraints)} constraints with {lane_count} addresses"
+    )
 
 
 @dataclass(frozen=True)
@@ -261,11 +281,13 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         assert solver is not None
         assert addr_sym is not None
 
-        def _check_single_addr(addr_expr: Z3Expr) -> None:
+        def _check_single_addr(
+            addr_expr: Z3Expr, constraints: BoolRef | None
+        ) -> None:
             solver.push()
             solver.add(addr_sym == addr_expr)
-            if expr_constraints is not None:
-                solver.add(expr_constraints)
+            if constraints is not None:
+                solver.add(constraints)
             if solver.check() == sat:
                 # Get the model to find the violation address
                 model = solver.model()
@@ -293,11 +315,16 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
             solver.pop()
 
         if isinstance(access_addr, list):
-            for addr in access_addr:
-                _check_single_addr(addr)
+            constraints = _broadcast_constraints(expr_constraints, len(access_addr))
+            for addr, lane_constraints in zip(access_addr, constraints):
+                _check_single_addr(addr, lane_constraints)
             return
 
-        _check_single_addr(access_addr)
+        if isinstance(expr_constraints, list):
+            constraints = _broadcast_constraints(expr_constraints, 1)[0]
+        else:
+            constraints = expr_constraints
+        _check_single_addr(access_addr, constraints)
 
     def _handle_access_check(
         self,

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -29,6 +29,7 @@ from z3 import (
     Int2BV,
     BV2Int,
     BitVecRef,
+    LShR,
     BoolVal,
 )
 from z3.z3 import BoolRef, ArithRef, IntNumRef, ExprRef, Tactic, Probe
@@ -91,7 +92,8 @@ AccessMode: TypeAlias = Literal["read", "write"]
 
 Z3Expr: TypeAlias = ExprRef | list[ExprRef] | Tactic | Probe
 ConstraintExpr: TypeAlias = ExprRef | bool | int | float
-ConstraintConjunction: TypeAlias = BoolRef | None
+LaneConstraintConjunction: TypeAlias = BoolRef | None
+ConstraintConjunction: TypeAlias = BoolRef | list[LaneConstraintConjunction] | None
 
 
 def _constraint_to_bool(expr: ConstraintExpr) -> BoolRef:
@@ -115,7 +117,7 @@ def _iter_constraints_to_bool(
 
 def _and_constraints(
     *constraints: ConstraintExpr | Sequence[ConstraintExpr] | None,
-) -> ConstraintConjunction:
+) -> LaneConstraintConjunction:
     parts: list[BoolRef] = []
     for constraint in constraints:
         if constraint is None:
@@ -130,6 +132,45 @@ def _and_constraints(
     if len(parts) == 1:
         return parts[0]
     return And(*parts)
+
+
+def _broadcast_lane_value(value: Any, lane_count: int) -> list[Any]:
+    if isinstance(value, (list, tuple)):
+        if len(value) == lane_count:
+            return list(value)
+        if len(value) == 1:
+            return list(value) * lane_count
+        raise ValueError(
+            f"Cannot broadcast {len(value)} values to {lane_count} lanes"
+        )
+    return [value] * lane_count
+
+
+def _lane_count_from(*values: Any) -> int | None:
+    lane_count: int | None = None
+    for value in values:
+        if not isinstance(value, (list, tuple)):
+            continue
+        if lane_count is None:
+            lane_count = len(value)
+        elif len(value) not in (1, lane_count):
+            raise ValueError(
+                f"Cannot combine lane constraints of length {len(value)} and {lane_count}"
+            )
+    return lane_count
+
+
+def _and_lane_constraints(
+    lane_count: int,
+    *constraints: ConstraintExpr | Sequence[ConstraintExpr] | None,
+) -> list[LaneConstraintConjunction]:
+    lane_constraints = [
+        _broadcast_lane_value(constraint, lane_count) for constraint in constraints
+    ]
+    return [
+        _and_constraints(*(constraint[i] for constraint in lane_constraints))
+        for i in range(lane_count)
+    ]
 
 
 def _range_to_iterator_constraint(
@@ -192,9 +233,11 @@ class SymbolicExprDataWrapper:
         self._value = value
         self.symbolic_expr = symbolic_expr
         self._is_scalar = self.size == 1
+        self._concrete: TensorHandle | None = None
 
     def invalidate(self) -> None:
         self._value = None
+        self._concrete = None
 
     def _ensure_value(self) -> str:
         if self._value is None:
@@ -216,21 +259,65 @@ class SymbolicExprDataWrapper:
             return 1
         return math.prod(shape)
 
+    def _concrete_data(self) -> np.ndarray:
+        concrete = self._concrete
+        if concrete is None:
+            concrete = self.symbolic_expr.concretize()
+            if not isinstance(concrete, TensorHandle):
+                raise TypeError(f"Expected TensorHandle, got {type(concrete)}")
+            self._concrete = concrete
+        return concrete.data
+
+    @property
+    def shape(self) -> tuple[int, ...]:
+        return tuple(self._concrete_data().shape)
+
+    @property
+    def dtype(self) -> np.dtype:
+        return self._concrete_data().dtype
+
     def _scalar_data(self) -> np.ndarray:
-        if not self._is_scalar:
+        concrete = self._concrete_data()
+        if concrete.size != 1:
             raise ValueError(
                 f"Expected scalar symbolic data, got shape {self.symbolic_expr.shape}"
             )
-        concrete = self.symbolic_expr.concretize()
-        if not isinstance(concrete, TensorHandle):
-            raise TypeError(f"Expected TensorHandle, got {type(concrete)}")
-        return concrete.data
+        return concrete
+
+    def flatten(self, *args: Any, **kwargs: Any) -> np.ndarray:
+        return self._concrete_data().flatten(*args, **kwargs)
+
+    def astype(self, *args: Any, **kwargs: Any) -> np.ndarray:
+        return self._concrete_data().astype(*args, **kwargs)
+
+    def item(self, *args: Any, **kwargs: Any) -> Any:
+        return self._concrete_data().item(*args, **kwargs)
+
+    def reshape(self, *args: Any, **kwargs: Any) -> np.ndarray:
+        return self._concrete_data().reshape(*args, **kwargs)
+
+    def __array__(self, dtype: Any = None) -> np.ndarray:
+        data = self._concrete_data()
+        if dtype is None:
+            return data
+        return data.astype(dtype)
+
+    def __len__(self) -> int:
+        return len(self._concrete_data())
+
+    def __iter__(self) -> Iterator[Any]:
+        return iter(self._concrete_data())
+
+    def __getattr__(self, name: str) -> Any:
+        if name == "value":
+            return self._ensure_value()
+        return getattr(self._concrete_data(), name)
 
     def __getitem__(self, item: Any) -> Any:
-        return self._scalar_data()[item]
+        return self._concrete_data()[item]
 
     def squeeze(self, axis: int | tuple[int, ...] | None = None) -> np.ndarray:
-        return self._scalar_data().squeeze(axis)
+        return self._concrete_data().squeeze(axis)
 
     @staticmethod
     def coerce_int(val: Any) -> int:
@@ -264,10 +351,10 @@ class SymbolicExprDataWrapper:
         return bool(self._scalar_data().item())
 
     def __str__(self) -> str:
-        return self.value
+        return self._ensure_value()
 
     def __repr__(self) -> str:
-        return self.value
+        return self._ensure_value()
 
 
 class SymbolicExpr:
@@ -462,6 +549,16 @@ class SymbolicExpr:
             if child_symbolic_expr is None:
                 Node(f"{child_key}: None", parent=root)
                 continue
+            if isinstance(child_symbolic_expr, tuple):
+                tuple_node = Node(f"{child_key}: tuple", parent=root)
+                for idx, item in enumerate(child_symbolic_expr):
+                    if isinstance(item, SymbolicExpr):
+                        child_node = item._to_anytree()
+                        child_node.name = f"{idx}: {child_node.name}"
+                        child_node.parent = tuple_node
+                    else:
+                        Node(f"{idx}: {item!r}", parent=tuple_node)
+                continue
             child_node = child_symbolic_expr._to_anytree()
             child_node.name = f"{child_key}: {child_node.name}"
             child_node.parent = root
@@ -583,8 +680,17 @@ class SymbolicExpr:
 
         if constraints is not None and simplify_constraints:
             if self._simplified_constraints is None:
-                # Z3 stubs type simplify(...) as ExprRef even when input is BoolRef.
-                self._simplified_constraints = cast(BoolRef, simplify(constraints))
+                if isinstance(constraints, list):
+                    # Z3 stubs type simplify(...) as ExprRef even when input is BoolRef.
+                    self._simplified_constraints = [
+                        cast(BoolRef, simplify(constraint))
+                        if constraint is not None
+                        else None
+                        for constraint in constraints
+                    ]
+                else:
+                    # Z3 stubs type simplify(...) as ExprRef even when input is BoolRef.
+                    self._simplified_constraints = cast(BoolRef, simplify(constraints))
             return self._simplified_z3, self._simplified_constraints
 
         return self._simplified_z3, constraints
@@ -845,10 +951,23 @@ class IndirectSymbolicExprBase(SymbolicExpr):
         ptr, constraints_ptr = ptr_expr._to_z3()
         mask_expr = self.mask
         mask_constraint: ConstraintExpr | Sequence[ConstraintExpr] | None = None
+        constraints_mask: ConstraintConjunction = None
         if mask_expr is not None:
-            mask, _ = mask_expr._to_z3()
+            mask, constraints_mask = mask_expr._to_z3()
             mask_constraint = mask
-        return ptr, _and_constraints(constraints_ptr, mask_constraint)
+
+        lane_count = _lane_count_from(ptr, constraints_ptr, mask_constraint, constraints_mask)
+        if lane_count is None:
+            return ptr, _and_constraints(
+                constraints_ptr, constraints_mask, mask_constraint
+            )
+
+        return _broadcast_lane_value(ptr, lane_count), _and_lane_constraints(
+            lane_count,
+            constraints_ptr,
+            constraints_mask,
+            mask_constraint,
+        )
 
     def concretize(self) -> Any:
         ptr_concrete = self.ptr.concretize()
@@ -925,6 +1044,20 @@ class UnarySymbolicExpr(SymbolicExpr):
             raise NotImplementedError(f"Unary op {self.op} is not implemented")
         return handler(val), constraints
 
+    def concretize(self) -> Any:
+        concrete = self.arg.concretize()
+        handler = self._NUMPY_OPS.get(self.op)
+        if handler is None:
+            if self.concrete_fn is None:
+                raise NotImplementedError(
+                    f"Concretize for unary op '{self.op}' is not implemented"
+                )
+            return self.concrete_fn(concrete)  # type: ignore
+        return TensorHandle(
+            np.asarray(handler(concrete.data), dtype=_get_np_dtype(self.dtype)),
+            self.dtype,
+        )
+
     @staticmethod
     def _abs(val) -> Z3Expr:
         return If(val >= 0, val, -val)
@@ -932,6 +1065,21 @@ class UnarySymbolicExpr(SymbolicExpr):
     _Z3_BUILDERS: ClassVar[dict[str, Callable[[Z3Expr], Z3Expr]]] = {
         "abs": _abs,
         "fabs": _abs,
+    }
+
+    _NUMPY_OPS: ClassVar[dict[str, Callable[[Any], Any]]] = {
+        "cos": np.cos,
+        "exp": np.exp,
+        "exp2": np.exp2,
+        "abs": np.abs,
+        "fabs": np.abs,
+        "floor": np.floor,
+        "ceil": np.ceil,
+        "log": np.log,
+        "log2": np.log2,
+        "sqrt": np.sqrt,
+        "sin": np.sin,
+        "rsqrt": lambda x: 1 / np.sqrt(x),
     }
 
 
@@ -1116,6 +1264,38 @@ class BinarySymbolicExpr(SymbolicExpr):
 
         return self._apply_binop(_bit_xor, lhs, rhs)
 
+    def _op_right_shift(self, lhs, rhs):
+        lhs_expr = self.lhs
+        rhs_expr = self.rhs
+        bitwidth = (
+            self._infer_bitwidth(self)
+            or self._infer_bitwidth(lhs_expr)
+            or self._infer_bitwidth(rhs_expr)
+            or 64
+        )
+
+        def _right_shift(a, b):
+            shifted = LShR(self._to_bv(a, bitwidth), self._to_bv(b, bitwidth))
+            return BV2Int(shifted, is_signed=False)
+
+        return self._apply_binop(_right_shift, lhs, rhs)
+
+    def _op_left_shift(self, lhs, rhs):
+        lhs_expr = self.lhs
+        rhs_expr = self.rhs
+        bitwidth = (
+            self._infer_bitwidth(self)
+            or self._infer_bitwidth(lhs_expr)
+            or self._infer_bitwidth(rhs_expr)
+            or 64
+        )
+
+        def _left_shift(a, b):
+            shifted = self._to_bv(a, bitwidth) << self._to_bv(b, bitwidth)
+            return BV2Int(shifted, is_signed=False)
+
+        return self._apply_binop(_left_shift, lhs, rhs)
+
     def _op_ashr(self, lhs, rhs):
         bitwidth = (
             self._infer_bitwidth(self)
@@ -1171,6 +1351,8 @@ class BinarySymbolicExpr(SymbolicExpr):
         "bitwise_and": _op_bitwise_and,
         "bitwise_or": _op_bitwise_or,
         "bitwise_xor": _op_bitwise_xor,
+        "right_shift": _op_right_shift,
+        "left_shift": _op_left_shift,
         "ashr": _op_ashr,
     }
 
@@ -1576,6 +1758,14 @@ class ExpandDimsSymbolicExpr(SymbolicExpr):
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         return self.arg._to_z3()
 
+    def concretize(self) -> Any:
+        concrete = self.arg.concretize()
+        axis = self.axis.to_py()
+        return TensorHandle(
+            np.expand_dims(concrete.data, axis=axis).astype(concrete.data.dtype),
+            concrete.dtype,
+        )
+
 
 class BroadcastSymbolicExpr(SymbolicExpr):
     arg: SymbolicExpr
@@ -1598,18 +1788,51 @@ class BroadcastSymbolicExpr(SymbolicExpr):
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         return self.arg._to_z3()
 
+    def concretize(self) -> Any:
+        concrete = self.arg.concretize()
+        shape = self.target_shape if self.target_shape else self.arg.shape
+        return TensorHandle(
+            np.broadcast_to(concrete.data, shape).astype(concrete.data.dtype),
+            concrete.dtype,
+        )
+
 
 class ReshapeSymbolicExpr(SymbolicExpr):
     arg: SymbolicExpr
+    target_shape: tuple[int, ...]
+
+    @staticmethod
+    def _shape_to_tuple(shape: Any) -> tuple[int, ...]:
+        if isinstance(shape, tuple):
+            return tuple(
+                int(item.to_py()) if hasattr(item, "to_py") else int(item)
+                for item in shape
+            )
+        if hasattr(shape, "to_py"):
+            shape = shape.to_py()
+        if isinstance(shape, np.ndarray):
+            shape = shape.tolist()
+        if isinstance(shape, (int, np.integer)):
+            return (int(shape),)
+        return tuple(int(x) for x in shape)
 
     def __init__(self, op: str, arg: Any, shape: Any):
         super().__init__(op)
         self.add_child("arg", arg)
+        self.add_child("target", shape)
+        self.target_shape = self._shape_to_tuple(self.target)
         self.dtype = self.arg.dtype
-        self.shape = self.arg.shape
+        self.shape = self.target_shape
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         return self.arg._to_z3()
+
+    def concretize(self) -> Any:
+        concrete = self.arg.concretize()
+        return TensorHandle(
+            np.reshape(concrete.data, self.target_shape).astype(concrete.data.dtype),
+            concrete.dtype,
+        )
 
 
 class TransSymbolicExpr(SymbolicExpr):
@@ -1620,11 +1843,24 @@ class TransSymbolicExpr(SymbolicExpr):
         super().__init__(op)
         self.add_child("arg", arg)
         self.add_child("permutation", permutation)
+        permutation_value = (
+            permutation.to_py() if hasattr(permutation, "to_py") else permutation
+        )
+        self.permutation_value = tuple(int(x) for x in permutation_value)
         self.dtype = self.arg.dtype
-        self.shape = self.arg.shape
+        self.shape = tuple(self.arg.shape[i] for i in self.permutation_value)
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
         return self.arg._to_z3()
+
+    def concretize(self) -> Any:
+        concrete = self.arg.concretize()
+        return TensorHandle(
+            np.transpose(concrete.data, axes=self.permutation_value).astype(
+                concrete.data.dtype
+            ),
+            concrete.dtype,
+        )
 
 
 class JoinSymbolicExpr(SymbolicExpr):

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -24,6 +24,7 @@ from triton.runtime.interpreter import (
     GridExecutor,
     _implicit_cvt,
     interpreter_builder,
+    interpreter_semantic,
     _patch_builtin,
 )
 from triton.runtime.interpreter import _patch_lang as triton_patch_lang
@@ -63,24 +64,13 @@ class _LangPatchScope:
 _LANG_PATCH_SCOPES: dict[str, list[Any]] = {"triton": [], "nki": [], "nki_beta2": []}
 
 
-def _push_lang_patch_scope(backend: str, scope: Any) -> None:
-    _LANG_PATCH_SCOPES.setdefault(backend, []).append(scope)
+def _capture_builtin_attrs(scope: _LangPatchScope, obj: Any) -> None:
+    for name, member in inspect.getmembers(obj):
+        if tl.core.is_builtin(member):
+            scope.set_attr(obj, name, member)
 
 
-def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
-    """
-    Stores Triton attributes into a LangPatchScope for later unpatching.
-    This is to be run before patching with the interpreter.
-    This is equivalent to what triton>=3.6.0 does natively
-    but also works for triton<3.6.0.
-    """
-
-    def _capture_builtin_attrs(scope: _LangPatchScope, obj: Any) -> None:
-        for name, member in inspect.getmembers(obj):
-            if tl.core.is_builtin(member):
-                scope.set_attr(obj, name, member)
-
-    scope = _LangPatchScope()
+def _triton_language_attr_targets() -> list[tuple[Any, tuple[str, ...]]]:
     tensor_attrs = ("__index__", "__bool__", "__repr__", "__str__", "T")
     lang_attrs = (
         "range",
@@ -93,31 +83,84 @@ def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
         "reduce",
         "associative_scan",
     )
-    langs = [
-        value
-        for value in fn.__globals__.values()
-        if inspect.ismodule(value) and value in [tl, tl.core]
-    ]
-    if langs:
-        # Triton's interpreter scan patch mutates both tl and tl.core even when
-        # the kernel only imports one of them.
-        for lang in (tl, tl.core):
-            if lang not in langs:
-                langs.append(lang)
+
+    targets: list[tuple[Any, tuple[str, ...]]] = []
+    for lang in (tl, tl.core):
+        targets.append((lang.tensor, tensor_attrs))
+        targets.append((lang, lang_attrs))
+        targets.append((lang.dtype, ("to_ir",)))
+        if lang == tl:
+            targets.append((lang.math, ()))
+    if hasattr(tl.core, "tensor_descriptor_base"):
+        targets.append((tl.core.tensor_descriptor_base, ()))
+    return targets
+
+
+def _capture_triton_language_baseline() -> list[tuple[Any, str, Any]]:
+    baseline: list[tuple[Any, str, Any]] = []
+    seen: set[tuple[int, str]] = set()
+
+    def save(obj: Any, name: str) -> None:
+        key = (id(obj), name)
+        if key in seen:
+            return
+        seen.add(key)
+        baseline.append((obj, name, getattr(obj, name, _MISSING)))
+
+    for obj, attrs in _triton_language_attr_targets():
+        for name, member in inspect.getmembers(obj):
+            if tl.core.is_builtin(member):
+                save(obj, name)
+        for attr in attrs:
+            save(obj, attr)
+
+    return baseline
+
+
+_TRITON_LANGUAGE_BASELINE = _capture_triton_language_baseline()
+
+
+def _restore_triton_language_baseline() -> None:
+    for obj, name, original in reversed(_TRITON_LANGUAGE_BASELINE):
+        if original is _MISSING:
+            if hasattr(obj, name):
+                delattr(obj, name)
+        else:
+            setattr(obj, name, original)
+
+
+def _push_lang_patch_scope(backend: str, scope: Any) -> None:
+    _LANG_PATCH_SCOPES.setdefault(backend, []).append(scope)
+
+
+def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
+    """
+    Stores Triton attributes into a LangPatchScope for later unpatching.
+    This is to be run before patching with the interpreter.
+    This is equivalent to what triton>=3.6.0 does natively
+    but also works for triton<3.6.0.
+    """
+
+    scope = _LangPatchScope()
+    # Triton's interpreter patch mutates global tl/tl.core objects. Snapshot
+    # both unconditionally so nested or generated JIT functions without a
+    # direct `tl` global still restore the language state after tracing.
+    langs = [tl, tl.core]
+    for value in fn.__globals__.values():
+        if inspect.ismodule(value) and value in (tl, tl.core) and value not in langs:
+            langs.append(value)
     for lang in langs:
         _capture_builtin_attrs(scope, lang)
         _capture_builtin_attrs(scope, lang.tensor)
         if lang == tl:
             _capture_builtin_attrs(scope, lang.math)
 
-        for attr in tensor_attrs:
-            if hasattr(lang.tensor, attr):
-                scope.set_attr(lang.tensor, attr, getattr(lang.tensor, attr))
-
-        for attr in lang_attrs:
-            if hasattr(lang, attr):
-                scope.set_attr(lang, attr, getattr(lang, attr))
-        scope.set_attr(lang.dtype, "to_ir", lang.dtype.to_ir)
+        for obj, attrs in _triton_language_attr_targets():
+            if obj not in (lang, lang.tensor, lang.dtype, getattr(lang, "math", None)):
+                continue
+            for attr in attrs:
+                if hasattr(obj, attr):
+                    scope.set_attr(obj, attr, getattr(obj, attr))
 
     if hasattr(tl.core, "tensor_descriptor_base"):
         _capture_builtin_attrs(scope, tl.core.tensor_descriptor_base)
@@ -168,6 +211,45 @@ def _patch_triton_inline_asm(scope: _LangPatchScope) -> None:
         return args[0].to(dtype)
 
     scope.set_attr(tl, "inline_asm_elementwise", _inline_asm_elementwise_fallback)
+
+
+def _patch_triton_semantic_to_tensor(scope: _LangPatchScope) -> None:
+    original_to_tensor = interpreter_semantic.to_tensor
+
+    def _is_triton_tensor_like(x: Any) -> bool:
+        return type(x).__name__ == "tensor" or (
+            hasattr(x, "handle") and hasattr(x, "dtype")
+        )
+
+    def _to_tensor_symbolic_aware(x, check_type=True):
+        unwrapped = x.value if isinstance(x, tl.constexpr) else x
+        if _is_triton_tensor_like(unwrapped):
+            return unwrapped
+        try:
+            return original_to_tensor(x, check_type)
+        except TypeError:
+            if isinstance(unwrapped, tl.core.tensor):
+                return unwrapped
+            raise
+
+    scope.set_attr(interpreter_semantic, "to_tensor", _to_tensor_symbolic_aware)
+
+
+def _patch_triton_data_dependent_helpers(scope: _LangPatchScope) -> None:
+    if not hasattr(tl, "bitonic_merge"):
+        return
+
+    original_bitonic_merge = tl.bitonic_merge
+
+    def _bitonic_merge_concrete(x, *args, **kwargs):
+        handle = getattr(x, "handle", None)
+        concretize = getattr(handle, "concretize", None)
+        if concretize is None:
+            return original_bitonic_merge(x, *args, **kwargs)
+        concrete = concretize()
+        return original_bitonic_merge(tl.core.tensor(concrete, x.type), *args, **kwargs)
+
+    scope.set_attr(tl, "bitonic_merge", _bitonic_merge_concrete)
 
 
 def _pop_lang_patch_scope(backend: str) -> Any | None:
@@ -386,6 +468,8 @@ def patch_lang(fn, backend, client_manager=None):
         for module in _triton_extra_builtin_modules():
             _patch_builtin(module, interpreter_builder, scope)
         _patch_triton_inline_asm(scope)
+        _patch_triton_semantic_to_tensor(scope)
+        _patch_triton_data_dependent_helpers(scope)
     elif backend == "nki":
         from triton_viz.core.nki import nki_patch_lang
 
@@ -412,6 +496,8 @@ def unpatch_lang(backend):
     scope = _pop_lang_patch_scope(backend)
     if scope is not None and hasattr(scope, "restore"):
         scope.restore()
+    if backend == "triton" and not _LANG_PATCH_SCOPES.get("triton"):
+        _restore_triton_language_baseline()
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
Superseded by the smaller stacked PRs:

- #393 `[FIX] Preserve lane constraints in sanitizer checks`
- #394 `[FIX] Concretize symbolic expressions used by topk`
- #395 `[FIX] Concretize topk trace helpers`
- #396 `[TEST] Add topk sanitizer e2e cases`

The split keeps each behavior change paired with focused unit or end-to-end coverage.