### PR TITLE
[FIX] Patch Triton trace helpers for topk

### DIFF
--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -1,7 +1,9 @@
 import pytest
 import warnings
 
+import numpy as np
 import triton.language as tl
+from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.core import patch as patch_mod
 from triton_viz.core.patch import _triton_snapshot_scope
@@ -132,3 +134,14 @@ def test_inline_asm_patch_returns_inputs_and_warns_once():
     assert b.cast_dtypes == []
     assert len(caught) == 1
     assert "inline assembly is approximated" in str(caught[0].message)
+
+
+def test_patch_lang_accepts_constexpr_wrapped_symbolic_tensors():
+    handle = TensorHandle(np.array([1, 2], dtype=np.int32), tl.int32)
+    tensor = tl.core.tensor(handle, tl.block_type(tl.int32, [2]))
+
+    patch_mod.patch_lang(_dummy_kernel, "triton")
+    try:
+        assert patch_mod.interpreter_semantic.to_tensor(tl.constexpr(tensor)) is tensor
+    finally:
+        patch_mod.unpatch_lang("triton")

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -24,6 +24,7 @@ from triton.runtime.interpreter import (
     GridExecutor,
     _implicit_cvt,
     interpreter_builder,
+    interpreter_semantic,
     _patch_builtin,
 )
 from triton.runtime.interpreter import _patch_lang as triton_patch_lang
@@ -63,24 +64,7 @@ class _LangPatchScope:
 _LANG_PATCH_SCOPES: dict[str, list[Any]] = {"triton": [], "nki": [], "nki_beta2": []}
 
 
-def _push_lang_patch_scope(backend: str, scope: Any) -> None:
-    _LANG_PATCH_SCOPES.setdefault(backend, []).append(scope)
-
-
-def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
-    """
-    Stores Triton attributes into a LangPatchScope for later unpatching.
-    This is to be run before patching with the interpreter.
-    This is equivalent to what triton>=3.6.0 does natively
-    but also works for triton<3.6.0.
-    """
-
-    def _capture_builtin_attrs(scope: _LangPatchScope, obj: Any) -> None:
-        for name, member in inspect.getmembers(obj):
-            if tl.core.is_builtin(member):
-                scope.set_attr(obj, name, member)
-
-    scope = _LangPatchScope()
+def _triton_language_attr_targets() -> list[tuple[Any, tuple[str, ...]]]:
     tensor_attrs = ("__index__", "__bool__", "__repr__", "__str__", "T")
     lang_attrs = (
         "range",
@@ -93,34 +77,38 @@ def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
         "reduce",
         "associative_scan",
     )
-    langs = [
-        value
-        for value in fn.__globals__.values()
-        if inspect.ismodule(value) and value in [tl, tl.core]
-    ]
-    if langs:
-        # Triton's interpreter scan patch mutates both tl and tl.core even when
-        # the kernel only imports one of them.
-        for lang in (tl, tl.core):
-            if lang not in langs:
-                langs.append(lang)
-    for lang in langs:
-        _capture_builtin_attrs(scope, lang)
-        _capture_builtin_attrs(scope, lang.tensor)
+
+    targets: list[tuple[Any, tuple[str, ...]]] = []
+    for lang in (tl, tl.core):
+        targets.append((lang.tensor, tensor_attrs))
+        targets.append((lang, lang_attrs))
+        targets.append((lang.dtype, ("to_ir",)))
         if lang == tl:
-            _capture_builtin_attrs(scope, lang.math)
-
-        for attr in tensor_attrs:
-            if hasattr(lang.tensor, attr):
-                scope.set_attr(lang.tensor, attr, getattr(lang.tensor, attr))
-
-        for attr in lang_attrs:
-            if hasattr(lang, attr):
-                scope.set_attr(lang, attr, getattr(lang, attr))
-        scope.set_attr(lang.dtype, "to_ir", lang.dtype.to_ir)
-
+            targets.append((lang.math, ()))
     if hasattr(tl.core, "tensor_descriptor_base"):
