### PR TITLE
[FIX] Support reduce sanitizer E2E case

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ def kernel(x_ptr, out_ptr, BLOCK: tl.constexpr):
     tl.store(out_ptr + offsets, values)
 ```
 
+For Triton JIT helper functions that are called from another traced kernel, use
+`specialized=True` with the same client:
+
+```py
+helper = triton_viz.trace("sanitizer", specialized=True)(helper)
+```
+
 Use the CLI wrappers to run an existing Python script without editing it. These
 wrappers patch plain `@triton.jit` kernels, so use them with scripts that do not
 already apply `@triton_viz.trace(...)`.

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -46,6 +46,18 @@ def test_trace_decorator_add_clients():
     assert sum(c == "tracer" for c in clients) == 1
 
 
+def test_trace_specialized_option_handles_constexpr_helpers():
+    @triton.jit
+    def helper(value, scale: tl.constexpr):
+        return value + scale
+
+    traced = triton_viz.trace("tracer", specialized=True)(helper)
+    traced.interpreted_fn = lambda value, scale: value + scale
+
+    assert traced.specialized is True
+    assert traced(3, tl.constexpr(4)) == 7
+
+
 # ======== Unpatch Tests =========
 def test_unpatch_lang_restores_builtins():
     @triton.jit

--- a/tests/end_to_end/test_triton_kernels.py
+++ b/tests/end_to_end/test_triton_kernels.py
@@ -55,14 +55,21 @@ def _new_sanitizer():
     return sanitizer_mod.SymbolicSanitizer(abort_on_error=True)
 
 
-def _trace_kernel(monkeypatch, module, name, sanitizer):
+def _trace_kernel(monkeypatch, module, name, sanitizer, *, specialized=False):
     triton_viz = pytest.importorskip("triton_viz")
-    traced = triton_viz.trace(client=sanitizer)(getattr(module, name))
+    traced = triton_viz.trace(client=sanitizer, specialized=specialized)(
+        getattr(module, name)
+    )
     monkeypatch.setattr(module, name, traced)
 
 
 def _trace_specialization_get(
-    monkeypatch, specialization_module, sanitizer, kernel_names
+    monkeypatch,
+    specialization_module,
+    sanitizer,
+    kernel_names,
+    *,
+    specialized_global_names=(),
 ):
     orig_get = specialization_module.get
     traced_modules = set()
@@ -71,6 +78,18 @@ def _trace_specialization_get(
         module = orig_get(**kwargs)
         if id(module) not in traced_modules:
             for name in kernel_names:
+                kernel = getattr(module, name)
+                # SpecializationModule clones launch kernels into dynamic modules.
+                # Patch captured nested helpers in that generated global scope.
+                for global_name in specialized_global_names:
+                    globals_dict = kernel.fn.__globals__
+                    if global_name in globals_dict:
+                        triton_viz = pytest.importorskip("triton_viz")
+                        traced = triton_viz.trace(
+                            client=sanitizer,
+                            specialized=True,
+                        )(globals_dict[global_name])
+                        monkeypatch.setitem(globals_dict, global_name, traced)
                 _trace_kernel(monkeypatch, module, name, sanitizer)
             traced_modules.add(id(module))
         return module
@@ -426,6 +445,7 @@ def test_triton_viz_sanitizer_reduce(monkeypatch, device, shape, dim, dtype):
         reduce_mod.forward_specializations,
         sanitizer,
         ("_reduce_forward",),
+        specialized_global_names=("_reduce_forward_inner",),
     )
     _trace_specialization_get(
         monkeypatch,

--- a/tests/end_to_end/test_triton_kernels.py
+++ b/tests/end_to_end/test_triton_kernels.py
@@ -32,6 +32,15 @@ TOPK_BACKWARD_CASES = [
 ]
 SWIGLU_CASES = [(1311, 4352, 1e-2), (1311, 4352, 10)]
 MXFP4_TILE_UPCAST_CASES = ["float16", "bfloat16", "float32"]
+REDUCE_CASES = [
+    ((3, 15, 25), 0, torch.float16),
+    ((3, 15, 25), 1, torch.float16),
+    ((3, 15, 25), 2, torch.float16),
+    ((4, 4, 4), 0, torch.float32),
+    ((4, 4, 4), 1, torch.float32),
+    ((4, 4, 4), 2, torch.float32),
+    ((15, 345, 789), 2, torch.float16),
+]
 _mxfp4_tile_upcast = None
 
 
@@ -50,6 +59,23 @@ def _trace_kernel(monkeypatch, module, name, sanitizer):
     triton_viz = pytest.importorskip("triton_viz")
     traced = triton_viz.trace(client=sanitizer)(getattr(module, name))
     monkeypatch.setattr(module, name, traced)
+
+
+def _trace_specialization_get(
+    monkeypatch, specialization_module, sanitizer, kernel_names
+):
+    orig_get = specialization_module.get
+    traced_modules = set()
+
+    def wrapped_get(**kwargs):
+        module = orig_get(**kwargs)
+        if id(module) not in traced_modules:
+            for name in kernel_names:
+                _trace_kernel(monkeypatch, module, name, sanitizer)
+            traced_modules.add(id(module))
+        return module
+
+    monkeypatch.setattr(specialization_module, "get", wrapped_get)
 
 
 @pytest.mark.parametrize(
@@ -365,4 +391,49 @@ def test_triton_viz_sanitizer_mxfp4_tile_upcast(device, dst_dtype):
         scale.shape[-1],
         tl_dtype,
     )
+    assert len(sanitizer.records) == 0
+
+
+@pytest.mark.parametrize(("shape", "dim", "dtype"), REDUCE_CASES)
+@pytest.mark.parametrize("device", ["cuda"], indirect=True)
+def test_triton_viz_sanitizer_reduce(monkeypatch, device, shape, dim, dtype):
+    _require_cuda(device)
+
+    reduce_mod = pytest.importorskip("triton_kernels.reduce")
+
+    torch.manual_seed(0)
+    x_tri = torch.randn(shape, device=device, dtype=dtype, requires_grad=True)
+    x_ref = x_tri.detach().clone().requires_grad_(True)
+
+    y_tri, _ = reduce_mod.reduce(x_tri, dim=dim)
+    y_ref, _ = reduce_mod.reduce_torch(
+        x_ref,
+        dim=dim,
+        x_flex=None,
+        y_flex=None,
+    )
+    assert torch.allclose(y_tri.float(), y_ref.float(), atol=1e-3, rtol=1e-3)
+
+    dy = torch.randn_like(y_tri)
+    y_tri.backward(dy)
+    y_ref.backward(dy)
+    assert torch.allclose(x_tri.grad.float(), x_ref.grad.float(), atol=1e-3, rtol=1e-3)
+
+    sanitizer = _new_sanitizer()
+    _trace_kernel(monkeypatch, reduce_mod, "_create_row_idxs", sanitizer)
+    _trace_specialization_get(
+        monkeypatch,
+        reduce_mod.forward_specializations,
+        sanitizer,
+        ("_reduce_forward",),
+    )
+    _trace_specialization_get(
+        monkeypatch,
+        reduce_mod.backward_specializations,
+        sanitizer,
+        ("_reduce_backward",),
+    )
+    x_san = x_tri.detach().clone().requires_grad_(True)
+    y_san, _ = reduce_mod.reduce(x_san, dim=dim)
+    y_san.backward(torch.randn_like(y_san))
     assert len(sanitizer.records) == 0

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -510,6 +510,16 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
         args_hst, kwargs_hst = self._init_args_hst(args_dev, kwargs)
 
     # Prepare call arguments
+    # Triton may omit nullable positional values immediately before constexpr
+    # keyword arguments in interpreter launches. Restore those slots so Python
+    # signature binding preserves the original argument positions.
+    kwarg_indexes = [
+        argspec.args.index(name) for name in kwargs_hst if name in argspec.args
+    ]
+    if kwarg_indexes:
+        positional_limit = min(kwarg_indexes)
+        if len(args_hst) < positional_limit:
+            args_hst = [*args_hst, *([None] * (positional_limit - len(args_hst)))]
     args = inspect.getcallargs(self.fn, *args_hst, **kwargs_hst)
     call_args = {}
     for name, arg in args.items():
@@ -604,6 +614,21 @@ def _jit_function_call(self, *args, backend=None, **kwargs):
     assert backend is not None
     patch_lang(self.fn, backend, client_manager=_current_client_manager)
     try:
+
+        def unwrap_constexpr(value):
+            # Nested JIT helpers are executed as Python functions under tracing,
+            # so compile-time wrappers must behave like their underlying values.
+            if isinstance(value, tl.constexpr):
+                return unwrap_constexpr(value.value)
+            if hasattr(value, "__dict__") and isinstance(value, tl.core.base_value):
+                for name, attr in vars(value).items():
+                    unwrapped_attr = unwrap_constexpr(attr)
+                    if unwrapped_attr is not attr:
+                        object.__setattr__(value, name, unwrapped_attr)
+            return value
+
+        args = tuple(unwrap_constexpr(arg) for arg in args)
+        kwargs = {key: unwrap_constexpr(value) for key, value in kwargs.items()}
         return self.fn(*args, **kwargs)
     finally:
         unpatch_lang(backend)

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -510,16 +510,6 @@ def _grid_executor_call(self, *args_dev, backend=None, **kwargs):
         args_hst, kwargs_hst = self._init_args_hst(args_dev, kwargs)
 
     # Prepare call arguments
-    # Triton may omit nullable positional values immediately before constexpr
-    # keyword arguments in interpreter launches. Restore those slots so Python
-    # signature binding preserves the original argument positions.
-    kwarg_indexes = [
-        argspec.args.index(name) for name in kwargs_hst if name in argspec.args
-    ]
-    if kwarg_indexes:
-        positional_limit = min(kwarg_indexes)
-        if len(args_hst) < positional_limit:
-            args_hst = [*args_hst, *([None] * (positional_limit - len(args_hst)))]
     args = inspect.getcallargs(self.fn, *args_hst, **kwargs_hst)
     call_args = {}
     for name, arg in args.items():
@@ -614,21 +604,6 @@ def _jit_function_call(self, *args, backend=None, **kwargs):
     assert backend is not None
     patch_lang(self.fn, backend, client_manager=_current_client_manager)
     try:
-
-        def unwrap_constexpr(value):
-            # Nested JIT helpers are executed as Python functions under tracing,
-            # so compile-time wrappers must behave like their underlying values.
-            if isinstance(value, tl.constexpr):
-                return unwrap_constexpr(value.value)
-            if hasattr(value, "__dict__") and isinstance(value, tl.core.base_value):
-                for name, attr in vars(value).items():
-                    unwrapped_attr = unwrap_constexpr(attr)
-                    if unwrapped_attr is not attr:
-                        object.__setattr__(value, name, unwrapped_attr)
-            return value
-
-        args = tuple(unwrap_constexpr(arg) for arg in args)
-        kwargs = {key: unwrap_constexpr(value) for key, value in kwargs.items()}
         return self.fn(*args, **kwargs)
     finally:
         unpatch_lang(backend)

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -5,6 +5,7 @@ from triton.runtime import KernelInterface, Autotuner
 from triton.runtime.autotuner import Heuristics
 from triton.runtime.interpreter import InterpretedFunction
 from triton import JITFunction
+import triton.language as tl
 
 from .config import config as cfg
 from ..clients import Sanitizer, Profiler, RaceDetector, Tracer
@@ -16,6 +17,19 @@ import types
 
 
 launches: list[Launch] = []
+
+
+def _unwrap_triton_constexpr(value):
+    # Specialized Triton helper functions can receive constexpr wrappers from
+    # generated kernels; the Python implementation expects their raw values.
+    if isinstance(value, tl.constexpr):
+        return _unwrap_triton_constexpr(value.value)
+    if hasattr(value, "__dict__") and isinstance(value, tl.core.base_value):
+        for name, attr in vars(value).items():
+            unwrapped_attr = _unwrap_triton_constexpr(attr)
+            if unwrapped_attr is not attr:
+                object.__setattr__(value, name, unwrapped_attr)
+    return value
 
 
 class TraceInterface:
@@ -54,10 +68,12 @@ class TritonTrace(KernelInterface, TraceInterface):
         self,
         runner: JITFunction | InterpretedFunction | Autotuner | Heuristics,
         client: str | Client,
+        specialized: bool = False,
     ) -> None:
         self.jit_fn: JITFunction | None = None
         self.base_fn: Callable | None = None
         self.interpreted_fn: InterpretedFunction | None = None
+        self.specialized = specialized
 
         def unpack_kernel(
             source: TritonTrace | JITFunction | InterpretedFunction | Heuristics,
@@ -166,6 +182,13 @@ class TritonTrace(KernelInterface, TraceInterface):
                     f"outer={outer_clients}, inner={inner_clients}"
                 )
 
+        if self.specialized:
+            args = tuple(_unwrap_triton_constexpr(arg) for arg in args)
+            kwargs = {
+                key: _unwrap_triton_constexpr(value) for key, value in kwargs.items()
+            }
+
+        assert self.interpreted_fn is not None
         return self.interpreted_fn(*args, **kwargs)
 
     def warmup(self, *args, **kwargs):
@@ -270,18 +293,29 @@ def trace_source(kernel):
     return kernel
 
 
-def trace(client: str | Client | None = None, backend: str = "triton"):
+def trace(
+    client: str | Client | None = None,
+    backend: str = "triton",
+    specialized: bool = False,
+):
     """
     Create a trace object that can be used to run a kernel with instrumentation client(s).
 
     :param kernel: The kernel to run.
     :param client: A client to run with the kernel. Defaults to Tracer() if not specified.
+    :param specialized: Treat a Triton JIT helper as a specialized device
+        function when it is called from another traced kernel. This is intended
+        for nested helper functions, not as a way to bypass tracing for
+        launched kernels.
     """
     if client is None:
         client = Tracer()
 
     if not isinstance(client, (str, Client)):
         raise TypeError(f"Expected str or Client, got {type(client)}")
+
+    if specialized and backend != "triton":
+        raise ValueError("specialized=True is only supported for Triton trace targets")
 
     def _is_sanitizer_client(selected: str | Client) -> bool:
         if isinstance(selected, str):
@@ -323,6 +357,12 @@ def trace(client: str | Client | None = None, backend: str = "triton"):
         if isinstance(kernel, TraceInterface):
             trace = kernel
             trace.add_client(client)
+            if specialized:
+                if not isinstance(trace, TritonTrace):
+                    raise ValueError(
+                        "specialized=True is only supported for Triton trace targets"
+                    )
+                trace.specialized = True
             return trace
 
         trace_source(kernel)
@@ -336,7 +376,7 @@ def trace(client: str | Client | None = None, backend: str = "triton"):
             kernel, (JITFunction, InterpretedFunction, Autotuner, Heuristics)
         ):
             if backend == "triton":
-                return TritonTrace(kernel, client)
+                return TritonTrace(kernel, client, specialized=specialized)
             else:
                 raise ValueError(f"Unknown backend: {backend}")
 


### PR DESCRIPTION
## Summary
- Add focused Triton kernels reduce E2E cases to `test_triton_kernels.py`.
- Validate native reduce forward/backward against `reduce_torch` across multiple dimensions, dtypes, and shapes.
- Fix Triton-Viz tracing of generated/nested Triton JIT helpers so reduce forward/backward specializations can run under the sanitizer without false launch-binding failures.

## Tests
- `PYTHONPATH=/mnt/keren/triton/python/triton_kernels:$PYTHONPATH python -m pytest tests/end_to_end/test_triton_kernels.py::test_triton_viz_sanitizer_reduce -q --tb=short` -> `7 passed`
- `python -m pytest tests/unit/test_patch_scope.py -q --tb=short` -> `5 passed`
- `PYTHONPATH=/mnt/keren/triton/python/triton_kernels:$PYTHONPATH python -m pytest tests/end_to_end/test_triton_kernels.py -q --tb=short -rx` -> `18 passed, 9 xfailed`
- `pre-commit run --all-files`