### PR TITLE
[TEST] Add MXFP sanitizer E2E cases

### DIFF
--- a/tests/end_to_end/test_triton_kernels.py
+++ b/tests/end_to_end/test_triton_kernels.py
@@ -1,5 +1,7 @@
 import pytest
 import torch
+import triton
+import triton.language as tl
 
 
 def assert_equal(*args, **kwargs):
@@ -29,6 +31,8 @@ TOPK_BACKWARD_CASES = [
     (7, 13, 8, True, "float16"),
 ]
 SWIGLU_CASES = [(1311, 4352, 1e-2), (1311, 4352, 10)]
+MXFP4_TILE_UPCAST_CASES = ["float16", "bfloat16", "float32"]
+_mxfp4_tile_upcast = None
 
 
 def _require_cuda(device):
@@ -268,4 +272,97 @@ def test_triton_viz_sanitizer_swiglu(monkeypatch, device, m, n, limit):
     sanitizer = _new_sanitizer()
     _trace_kernel(monkeypatch, swiglu_mod, "_swiglu", sanitizer)
     swiglu_mod.swiglu(x, 0.5, precision_config)
+    assert len(sanitizer.records) == 0
+
+
+@triton.jit
+def _triton_viz_mxfp4_tile_upcast_kernel(
+    out,
+    tensor,
+    scale,
+    stride_out_m,
+    stride_out_k,
+    stride_tensor_m,
+    stride_tensor_k,
+    stride_scale_m,
+    stride_scale_k,
+    BLOCK_M: tl.constexpr,
+    PACKED_K: tl.constexpr,
+    SCALE_K: tl.constexpr,
+    dst_dtype: tl.constexpr,
+):
+    m_offsets = tl.arange(0, BLOCK_M)[:, None]
+    packed_k_offsets = tl.arange(0, PACKED_K)[None, :]
+    tensor_tile = tl.load(
+        tensor + m_offsets * stride_tensor_m + packed_k_offsets * stride_tensor_k
+    )
+
+    scale_k_offsets = tl.arange(0, SCALE_K)[None, :]
+    scale_tile = tl.load(
+        scale + m_offsets * stride_scale_m + scale_k_offsets * stride_scale_k
+    )
+
+    out_tile = _mxfp4_tile_upcast(tensor_tile, scale_tile, dst_dtype)
+    k_offsets = tl.arange(0, PACKED_K * 2)[None, :]
+    tl.store(out + m_offsets * stride_out_m + k_offsets * stride_out_k, out_tile)
+
+
+@pytest.mark.parametrize("dst_dtype", MXFP4_TILE_UPCAST_CASES)
+@pytest.mark.parametrize("device", ["cuda"], indirect=True)
+def test_triton_viz_sanitizer_mxfp4_tile_upcast(device, dst_dtype):
+    _require_cuda(device)
+
+    global _mxfp4_tile_upcast
+    mxfp_mod = pytest.importorskip("triton_kernels.numerics_details.mxfp")
+    upcast_mod = pytest.importorskip(
+        "triton_kernels.numerics_details.mxfp_details._upcast_from_mxfp"
+    )
+    _mxfp4_tile_upcast = upcast_mod.upcast_mxfp4_tile
+
+    torch.manual_seed(0)
+    torch_dtype = getattr(torch, dst_dtype)
+    rows, k = 64, 128
+    block_scales = torch.tensor(
+        [0.125, 1.0, 8.0, 64.0], dtype=torch_dtype, device=device
+    )
+    block_scales = block_scales.repeat_interleave(mxfp_mod.MXFP_BLOCK_SIZE.value)
+    x = torch.randn((rows, k), dtype=torch_dtype, device=device) * block_scales
+    tensor, scale = mxfp_mod.downcast_to_mxfp(x, torch.uint8, axis=-1)
+    ref = mxfp_mod.upcast_from_mxfp(tensor, scale, torch_dtype, axis=-1)
+    out = torch.empty_like(ref)
+    tl_dtype = {
+        torch.float16: tl.float16,
+        torch.bfloat16: tl.bfloat16,
+        torch.float32: tl.float32,
+    }[torch_dtype]
+
+    kernel = _triton_viz_mxfp4_tile_upcast_kernel
+    kernel[(1,)](
+        out,
+        tensor,
+        scale,
+        *out.stride(),
+        *tensor.stride(),
+        *scale.stride(),
+        rows,
+        tensor.shape[-1],
+        scale.shape[-1],
+        tl_dtype,
+    )
+    assert_equal(ref, out)
+
+    sanitizer = _new_sanitizer()
+    traced = pytest.importorskip("triton_viz").trace(client=sanitizer)(kernel)
+    traced[(1,)](
+        torch.empty_like(ref),
+        tensor,
+        scale,
+        *out.stride(),
+        *tensor.stride(),
+        *scale.stride(),
+        rows,
+        tensor.shape[-1],
+        scale.shape[-1],
+        tl_dtype,
+    )
     assert len(sanitizer.records) == 0


### PR DESCRIPTION
## Summary
- Import MXFP4 tile upcast coverage from Triton kernels into the sanitizer end-to-end suite.
- Validate native kernel output against the Triton kernels reference before tracing the same kernel with `SymbolicSanitizer`.
- Cover `float16`, `bfloat16`, and `float32` destination dtypes.

## Tests
- `PYTHONPATH=/mnt/keren/triton/python/triton_kernels:$PYTHONPATH python -m pytest tests/end_to_end/test_triton_kernels.py::test_triton_viz_sanitizer_mxfp4_tile_upcast -q --tb=short -rx`
- `PYTHONPATH=/mnt/keren/triton/python/triton_kernels:$PYTHONPATH python -m pytest tests/end_to_end/test_triton_kernels.py -q --tb=short -rx`
- `pre-commit run --all-files`