### PR TITLE
[PERF] Reduce frontend runtime dispatch overhead

### DIFF
--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -29,7 +29,8 @@ from triton_viz.core.symbolic_metadata import (
 
 from triton_viz.core.patch import PatchOp
 
-TRITON_ADAPTERS = get_frontend("triton").adapters
+TRITON_FRONTEND = get_frontend("triton")
+TRITON_ADAPTERS = TRITON_FRONTEND.adapters
 NKI_ADAPTERS = get_frontend("nki").adapters
 
 
@@ -265,6 +266,7 @@ def test_patchop_uses_adapter_for_callbacks():
         op_type=Store,
         callbacks=callbacks,
         adapter=adapter,
+        run_op_overrider=TRITON_FRONTEND.run_op_overrider,
     )
 
     ptr = object()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -267,6 +267,7 @@ def test_patchop_uses_adapter_for_callbacks():
         callbacks=callbacks,
         adapter=adapter,
         run_op_overrider=TRITON_FRONTEND.run_op_overrider,
+        maybe_yield_for_multism=TRITON_FRONTEND.maybe_yield_for_multism,
     )
 
     ptr = object()

--- a/tests/unit/test_client_manager.py
+++ b/tests/unit/test_client_manager.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
+
 from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
 from triton_viz.core.client import Client, ClientManager
+from triton_viz.core.config import config as cfg
 
 
 class _DummyClient(Client):
@@ -56,3 +59,28 @@ def test_client_manager_finalize_collects_client_tensors():
 
     assert tensor in manager.launch.tensors
     assert manager.launch.records == [record]
+
+
+def test_lock_fn_keeps_runtime_lock_decision():
+    previous_num_sms = cfg.num_sms
+
+    class LockCountingClient(_DummyClient):
+        def __init__(self):
+            super().__init__()
+            self.lock_context_calls = 0
+
+        @contextmanager
+        def _lock_context(self):
+            self.lock_context_calls += 1
+            yield
+
+    client = LockCountingClient()
+    cfg.num_sms = 1
+    wrapped = client.lock_fn(lambda: None)
+
+    try:
+        wrapped()
+    finally:
+        cfg.num_sms = previous_num_sms
+
+    assert client.lock_context_calls == 1

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -1,5 +1,6 @@
 import pytest
 import warnings
+from types import SimpleNamespace
 
 import numpy as np
 import triton.language as tl
@@ -13,6 +14,25 @@ from triton_viz.core.frontend import triton as triton_frontend
 def _dummy_kernel():
     """Provides tl/tl.core globals for language patch scope capture."""
     return tl.arange(0, 1)
+
+
+_UNUSED_TL_CORE_ALIAS = tl.core
+_TL_CORE_ALIAS = tl.core
+
+
+def _uses_no_triton_language_module():
+    return 1
+
+
+def _uses_tl_core_alias():
+    return _TL_CORE_ALIAS
+
+
+def test_jit_function_lang_patch_check_uses_referenced_globals_only():
+    needs_patch = triton_frontend.frontend._jit_function_needs_lang_patch
+
+    assert not needs_patch(SimpleNamespace(fn=_uses_no_triton_language_module))
+    assert needs_patch(SimpleNamespace(fn=_uses_tl_core_alias))
 
 
 def test_scope_restores_tensor_magic_methods():

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -170,14 +170,14 @@ def test_patch_lang_does_not_inject_loop_global():
     assert wrapper_key not in globals_dict
 
 
-def test_sanitizer_grid_executor_temporarily_disables_overflow_checks(monkeypatch):
+def test_grid_executor_temporarily_disables_overflow_checks(monkeypatch):
     frontend = triton_frontend.frontend
     old_virtual_memory = cfg.virtual_memory
     cfg.virtual_memory = True
 
     class ClientManagerStub:
         def get_client(self, name):
-            return object() if name == "sanitizer" else None
+            return None
 
     class GridExecutorStub:
         fn = staticmethod(_dummy_kernel)

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -1,5 +1,6 @@
 import pytest
 import warnings
+from types import SimpleNamespace
 
 import numpy as np
 import triton.language as tl
@@ -13,6 +14,26 @@ from triton_viz.core.frontend import triton as triton_frontend
 def _dummy_kernel():
     """Provides tl/tl.core globals for language patch scope capture."""
     return tl.arange(0, 1)
+
+
+_TL_CORE_ALIAS = tl.core
+
+
+def _uses_tl_language_module():
+    return tl.arange(0, 1)
+
+
+def _uses_tl_core_alias():
+    return _TL_CORE_ALIAS.full([1], 0, tl.float32)
+
+
+def test_jit_function_core_module_check_is_function_specific():
+    uses_core = triton_frontend.frontend._jit_function_uses_core_module
+
+    assert not uses_core(SimpleNamespace(fn=_uses_tl_language_module))
+    assert uses_core(SimpleNamespace(fn=_uses_tl_core_alias))
+    assert uses_core(tl.zeros)
+    assert not uses_core(tl.cdiv)
 
 
 def test_scope_restores_tensor_magic_methods():

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -1,6 +1,5 @@
 import pytest
 import warnings
-from types import SimpleNamespace
 
 import numpy as np
 import triton.language as tl
@@ -14,25 +13,6 @@ from triton_viz.core.frontend import triton as triton_frontend
 def _dummy_kernel():
     """Provides tl/tl.core globals for language patch scope capture."""
     return tl.arange(0, 1)
-
-
-_UNUSED_TL_CORE_ALIAS = tl.core
-_TL_CORE_ALIAS = tl.core
-
-
-def _uses_no_triton_language_module():
-    return 1
-
-
-def _uses_tl_core_alias():
-    return _TL_CORE_ALIAS
-
-
-def test_jit_function_lang_patch_check_uses_referenced_globals_only():
-    needs_patch = triton_frontend.frontend._jit_function_needs_lang_patch
-
-    assert not needs_patch(SimpleNamespace(fn=_uses_no_triton_language_module))
-    assert needs_patch(SimpleNamespace(fn=_uses_tl_core_alias))
 
 
 def test_scope_restores_tensor_magic_methods():

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -7,7 +7,6 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.core import patch as patch_mod
-from triton_viz.core.config import config as cfg
 from triton_viz.core.frontend import triton as triton_frontend
 
 
@@ -189,54 +188,3 @@ def test_patch_lang_does_not_inject_loop_global():
 
     assert legacy_key not in globals_dict
     assert wrapper_key not in globals_dict