-        _capture_builtin_attrs(scope, tl.core.tensor_descriptor_base)
+        targets.append((tl.core.tensor_descriptor_base, ()))
+    return targets
+
+
+def _triton_snapshot_scope(fn: Callable[..., Any]) -> _LangPatchScope:
+    """
+    Stores Triton attributes into a LangPatchScope for later unpatching.
+    This is to be run before patching with the interpreter.
+    This is equivalent to what triton>=3.6.0 does natively
+    but also works for triton<3.6.0.
+    """
+
+    scope = _LangPatchScope()
+    # Triton's interpreter patch mutates global tl/tl.core objects. Snapshot
+    # both unconditionally so nested or generated JIT functions without a
+    # direct `tl` global still restore the language state after tracing.
+    for obj, attrs in _triton_language_attr_targets():
+        for name, member in inspect.getmembers(obj):
+            if tl.core.is_builtin(member):
+                scope.set_attr(obj, name, member)
+        for attr in attrs:
+            if hasattr(obj, attr):
+                scope.set_attr(obj, attr, getattr(obj, attr))
 
     return scope
 
@@ -170,11 +158,16 @@ def _patch_triton_inline_asm(scope: _LangPatchScope) -> None:
     scope.set_attr(tl, "inline_asm_elementwise", _inline_asm_elementwise_fallback)
 
 
-def _pop_lang_patch_scope(backend: str) -> Any | None:
-    scopes = _LANG_PATCH_SCOPES.get(backend)
-    if not scopes:
-        return None
-    return scopes.pop()
+def _patch_triton_semantic_to_tensor(scope: _LangPatchScope) -> None:
+    original_to_tensor = interpreter_semantic.to_tensor
+
+    def _to_tensor_symbolic_aware(x, check_type=True):
+        unwrapped = x.value if isinstance(x, tl.constexpr) else x
+        if isinstance(unwrapped, tl.core.tensor):
+            return unwrapped
+        return original_to_tensor(x, check_type)
+
+    scope.set_attr(interpreter_semantic, "to_tensor", _to_tensor_symbolic_aware)
 
 
 _thread_local_interpreter_state = threading.local()
@@ -384,6 +377,7 @@ def patch_lang(fn, backend, client_manager=None):
         for module in _triton_extra_builtin_modules():
             _patch_builtin(module, interpreter_builder, scope)
         _patch_triton_inline_asm(scope)
+        _patch_triton_semantic_to_tensor(scope)
     elif backend == "nki":
         from triton_viz.core.nki import nki_patch_lang
 
@@ -399,7 +393,7 @@ def patch_lang(fn, backend, client_manager=None):
             f"Unsupported backend {backend} received. Triton-viz only supports one of ('triton', 'nki', 'nki_beta2')."
         )
 
-    _push_lang_patch_scope(backend, scope)
+    _LANG_PATCH_SCOPES.setdefault(backend, []).append(scope)
 
     if client_manager is not None:
         fn.__globals__["_triton_viz_loop_patcher"] = client_manager
@@ -407,7 +401,8 @@ def patch_lang(fn, backend, client_manager=None):
 
 
 def unpatch_lang(backend):
-    scope = _pop_lang_patch_scope(backend)
+    scopes = _LANG_PATCH_SCOPES.get(backend)
+    scope = scopes.pop() if scopes else None
     if scope is not None and hasattr(scope, "restore"):
         scope.restore()
 


### PR DESCRIPTION
## Summary

Patch generic Triton trace-time helper behavior needed by topk-related helper JIT functions.

This PR:
- snapshots the relevant Triton language attributes so `patch_lang`/`unpatch_lang` restores Triton's interpreter-patched language state after tracing
- accepts `tl.constexpr` values that wrap `tl.tensor` objects in `interpreter_semantic.to_tensor`
- keeps topk helpers as ordinary Triton code; there is no `tl.bitonic_merge` specialization

## Validation

- `python -m pytest tests/unit/test_patch_scope.py tests/unit/test_wrapper.py tests/end_to_end/test_core.py -q --tb=short`
- `pre-commit run --all-files`
- `python -m pytest tests/ -q --tb=short`