### PR TITLE
[FIX] Patch symbolic transpose at builder level

### DIFF
--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -2352,7 +2352,7 @@ class SymbolicClient(Client):
             SymbolicExpr.from_value(shape),
         )
 
-    def _op_trans_overrider(self, arg, perm=[1, 0]):
+    def _op_trans_overrider(self, arg, perm=(1, 0)):
         return SymbolicExpr.create("trans", SymbolicExpr.from_value(arg), perm)
 
     def _op_join_overrider(self, lhs, rhs):

--- a/triton_viz/frontends/triton.py
+++ b/triton_viz/frontends/triton.py
@@ -125,6 +125,7 @@ TRITON_NAMESPACES: dict[Any, dict[str, type[Op]]] = {
         "create_rsqrt": Rsqrt,
         "cast_impl": CastImpl,
         "create_reshape": Reshape,
+        "create_trans": Trans,
         "create_join": Join,
         "create_split": Split,
         "create_fabs": Fabs,
@@ -146,7 +147,6 @@ TRITON_NAMESPACES: dict[Any, dict[str, type[Op]]] = {
         "reduce_or": ReduceOr,
         "sort": Sort,
         "cumsum": CumSum,
-        "trans": Trans,
     },
     tl.standard: {
         "max": ReduceMax,


### PR DESCRIPTION
## Summary
- Register symbolic `Trans` handling on `interpreter_builder.create_trans` instead of patching `tl.trans` directly.
- Keep Triton's language-level `tl.trans`/`permute` validation and return-type construction intact while letting the symbolic engine override the builder operation.
- Add tests for the frontend registration and symbolic transpose shape/dtype preservation.

## Tests
- `python -m pytest tests/unit/test_adapters.py::test_triton_trans_is_registered_on_interpreter_builder tests/unit/test_symbolic_client.py::test_symbolic_trans_overrider_preserves_permuted_shape_and_dtype -q --tb=short`
- `pre-commit run --all-files`