-
-
-def test_grid_executor_temporarily_disables_overflow_checks(monkeypatch):
-    frontend = triton_frontend.frontend
-    old_virtual_memory = cfg.virtual_memory
-    cfg.virtual_memory = True
-
-    class ClientManagerStub:
-        def get_client(self, name):
-            return None
-
-    class GridExecutorStub:
-        fn = staticmethod(_dummy_kernel)
-
-    def prepare_grid_launch(_grid_executor, _args_dev, kwargs):
-        return (
-            ClientManagerStub(),
-            kwargs,
-            (),
-            {},
-            {},
-            (1, 1, 1),
-            1,
-        )
-
-    observed = []
-
-    def run_grid(_grid_executor, _call_args, _client_manager, _grid, _max_workers):
-        observed.append(frontend.builder.options.sanitize_overflow)
-
-    monkeypatch.setattr(frontend, "_prepare_grid_launch", prepare_grid_launch)
-    monkeypatch.setattr(frontend, "_run_grid", run_grid)
-
-    had_attr = hasattr(frontend.builder.options, "sanitize_overflow")
-    old_value = getattr(frontend.builder.options, "sanitize_overflow", None)
-    object.__setattr__(frontend.builder.options, "sanitize_overflow", True)
-    try:
-        frontend._grid_executor_call(GridExecutorStub())
-    finally:
-        cfg.virtual_memory = old_virtual_memory
-        if had_attr:
-            object.__setattr__(
-                frontend.builder.options,
-                "sanitize_overflow",
-                old_value,
-            )
-        else:
-            object.__delattr__(frontend.builder.options, "sanitize_overflow")
-
-    assert observed == [False]
-    assert frontend.builder.options.sanitize_overflow is True

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -6,6 +6,7 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.core import patch as patch_mod
+from triton_viz.core.config import config as cfg
 from triton_viz.core.frontend import triton as triton_frontend
 
 
@@ -167,3 +168,54 @@ def test_patch_lang_does_not_inject_loop_global():
 
     assert legacy_key not in globals_dict
     assert wrapper_key not in globals_dict
+
+
+def test_sanitizer_grid_executor_temporarily_disables_overflow_checks(monkeypatch):
+    frontend = triton_frontend.frontend
+    old_virtual_memory = cfg.virtual_memory
+    cfg.virtual_memory = True
+
+    class ClientManagerStub:
+        def get_client(self, name):
+            return object() if name == "sanitizer" else None
+
+    class GridExecutorStub:
+        fn = staticmethod(_dummy_kernel)
+
+    def prepare_grid_launch(_grid_executor, _args_dev, kwargs):
+        return (
+            ClientManagerStub(),
+            kwargs,
+            (),
+            {},
+            {},
+            (1, 1, 1),
+            1,
+        )
+
+    observed = []
+
+    def run_grid(_grid_executor, _call_args, _client_manager, _grid, _max_workers):
+        observed.append(frontend.builder.options.sanitize_overflow)
+
+    monkeypatch.setattr(frontend, "_prepare_grid_launch", prepare_grid_launch)
+    monkeypatch.setattr(frontend, "_run_grid", run_grid)
+
+    had_attr = hasattr(frontend.builder.options, "sanitize_overflow")
+    old_value = getattr(frontend.builder.options, "sanitize_overflow", None)
+    object.__setattr__(frontend.builder.options, "sanitize_overflow", True)
+    try:
+        frontend._grid_executor_call(GridExecutorStub())
+    finally:
+        cfg.virtual_memory = old_virtual_memory
+        if had_attr:
+            object.__setattr__(
+                frontend.builder.options,
+                "sanitize_overflow",
+                old_value,
+            )
+        else:
+            object.__delattr__(frontend.builder.options, "sanitize_overflow")
+
+    assert observed == [False]
+    assert frontend.builder.options.sanitize_overflow is True

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -118,6 +118,7 @@ class Client(ABC):
 class ClientManager:
     def __init__(self, clients: list[Client] | None = None):
         self.clients: dict[str, Client] = {}
+        self._client_values: tuple[Client, ...] = ()
         if clients:
             self.add_clients(clients)
         self.launch = Launch()
@@ -140,6 +141,7 @@ class ClientManager:
             )
             if not duplicate:
                 self.clients[new_client.NAME] = new_client
+        self._client_values = tuple(self.clients.values())
 
     @contextmanager
     def patch_warmup(self, jit_fn):
@@ -201,13 +203,27 @@ class ClientManager:
                 unpatch_lang(frontend_name)
 
     def pre_run_callback(self, fn: Callable) -> bool:
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                return self._client_values[0].pre_run_callback(fn)
+            rets = [client.pre_run_callback(fn) for client in self._client_values]
+            return all(rets) if rets else True
         with self._lock_context():
-            rets = [client.pre_run_callback(fn) for client in self.clients.values()]
+            if len(self._client_values) == 1:
+                return self._client_values[0].pre_run_callback(fn)
+            rets = [client.pre_run_callback(fn) for client in self._client_values]
             return all(rets) if rets else True
 
     def post_run_callback(self, fn: Callable) -> bool:
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                return self._client_values[0].post_run_callback(fn)
+            rets = [client.post_run_callback(fn) for client in self._client_values]
+            return any(rets)
         with self._lock_context():
-            rets = [client.post_run_callback(fn) for client in self.clients.values()]
+            if len(self._client_values) == 1:
+                return self._client_values[0].post_run_callback(fn)
+            rets = [client.post_run_callback(fn) for client in self._client_values]
             return any(rets)
 
     def finalize(self) -> None:
@@ -222,29 +238,43 @@ class ClientManager:
         with self._lock_context():
             if hasattr(arg, "data_ptr"):
                 self.launch.tensors.add(arg)
-            for client in self.clients.values():
+            for client in self._client_values:
                 client.arg_callback(name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int]):
         with self._lock_context():
             self.launch.grid = grid
-            for client in self.clients.values():
+            for client in self._client_values:
                 client.grid_callback(grid)
 
     def grid_idx_callback(self, grid_idx: tuple[int, ...]):
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                self._client_values[0].grid_idx_callback(grid_idx)
+                return
+            for client in self._client_values:
+                client.grid_idx_callback(grid_idx)
+            return
         with self._lock_context():
-            for client in self.clients.values():
+            if len(self._client_values) == 1:
+                self._client_values[0].grid_idx_callback(grid_idx)
+                return
+            for client in self._client_values:
                 client.grid_idx_callback(grid_idx)
 
     # --- For-loop callback management ---
 
     def _clear_loop_hooks(self) -> None:
         self._range_type_hooks: list[Callable] = []
+        self._range_type_hook: Callable | None = None
         self._before: list[Callable] = []
+        self._before_hook: Callable | None = None
         self._iter_listeners: list[Callable] = []
+        self._iter_listener: Callable | None = None
         self._iter_overrider: Callable | None = None
         self._range_wrapper_factory: Callable | None = None
         self._after: list[Callable] = []
+        self._after_hook: Callable | None = None
 
     def _populate_loop_hooks(self, callbacks_list: list[ForLoopCallbacks]) -> None:
         self._clear_loop_hooks()
@@ -265,12 +295,26 @@ class ClientManager:
                 self._range_wrapper_factory = cb.range_wrapper_factory
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
+        if len(self._range_type_hooks) == 1:
+            self._range_type_hook = self._range_type_hooks[0]
+        if len(self._before) == 1:
+            self._before_hook = self._before[0]
+        if len(self._iter_listeners) == 1:
+            self._iter_listener = self._iter_listeners[0]
+        if len(self._after) == 1:
+            self._after_hook = self._after[0]
 
     def range_type(self, lineno: int, range_type: str) -> None:
+        if self._range_type_hook is not None:
+            self._range_type_hook(lineno, range_type)
+            return
         for hook in self._range_type_hooks:
             hook(lineno, range_type)
 
     def before_loop(self, lineno: int, iterable: Any) -> None:
+        if self._before_hook is not None:
+            self._before_hook(lineno, iterable)
+            return
         for hook in self._before:
             hook(lineno, iterable)
 
@@ -280,12 +324,18 @@ class ClientManager:
             if new_idx is not None:
                 idx = new_idx
 
-        for hook in self._iter_listeners:
-            hook(lineno, idx)
+        if self._iter_listener is not None:
+            self._iter_listener(lineno, idx)
+        else:
+            for hook in self._iter_listeners:
+                hook(lineno, idx)
 
         return idx
 
     def after_loop(self, lineno: int) -> None:
+        if self._after_hook is not None:
+            self._after_hook(lineno)
+            return
         for hook in self._after:
             hook(lineno)
 

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -118,7 +118,6 @@ class Client(ABC):
 class ClientManager:
     def __init__(self, clients: list[Client] | None = None):
         self.clients: dict[str, Client] = {}
-        self._client_values: tuple[Client, ...] = ()
         if clients:
             self.add_clients(clients)
         self.launch = Launch()
@@ -141,7 +140,6 @@ class ClientManager:
             )
             if not duplicate:
                 self.clients[new_client.NAME] = new_client
-        self._client_values = tuple(self.clients.values())
 
     @contextmanager
     def patch_warmup(self, jit_fn):
@@ -203,27 +201,13 @@ class ClientManager:
                 unpatch_lang(frontend_name)
 
     def pre_run_callback(self, fn: Callable) -> bool:
-        if cfg.num_sms <= 1:
-            if len(self._client_values) == 1:
-                return self._client_values[0].pre_run_callback(fn)
-            rets = [client.pre_run_callback(fn) for client in self._client_values]
-            return all(rets) if rets else True
         with self._lock_context():
-            if len(self._client_values) == 1:
-                return self._client_values[0].pre_run_callback(fn)
-            rets = [client.pre_run_callback(fn) for client in self._client_values]
+            rets = [client.pre_run_callback(fn) for client in self.clients.values()]
             return all(rets) if rets else True
 
     def post_run_callback(self, fn: Callable) -> bool:
-        if cfg.num_sms <= 1:
-            if len(self._client_values) == 1:
-                return self._client_values[0].post_run_callback(fn)
-            rets = [client.post_run_callback(fn) for client in self._client_values]
-            return any(rets)
         with self._lock_context():
-            if len(self._client_values) == 1:
-                return self._client_values[0].post_run_callback(fn)
-            rets = [client.post_run_callback(fn) for client in self._client_values]
+            rets = [client.post_run_callback(fn) for client in self.clients.values()]
             return any(rets)
 
     def finalize(self) -> None:
@@ -238,43 +222,29 @@ class ClientManager:
         with self._lock_context():
             if hasattr(arg, "data_ptr"):
                 self.launch.tensors.add(arg)
-            for client in self._client_values:
+            for client in self.clients.values():
                 client.arg_callback(name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int]):
         with self._lock_context():
             self.launch.grid = grid
-            for client in self._client_values:
+            for client in self.clients.values():
                 client.grid_callback(grid)
 
     def grid_idx_callback(self, grid_idx: tuple[int, ...]):
-        if cfg.num_sms <= 1:
-            if len(self._client_values) == 1:
-                self._client_values[0].grid_idx_callback(grid_idx)
-                return
-            for client in self._client_values:
-                client.grid_idx_callback(grid_idx)
-            return
         with self._lock_context():
-            if len(self._client_values) == 1:
-                self._client_values[0].grid_idx_callback(grid_idx)
-                return
-            for client in self._client_values:
+            for client in self.clients.values():
                 client.grid_idx_callback(grid_idx)
 
     # --- For-loop callback management ---
 
     def _clear_loop_hooks(self) -> None:
         self._range_type_hooks: list[Callable] = []
-        self._range_type_hook: Callable | None = None
         self._before: list[Callable] = []
-        self._before_hook: Callable | None = None
         self._iter_listeners: list[Callable] = []
-        self._iter_listener: Callable | None = None
         self._iter_overrider: Callable | None = None
         self._range_wrapper_factory: Callable | None = None
         self._after: list[Callable] = []
-        self._after_hook: Callable | None = None
 
     def _populate_loop_hooks(self, callbacks_list: list[ForLoopCallbacks]) -> None:
         self._clear_loop_hooks()
@@ -295,26 +265,12 @@ class ClientManager:
                 self._range_wrapper_factory = cb.range_wrapper_factory
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
-        if len(self._range_type_hooks) == 1:
-            self._range_type_hook = self._range_type_hooks[0]
-        if len(self._before) == 1:
-            self._before_hook = self._before[0]
-        if len(self._iter_listeners) == 1:
-            self._iter_listener = self._iter_listeners[0]
-        if len(self._after) == 1:
-            self._after_hook = self._after[0]
 
     def range_type(self, lineno: int, range_type: str) -> None:
-        if self._range_type_hook is not None:
-            self._range_type_hook(lineno, range_type)
-            return
         for hook in self._range_type_hooks:
             hook(lineno, range_type)
 
     def before_loop(self, lineno: int, iterable: Any) -> None:
-        if self._before_hook is not None:
-            self._before_hook(lineno, iterable)
-            return
         for hook in self._before:
             hook(lineno, iterable)
 
@@ -324,18 +280,12 @@ class ClientManager:
             if new_idx is not None:
                 idx = new_idx
 
-        if self._iter_listener is not None:
-            self._iter_listener(lineno, idx)
-        else:
-            for hook in self._iter_listeners:
-                hook(lineno, idx)
+        for hook in self._iter_listeners:
+            hook(lineno, idx)
 
         return idx
 
     def after_loop(self, lineno: int) -> None:
-        if self._after_hook is not None:
-            self._after_hook(lineno)
-            return
         for hook in self._after:
             hook(lineno)
 

--- a/triton_viz/core/frontend/base.py
+++ b/triton_viz/core/frontend/base.py
@@ -129,9 +129,6 @@ class Frontend:
     ):
         return op_overrider(*args, **kwargs)
 
-    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
-        return True
-
     @staticmethod
     def concrete_fn_for_op_type(
         namespace_ops: dict[str, Callable], op_type: type[Op], original_op: Callable

--- a/triton_viz/core/frontend/base.py
+++ b/triton_viz/core/frontend/base.py
@@ -123,11 +123,14 @@ class Frontend:
         self,
         op: Callable,
         op_type: type[Op],
-        callbacks: Any,
+        op_overrider: Callable,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
-        return callbacks.op_overrider(*args, **kwargs)
+        return op_overrider(*args, **kwargs)
+
+    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
+        return True
 
     @staticmethod
     def concrete_fn_for_op_type(

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -853,6 +853,9 @@ class TritonFrontend(Frontend):
         return op_overrider(*args, **kwargs)
 
     def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
+        # Triton language ops need frontend-specific argument/return conversion
+        # in run_op_overrider; interpreter builder ops already receive the
+        # representation expected by client overriders.
         return op_type not in self._math_op_types and op_type not in self._tl_op_types
 
     def patch_for_loop(self) -> None:

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -852,12 +852,6 @@ class TritonFrontend(Frontend):
 
         return op_overrider(*args, **kwargs)
 
-    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
-        # Triton language ops need frontend-specific argument/return conversion
-        # in run_op_overrider; interpreter builder ops already receive the
-        # representation expected by client overriders.
-        return op_type not in self._math_op_types and op_type not in self._tl_op_types
-
     def patch_for_loop(self) -> None:
         if self._loop_ast_patched:
             return
@@ -1012,6 +1006,22 @@ class TritonFrontend(Frontend):
             for fut in futures:
                 fut.result()
 
+    @contextmanager
+    def _builder_options_scope(self, **updates: Any):
+        originals = {
+            name: getattr(self.builder.options, name, _MISSING) for name in updates
+        }
+        for name, value in updates.items():
+            object.__setattr__(self.builder.options, name, value)
+        try:
+            yield
+        finally:
+            for name, value in originals.items():
+                if value is _MISSING:
+                    object.__delattr__(self.builder.options, name)
+                else:
+                    object.__setattr__(self.builder.options, name, value)
+
     def _grid_executor_call(self, grid_executor, *args_dev, **kwargs):
         if kwargs.pop("warmup", False):
             return
@@ -1036,17 +1046,14 @@ class TritonFrontend(Frontend):
             disable_sanitize_overflow = (
                 client_manager.get_client("sanitizer") is not None
             )
-            old_num_warps = getattr(self.builder.options, "num_warps", _MISSING)
-            old_sanitize_overflow = getattr(
-                self.builder.options, "sanitize_overflow", _MISSING
-            )
-            object.__setattr__(self.builder.options, "num_warps", launch_num_warps)
+            builder_option_updates = {"num_warps": launch_num_warps}
             if disable_sanitize_overflow:
                 # Sanitizer validates memory addresses. Triton's interpreter
                 # integer-overflow device_asserts create extra symbolic trees
                 # unrelated to OOB reporting, so keep them off for this launch.
-                object.__setattr__(self.builder.options, "sanitize_overflow", False)
-            try:
+                builder_option_updates["sanitize_overflow"] = False
+
+            with self._builder_options_scope(**builder_option_updates):
                 self._run_grid(
                     grid_executor,
                     call_args,
@@ -1054,23 +1061,6 @@ class TritonFrontend(Frontend):
                     grid,
                     max_workers,
                 )
-            finally:
-                if old_num_warps is _MISSING:
-                    object.__delattr__(self.builder.options, "num_warps")
-                else:
-                    object.__setattr__(
-                        self.builder.options,
-                        "num_warps",
-                        old_num_warps,
-                    )
-                if old_sanitize_overflow is _MISSING:
-                    object.__delattr__(self.builder.options, "sanitize_overflow")
-                else:
-                    object.__setattr__(
-                        self.builder.options,
-                        "sanitize_overflow",
-                        old_sanitize_overflow,
-                    )
 
             if cfg.enable_timing:
                 end_time = time.time()

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -1073,10 +1073,7 @@ class TritonFrontend(Frontend):
             self._current_client_manager = previous_client_manager
 
     def _jit_function_call(self, jit_function, *args, **kwargs):
-        if (
-            self._current_client_manager is not None
-            and not self._jit_function_needs_lang_patch(jit_function)
-        ):
+        if self._current_client_manager is not None:
             return jit_function.fn(*args, **kwargs)
 
         scope = self.patch_lang(
@@ -1087,16 +1084,6 @@ class TritonFrontend(Frontend):
             return jit_function.fn(*args, **kwargs)
         finally:
             scope.restore()
-
-    @staticmethod
-    def _jit_function_needs_lang_patch(jit_function) -> bool:
-        referenced_globals = inspect.getclosurevars(jit_function.fn).globals
-        langs = [
-            value
-            for value in referenced_globals.values()
-            if inspect.ismodule(value) and value in (tl, tl.core)
-        ]
-        return any(lang is tl.core for lang in langs)
 
     @contextmanager
     def patch_calls(self):

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -1043,17 +1043,12 @@ class TritonFrontend(Frontend):
             if cfg.enable_timing:
                 start_time = time.time()
 
-            disable_sanitize_overflow = (
-                client_manager.get_client("sanitizer") is not None
-            )
-            builder_option_updates = {"num_warps": launch_num_warps}
-            if disable_sanitize_overflow:
-                # Sanitizer validates memory addresses. Triton's interpreter
-                # integer-overflow device_asserts create extra symbolic trees
-                # unrelated to OOB reporting, so keep them off for this launch.
-                builder_option_updates["sanitize_overflow"] = False
-
-            with self._builder_options_scope(**builder_option_updates):
+            # Triton's interpreter overflow asserts add runtime work that
+            # Triton-Viz clients do not consume, so keep them off for launches.
+            with self._builder_options_scope(
+                num_warps=launch_num_warps,
+                sanitize_overflow=False,
+            ):
                 self._run_grid(
                     grid_executor,
                     call_args,

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -257,6 +257,7 @@ class TritonFrontend(Frontend):
         self._triton_builtin_attr_cache: dict[int, tuple[str, ...]] = {}
         self._math_op_types = frozenset(self.namespaces[tl.math].values())
         self._tl_op_types = frozenset(self.namespaces[tl].values())
+        self._frontend_wrapped_op_types = self._math_op_types | self._tl_op_types
         self._bind_interpreter_builder_thread_state()
 
     def _bind_interpreter_builder_thread_state(self) -> None:
@@ -841,16 +842,16 @@ class TritonFrontend(Frontend):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
+        if op_type not in self._frontend_wrapped_op_types:
+            return op_overrider(*args, **kwargs)
         if op_type in self._math_op_types:
             raise NotImplementedError("Patching math ops not yet supported")
-        elif op_type in self._tl_op_types:
-            # see triton.runtime.interpreter:ReduceOps.sum
-            # First, convert input from tl.tensor to TensorHandle. Here, input tensor is args[0]
-            # Then, convert return value from TensorHandle to tl.tensor
-            ret = op_overrider(args[0].handle, *args[1:], **kwargs)
-            return self._wrap_tl_ret(ret, args[0].dtype)
 
-        return op_overrider(*args, **kwargs)
+        # see triton.runtime.interpreter:ReduceOps.sum
+        # First, convert input from tl.tensor to TensorHandle. Here, input tensor is args[0]
+        # Then, convert return value from TensorHandle to tl.tensor
+        ret = op_overrider(args[0].handle, *args[1:], **kwargs)
+        return self._wrap_tl_ret(ret, args[0].dtype)
 
     def patch_for_loop(self) -> None:
         if self._loop_ast_patched:
@@ -1089,12 +1090,13 @@ class TritonFrontend(Frontend):
 
     @staticmethod
     def _jit_function_needs_lang_patch(jit_function) -> bool:
+        referenced_globals = inspect.getclosurevars(jit_function.fn).globals
         langs = [
             value
-            for value in jit_function.fn.__globals__.values()
+            for value in referenced_globals.values()
             if inspect.ismodule(value) and value in (tl, tl.core)
         ]
-        return not langs or any(lang is tl.core for lang in langs)
+        return any(lang is tl.core for lang in langs)
 
     @contextmanager
     def patch_calls(self):

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -1073,7 +1073,10 @@ class TritonFrontend(Frontend):
             self._current_client_manager = previous_client_manager
 
     def _jit_function_call(self, jit_function, *args, **kwargs):
-        if self._current_client_manager is not None:
+        if (
+            self._current_client_manager is not None
+            and not self._jit_function_uses_core_module(jit_function)
+        ):
             return jit_function.fn(*args, **kwargs)
 
         scope = self.patch_lang(
@@ -1084,6 +1087,11 @@ class TritonFrontend(Frontend):
             return jit_function.fn(*args, **kwargs)
         finally:
             scope.restore()
+
+    @staticmethod
+    def _jit_function_uses_core_module(jit_function) -> bool:
+        fn = jit_function.fn
+        return any(fn.__globals__.get(name) is tl.core for name in fn.__code__.co_names)
 
     @contextmanager
     def patch_calls(self):

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -32,7 +32,6 @@ from triton.runtime.interpreter import (
 )
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from ..callbacks import OpCallbacks
 from ..config import config as cfg
 from ..data import (
     AddPtr,
@@ -253,6 +252,11 @@ class TritonFrontend(Frontend):
         self._loop_ast_methods: dict[str, Callable | object] = {}
         self._loop_ast_patched = False
         self._patch_calls_scope = 0
+        self._triton_language_targets = tuple(self._triton_language_attr_targets())
+        self._triton_extra_modules = self._triton_extra_builtin_modules()
+        self._triton_builtin_attr_cache: dict[int, tuple[str, ...]] = {}
+        self._math_op_types = frozenset(self.namespaces[tl.math].values())
+        self._tl_op_types = frozenset(self.namespaces[tl].values())
         self._bind_interpreter_builder_thread_state()
 
     def _bind_interpreter_builder_thread_state(self) -> None:
@@ -421,10 +425,18 @@ class TritonFrontend(Frontend):
         # Triton's interpreter patch mutates global tl/tl.core objects. Snapshot
         # both unconditionally so nested or generated JIT functions without a
         # direct `tl` global still restore the language state after tracing.
-        for obj, attrs in self._triton_language_attr_targets():
-            for name, member in inspect.getmembers(obj):
-                if tl.core.is_builtin(member):
-                    scope.set_attr(obj, name, member)
+        for obj, attrs in self._triton_language_targets:
+            obj_id = id(obj)
+            builtin_names = self._triton_builtin_attr_cache.get(obj_id)
+            if builtin_names is None:
+                builtin_names = tuple(
+                    name
+                    for name, member in inspect.getmembers(obj)
+                    if tl.core.is_builtin(member)
+                )
+                self._triton_builtin_attr_cache[obj_id] = builtin_names
+            for name in builtin_names:
+                scope.set_attr(obj, name, getattr(obj, name))
             for attr in attrs:
                 if hasattr(obj, attr):
                     scope.set_attr(obj, attr, getattr(obj, attr))
@@ -727,6 +739,22 @@ class TritonFrontend(Frontend):
         return cls._to_triton_dtype(value)
 
     def normalize_symbolic_value(self, value: Any) -> Any:
+        if isinstance(
+            value,
+            (
+                SymbolicTensorValue,
+                SymbolicScalarDType,
+                SymbolicPointerDType,
+                SymbolicTypeSpec,
+                int,
+                np.integer,
+                bool,
+                float,
+                np.floating,
+                type(None),
+            ),
+        ):
+            return value
         if isinstance(value, tl.core.tensor):
             value = value.handle
         if isinstance(value, TensorHandle):
@@ -809,15 +837,13 @@ class TritonFrontend(Frontend):
         self,
         op: Callable,
         op_type: type[Op],
-        callbacks: OpCallbacks,
+        op_overrider: Callable,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
-        op_overrider = callbacks.op_overrider
-        assert op_overrider is not None
-        if op_type in self.namespaces[tl.math].values():
+        if op_type in self._math_op_types:
             raise NotImplementedError("Patching math ops not yet supported")
-        elif op_type in self.namespaces[tl].values():
+        elif op_type in self._tl_op_types:
             # see triton.runtime.interpreter:ReduceOps.sum
             # First, convert input from tl.tensor to TensorHandle. Here, input tensor is args[0]
             # Then, convert return value from TensorHandle to tl.tensor
@@ -825,6 +851,9 @@ class TritonFrontend(Frontend):
             return self._wrap_tl_ret(ret, args[0].dtype)
 
         return op_overrider(*args, **kwargs)
+
+    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
+        return op_type not in self._math_op_types and op_type not in self._tl_op_types
 
     def patch_for_loop(self) -> None:
         if self._loop_ast_patched:
@@ -869,7 +898,7 @@ class TritonFrontend(Frontend):
         # restore metadata for nested/generated kernels.
         scope = self._triton_snapshot_scope(fn)
         triton_patch_lang(fn)
-        for module in self._triton_extra_builtin_modules():
+        for module in self._triton_extra_modules:
             _patch_builtin(module, interpreter_builder, scope)
         self._patch_triton_inline_asm(scope)
         self._patch_triton_semantic_to_tensor(scope)
@@ -1001,8 +1030,19 @@ class TritonFrontend(Frontend):
             if cfg.enable_timing:
                 start_time = time.time()
 
+            disable_sanitize_overflow = (
+                client_manager.get_client("sanitizer") is not None
+            )
             old_num_warps = getattr(self.builder.options, "num_warps", _MISSING)
+            old_sanitize_overflow = getattr(
+                self.builder.options, "sanitize_overflow", _MISSING
+            )
             object.__setattr__(self.builder.options, "num_warps", launch_num_warps)
+            if disable_sanitize_overflow:
+                # Sanitizer validates memory addresses. Triton's interpreter
+                # integer-overflow device_asserts create extra symbolic trees
+                # unrelated to OOB reporting, so keep them off for this launch.
+                object.__setattr__(self.builder.options, "sanitize_overflow", False)
             try:
                 self._run_grid(
                     grid_executor,
@@ -1020,6 +1060,14 @@ class TritonFrontend(Frontend):
                         "num_warps",
                         old_num_warps,
                     )
+                if old_sanitize_overflow is _MISSING:
+                    object.__delattr__(self.builder.options, "sanitize_overflow")
+                else:
+                    object.__setattr__(
+                        self.builder.options,
+                        "sanitize_overflow",
+                        old_sanitize_overflow,
+                    )
 
             if cfg.enable_timing:
                 end_time = time.time()
@@ -1036,6 +1084,12 @@ class TritonFrontend(Frontend):
             self._current_client_manager = previous_client_manager
 
     def _jit_function_call(self, jit_function, *args, **kwargs):
+        if (
+            self._current_client_manager is not None
+            and not self._jit_function_needs_lang_patch(jit_function)
+        ):
+            return jit_function.fn(*args, **kwargs)
+
         scope = self.patch_lang(
             jit_function.fn,
             client_manager=self._current_client_manager,
@@ -1044,6 +1098,15 @@ class TritonFrontend(Frontend):
             return jit_function.fn(*args, **kwargs)
         finally:
             scope.restore()
+
+    @staticmethod
+    def _jit_function_needs_lang_patch(jit_function) -> bool:
+        langs = [
+            value
+            for value in jit_function.fn.__globals__.values()
+            if inspect.ismodule(value) and value in (tl, tl.core)
+        ]
+        return not langs or any(lang is tl.core for lang in langs)
 
     @contextmanager
     def patch_calls(self):

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -252,9 +252,13 @@ class TritonFrontend(Frontend):
         self._loop_ast_methods: dict[str, Callable | object] = {}
         self._loop_ast_patched = False
         self._patch_calls_scope = 0
+        # These targets are stable for the process; compute them once so each
+        # launch only snapshots current values, not the list of attributes.
         self._triton_language_targets = tuple(self._triton_language_attr_targets())
         self._triton_extra_modules = self._triton_extra_builtin_modules()
         self._triton_builtin_attr_cache: dict[int, tuple[str, ...]] = {}
+        # Most patched ops are interpreter-builder ops and can call overriders
+        # directly. Cache the smaller frontend-wrapped sets for quick routing.
         self._math_op_types = frozenset(self.namespaces[tl.math].values())
         self._tl_op_types = frozenset(self.namespaces[tl].values())
         self._frontend_wrapped_op_types = self._math_op_types | self._tl_op_types
@@ -842,6 +846,8 @@ class TritonFrontend(Frontend):
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
+        # Interpreter-builder ops already use TensorHandle-style arguments; tl
+        # namespace ops need Triton tensor <-> handle conversion around clients.
         if op_type not in self._frontend_wrapped_op_types:
             return op_overrider(*args, **kwargs)
         if op_type in self._math_op_types:
@@ -1009,6 +1015,8 @@ class TritonFrontend(Frontend):
 
     @contextmanager
     def _builder_options_scope(self, **updates: Any):
+        # Triton's builder is process-global. Restore missing attributes as
+        # missing too, not merely to None, so launches do not leak option state.
         originals = {
             name: getattr(self.builder.options, name, _MISSING) for name in updates
         }
@@ -1091,6 +1099,9 @@ class TritonFrontend(Frontend):
     @staticmethod
     def _jit_function_uses_core_module(jit_function) -> bool:
         fn = jit_function.fn
+        # JIT helpers that call tl.core directly need a fresh language patch for
+        # semantic injection. Plain user/device JIT helpers can reuse the active
+        # top-level launch patch and skip another scope.
         return any(fn.__globals__.get(name) is tl.core for name in fn.__code__.co_names)
 
     @contextmanager

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -30,9 +30,8 @@ class PatchOp:
         op_type: type[Op],
         callbacks: OpCallbacks,
         adapter: Callable[..., AdapterResult],
+        run_op_overrider: Callable,
         maybe_yield_for_multism: Callable[[], None] | None = None,
-        run_op_overrider: Callable | None = None,
-        can_call_op_overrider_directly: bool = True,
     ):
         self.op = op
         self.op_type = op_type
@@ -41,14 +40,7 @@ class PatchOp:
         self.op_overrider = callbacks.op_overrider
         self.adapter = adapter
         self.maybe_yield_for_multism = maybe_yield_for_multism
-        self.run_op_overrider = (
-            None
-            if self.op_overrider and can_call_op_overrider_directly
-            else run_op_overrider
-        )
-        self._has_before_or_after_callback = bool(
-            self.before_callback or self.after_callback
-        )
+        self.run_op_overrider = run_op_overrider
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.op, name)
@@ -57,10 +49,8 @@ class PatchOp:
         if self.maybe_yield_for_multism is not None:
             self.maybe_yield_for_multism()
 
-        if not self._has_before_or_after_callback:
+        if not self.before_callback and not self.after_callback:
             if self.op_overrider:
-                if self.run_op_overrider is None:
-                    return self.op_overrider(*args, **kwargs)
                 return self.run_op_overrider(
                     self.op,
                     self.op_type,
@@ -75,16 +65,13 @@ class PatchOp:
             self.before_callback(*before_args.args, **before_args.kwargs)
 
         if self.op_overrider:
-            if self.run_op_overrider is None:
-                ret = self.op_overrider(*args, **kwargs)
-            else:
-                ret = self.run_op_overrider(
-                    self.op,
-                    self.op_type,
-                    self.op_overrider,
-                    args,
-                    kwargs,
-                )
+            ret = self.run_op_overrider(
+                self.op,
+                self.op_type,
+                self.op_overrider,
+                args,
+                kwargs,
+            )
         else:
             ret = self.op(*args, **kwargs)
 
@@ -125,9 +112,8 @@ def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: s
         op_type,
         callbacks,
         adapter,
-        maybe_yield_for_multism=maybe_yield_for_multism,
         run_op_overrider=frontend.run_op_overrider,
-        can_call_op_overrider_directly=frontend.can_call_op_overrider_directly(op_type),
+        maybe_yield_for_multism=maybe_yield_for_multism,
     )
     setattr(namespace, attr, patched_op)
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -30,36 +30,34 @@ class PatchOp:
         op_type: type[Op],
         callbacks: OpCallbacks,
         adapter: Callable[..., AdapterResult],
-        frontend_name: str = "triton",
-        frontend: Any | None = None,
+        maybe_yield_for_multism: Callable[[], None] | None = None,
+        run_op_overrider: Callable | None = None,
+        can_call_op_overrider_directly: bool = True,
     ):
         self.op = op
         self.op_type = op_type
-        self.callbacks = callbacks
         self.before_callback = callbacks.before_callback
         self.after_callback = callbacks.after_callback
         self.op_overrider = callbacks.op_overrider
         self.adapter = adapter
-        self.frontend_name = frontend_name
-        self.frontend = frontend if frontend is not None else _frontend(frontend_name)
-        self.maybe_yield_for_multism = (
-            self.frontend.maybe_yield_for_multism if cfg.num_sms > 1 else None
-        )
+        self.maybe_yield_for_multism = maybe_yield_for_multism
         self.run_op_overrider = (
             None
-            if self.op_overrider
-            and self.frontend.can_call_op_overrider_directly(op_type)
-            else self.frontend.run_op_overrider
+            if self.op_overrider and can_call_op_overrider_directly
+            else run_op_overrider
         )
-        self._has_callbacks = bool(
-            self.maybe_yield_for_multism or self.before_callback or self.after_callback
+        self._has_before_or_after_callback = bool(
+            self.before_callback or self.after_callback
         )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.op, name)
 
     def __call__(self, *args, **kwargs):
-        if not self._has_callbacks:
+        if self.maybe_yield_for_multism is not None:
+            self.maybe_yield_for_multism()
+
+        if not self._has_before_or_after_callback:
             if self.op_overrider:
                 if self.run_op_overrider is None:
                     return self.op_overrider(*args, **kwargs)
@@ -71,9 +69,6 @@ class PatchOp:
                     kwargs,
                 )
             return self.op(*args, **kwargs)
-
-        if self.maybe_yield_for_multism is not None:
-            self.maybe_yield_for_multism()
 
         if self.before_callback:
             before_args = self.adapter(*args, **kwargs)
@@ -122,13 +117,17 @@ def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: s
     original_op = frontend.original_ops[namespace][attr]
     adapter = frontend.adapters[op_type]
     frontend.prepare_patched_op(namespace, op_type, original_op)
+    maybe_yield_for_multism = (
+        frontend.maybe_yield_for_multism if cfg.num_sms > 1 else None
+    )
     patched_op = PatchOp(
         original_op,
         op_type,
         callbacks,
         adapter,
-        frontend_name=frontend_name,
-        frontend=frontend,
+        maybe_yield_for_multism=maybe_yield_for_multism,
+        run_op_overrider=frontend.run_op_overrider,
+        can_call_op_overrider_directly=frontend.can_call_op_overrider_directly(op_type),
     )
     setattr(namespace, attr, patched_op)
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -34,10 +34,14 @@ class PatchOp:
     ):
         self.op = op
         self.op_type = op_type
+        # Copy callback fields once at patch time; patched ops are called for
+        # every frontend operation, so avoid repeated bundle attribute lookups.
         self.before_callback = callbacks.before_callback
         self.after_callback = callbacks.after_callback
         self.op_overrider = callbacks.op_overrider
         self.adapter = adapter
+        # Frontend hooks are resolved before installing the wrapper so __call__
+        # stays independent of frontend registry lookups.
         self.maybe_yield_for_multism = maybe_yield_for_multism
         self.run_op_overrider = run_op_overrider
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -5,7 +5,6 @@ from typing import Any
 from .frontend.base import AdapterResult, LANG_PATCH_SCOPES
 from .frontend.base import get_frontend
 from .callbacks import OpCallbacks
-from .config import config as cfg
 from .data import Op
 
 
@@ -31,7 +30,7 @@ class PatchOp:
         callbacks: OpCallbacks,
         adapter: Callable[..., AdapterResult],
         run_op_overrider: Callable,
-        maybe_yield_for_multism: Callable[[], None] | None = None,
+        maybe_yield_for_multism: Callable[[], None],
     ):
         self.op = op
         self.op_type = op_type
@@ -46,8 +45,7 @@ class PatchOp:
         return getattr(self.op, name)
 
     def __call__(self, *args, **kwargs):
-        if self.maybe_yield_for_multism is not None:
-            self.maybe_yield_for_multism()
+        self.maybe_yield_for_multism()
 
         if not self.before_callback and not self.after_callback:
             if self.op_overrider:
@@ -104,16 +102,13 @@ def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: s
     original_op = frontend.original_ops[namespace][attr]
     adapter = frontend.adapters[op_type]
     frontend.prepare_patched_op(namespace, op_type, original_op)
-    maybe_yield_for_multism = (
-        frontend.maybe_yield_for_multism if cfg.num_sms > 1 else None
-    )
     patched_op = PatchOp(
         original_op,
         op_type,
         callbacks,
         adapter,
         run_op_overrider=frontend.run_op_overrider,
-        maybe_yield_for_multism=maybe_yield_for_multism,
+        maybe_yield_for_multism=frontend.maybe_yield_for_multism,
     )
     setattr(namespace, attr, patched_op)
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -5,6 +5,7 @@ from typing import Any
 from .frontend.base import AdapterResult, LANG_PATCH_SCOPES
 from .frontend.base import get_frontend
 from .callbacks import OpCallbacks
+from .config import config as cfg
 from .data import Op
 
 
@@ -30,42 +31,73 @@ class PatchOp:
         callbacks: OpCallbacks,
         adapter: Callable[..., AdapterResult],
         frontend_name: str = "triton",
+        frontend: Any | None = None,
     ):
         self.op = op
         self.op_type = op_type
         self.callbacks = callbacks
+        self.before_callback = callbacks.before_callback
+        self.after_callback = callbacks.after_callback
+        self.op_overrider = callbacks.op_overrider
         self.adapter = adapter
         self.frontend_name = frontend_name
+        self.frontend = frontend if frontend is not None else _frontend(frontend_name)
+        self.maybe_yield_for_multism = (
+            self.frontend.maybe_yield_for_multism if cfg.num_sms > 1 else None
+        )
+        self.run_op_overrider = (
+            None
+            if self.op_overrider
+            and self.frontend.can_call_op_overrider_directly(op_type)
+            else self.frontend.run_op_overrider
+        )
+        self._has_callbacks = bool(
+            self.maybe_yield_for_multism or self.before_callback or self.after_callback
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.op, name)
 
     def __call__(self, *args, **kwargs):
-        _frontend(self.frontend_name).maybe_yield_for_multism()
+        if not self._has_callbacks:
+            if self.op_overrider:
+                if self.run_op_overrider is None:
+                    return self.op_overrider(*args, **kwargs)
+                return self.run_op_overrider(
+                    self.op,
+                    self.op_type,
+                    self.op_overrider,
+                    args,
+                    kwargs,
+                )
+            return self.op(*args, **kwargs)
 
-        if self.callbacks.before_callback:
+        if self.maybe_yield_for_multism is not None:
+            self.maybe_yield_for_multism()
+
+        if self.before_callback:
             before_args = self.adapter(*args, **kwargs)
-            self.callbacks.before_callback(*before_args.args, **before_args.kwargs)
+            self.before_callback(*before_args.args, **before_args.kwargs)
 
-        if self.callbacks.op_overrider:
-            ret = self._run_op_overrider(args, kwargs)
+        if self.op_overrider:
+            if self.run_op_overrider is None:
+                ret = self.op_overrider(*args, **kwargs)
+            else:
+                ret = self.run_op_overrider(
+                    self.op,
+                    self.op_type,
+                    self.op_overrider,
+                    args,
+                    kwargs,
+                )
         else:
             ret = self.op(*args, **kwargs)
 
-        if self.callbacks.after_callback:
+        if self.after_callback:
             # Pass ret so that we don't have to derive output shape from args.
             after_args = self.adapter(*args, **kwargs)
-            self.callbacks.after_callback(ret, *after_args.args, **after_args.kwargs)
+            self.after_callback(ret, *after_args.args, **after_args.kwargs)
         return ret
-
-    def _run_op_overrider(self, args: tuple[Any, ...], kwargs: dict[str, Any]):
-        return _frontend(self.frontend_name).run_op_overrider(
-            self.op,
-            self.op_type,
-            self.callbacks,
-            args,
-            kwargs,
-        )
 
 
 def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: str):
@@ -96,6 +128,7 @@ def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: s
         callbacks,
         adapter,
         frontend_name=frontend_name,
+        frontend=frontend,
     )
     setattr(namespace, attr, patched_op)
 


### PR DESCRIPTION
Draft stacked PR 1/3.

Summary:
- Reduce patched frontend-op dispatch overhead by caching `PatchOp` callback fields and resolving frontend hooks at patch time.
- Cache Triton frontend patch metadata and op-type sets so launches avoid repeated namespace/member scans and common builder-op overrides take the direct path.
- Keep nested Triton JIT calls on the raw-function fast path when safe, while re-patching helpers that directly reference `tl.core` so semantic injection still works.
- Scope Triton builder option updates for each launch, setting `num_warps` and disabling interpreter overflow checks while restoring prior option state afterward.
- Keep broader `ClientManager` fast paths out of the PR to preserve readability.

Benefits:
- Less repeated registry, callback-bundle, and frontend namespace work in hot patched-op paths.
- More predictable launch cleanup for process-global Triton builder options.
- Avoids the previous nested-JIT regression for `tl.core` helpers without falling back to broad module-specific checks.

Tests:
- `/mnt/keren/env/bin/python -m pytest tests/unit/test_patch_scope.py tests/unit/test_adapters.py tests/unit/test_client_manager.py`
- `/mnt/keren/env/bin/python -m pytest tests/end_to_end/test_race_detector.py::test_loop_repeated_access_deduped tests/end_to_end/test_sanitizer.py::test_data_dependent_loop_bound_div tests/end_to_end/test_sanitizer.py::test_data_dependent_cdiv_loop_bound tests/end_to_end/test_sanitizer.py::test_tuple_pointer_int_cast_uses_registered_tuple_ranges -q`