### PR TITLE
[FEAT] Start sanitizer loop IR analysis

### DIFF
--- a/tests/unit/test_client_manager.py
+++ b/tests/unit/test_client_manager.py
@@ -1,5 +1,8 @@
+from contextlib import contextmanager
+
 from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
 from triton_viz.core.client import Client, ClientManager
+from triton_viz.core.config import config as cfg
 
 
 class _DummyClient(Client):
@@ -56,3 +59,28 @@ def test_client_manager_finalize_collects_client_tensors():
 
     assert tensor in manager.launch.tensors
     assert manager.launch.records == [record]
+
+
+def test_lock_fn_keeps_runtime_lock_decision():
+    previous_num_sms = cfg.num_sms
+
+    class LockCountingClient(_DummyClient):
+        def __init__(self):
+            super().__init__()
+            self.lock_context_calls = 0
+
+        @contextmanager
+        def _lock_context(self):
+            self.lock_context_calls += 1
+            yield
+
+    client = LockCountingClient()
+    cfg.num_sms = 1
+    wrapped = client.lock_fn(lambda: None)
+
+    try:
+        wrapped()
+    finally:
+        cfg.num_sms = previous_num_sms
+
+    assert client.lock_context_calls == 1

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -6,6 +6,7 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.core import patch as patch_mod
+from triton_viz.core.config import config as cfg
 from triton_viz.core.frontend import triton as triton_frontend
 
 
@@ -167,3 +168,54 @@ def test_patch_lang_does_not_inject_loop_global():
 
     assert legacy_key not in globals_dict
     assert wrapper_key not in globals_dict
+
+
+def test_sanitizer_grid_executor_temporarily_disables_overflow_checks(monkeypatch):
+    frontend = triton_frontend.frontend
+    old_virtual_memory = cfg.virtual_memory
+    cfg.virtual_memory = True
+
+    class ClientManagerStub:
+        def get_client(self, name):
+            return object() if name == "sanitizer" else None
+
+    class GridExecutorStub:
+        fn = staticmethod(_dummy_kernel)
+
+    def prepare_grid_launch(_grid_executor, _args_dev, kwargs):
+        return (
+            ClientManagerStub(),
+            kwargs,
+            (),
+            {},
+            {},
+            (1, 1, 1),
+            1,
+        )
+
+    observed = []
+
+    def run_grid(_grid_executor, _call_args, _client_manager, _grid, _max_workers):
+        observed.append(frontend.builder.options.sanitize_overflow)
+
+    monkeypatch.setattr(frontend, "_prepare_grid_launch", prepare_grid_launch)
+    monkeypatch.setattr(frontend, "_run_grid", run_grid)
+
+    had_attr = hasattr(frontend.builder.options, "sanitize_overflow")
+    old_value = getattr(frontend.builder.options, "sanitize_overflow", None)
+    object.__setattr__(frontend.builder.options, "sanitize_overflow", True)
+    try:
+        frontend._grid_executor_call(GridExecutorStub())
+    finally:
+        cfg.virtual_memory = old_virtual_memory
+        if had_attr:
+            object.__setattr__(
+                frontend.builder.options,
+                "sanitize_overflow",
+                old_value,
+            )
+        else:
+            object.__delattr__(frontend.builder.options, "sanitize_overflow")
+
+    assert observed == [False]
+    assert frontend.builder.options.sanitize_overflow is True

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,8 +1,17 @@
+import numpy as np
 import pytest
 import torch
 from typing import cast
 
 from triton_viz.core.config import config as cfg
+from triton_viz.core.data import Store
+from triton_viz.core.symbolic_metadata import (
+    INT1,
+    INT32,
+    SymbolicTensorValue,
+    pointer_type,
+    type_spec,
+)
 from triton_viz.clients import Sanitizer
 from triton_viz.clients.sanitizer.report import _classify_layout_and_segments
 from triton_viz.clients.sanitizer.sanitizer import (
@@ -10,6 +19,7 @@ from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicSanitizer,
     _fn_symbolic_cache_set,
 )
+from triton_viz.clients.symbolic_engine import SymbolicExpr
 
 
 # ======== Init Tests ===========
@@ -36,8 +46,8 @@ def test_sanitizer_init(_isolate_sanitizer_cfg):
 # These guard the two spots that break most easily when SymbolicClient's
 # launch-lifecycle machinery is reshuffled:
 #   1. the cross-launch fn cache (sanitizer's pre_run_callback short-circuit)
-#   2. the post_run_callback guard that must NOT wipe launch state mid-
-#      full-grid enumeration.
+#   2. launch cleanup happens at finalize, after concurrent block workers are
+#      done with the shared tensor registry.
 
 
 @pytest.fixture
@@ -123,8 +133,8 @@ def test_post_run_callback_preserves_state_mid_full_grid():
     assert sanitizer.cache_grid == (4, 1, 1)
 
 
-def test_post_run_callback_clears_state_on_last_block():
-    """On the final block we DO want launch state cleared."""
+def test_finalize_clears_state_after_last_block():
+    """Launch state is cleared at finalize, not inside a block callback."""
     sanitizer = SymbolicSanitizer(abort_on_error=False)
 
     sentinel_tensor = object()
@@ -138,13 +148,58 @@ def test_post_run_callback_clears_state_on_last_block():
     sanitizer.grid_idx = (3, 0, 0)  # final block
     sanitizer.need_full_grid = True
 
-    sanitizer.post_run_callback(lambda: None)
+    assert sanitizer.post_run_callback(lambda: None) is True
+
+    assert sanitizer.tensors == [sentinel_tensor]
+    assert sanitizer.tensor_addrs == [(0, 0, sentinel_tensor)]
+    assert sanitizer.tensor_names == {id(sentinel_tensor): {"X"}}
+    assert sanitizer.cache_args == [("fake",)]
+    assert sanitizer.cache_grid == (4, 1, 1)
+
+    sanitizer.finalize()
 
     assert sanitizer.tensors == []
     assert sanitizer.tensor_addrs == []
     assert sanitizer.tensor_names == {}
     assert sanitizer.cache_args == []
     assert sanitizer.cache_grid is None
+
+
+def test_concrete_ptr_access_respects_masked_lanes():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+
+    ptr_dtype = pointer_type(INT32)
+    ptr_value = SymbolicTensorValue(
+        np.array([base, end + tensor.element_size()], dtype=np.uint64),
+        ptr_dtype,
+    )
+    ptr_sym = SymbolicExpr.create("const", ptr_value, type_spec(ptr_dtype, (2,)))
+    inactive_oob_mask = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.array([True, False], dtype=bool), INT1),
+        type_spec(INT1, (2,)),
+    )
+    access_expr = SymbolicExpr.create("store", ptr_sym, None, inactive_oob_mask)
+
+    assert sanitizer._check_concrete_ptr_access(ptr_sym, inactive_oob_mask, access_expr)
+    assert sanitizer.records == []
+
+    active_oob_mask = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.array([True, True], dtype=bool), INT1),
+        type_spec(INT1, (2,)),
+    )
+    access_expr = SymbolicExpr.create("store", ptr_sym, None, active_oob_mask)
+
+    assert sanitizer._check_concrete_ptr_access(ptr_sym, active_oob_mask, access_expr)
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Store
+    assert sanitizer.records[0].violation_address == end + tensor.element_size()
 
 
 # ======== Report Layout Classification Tests ===========

--- a/tests/unit/test_sanitizer_ir_analysis.py
+++ b/tests/unit/test_sanitizer_ir_analysis.py
@@ -1,0 +1,102 @@
+import triton
+import triton.language as tl
+
+from triton_viz.clients.sanitizer.ir_analysis import summarize_loop_structure
+
+
+@triton.jit
+def _jit_loop_kernel(x):
+    for i in tl.range(0, 4):
+        x += i
+
+
+def _wrapped_loop_kernel(x):
+    for i in range(2):
+        x += i
+
+
+class _TraceLikeKernel:
+    base_fn = staticmethod(_wrapped_loop_kernel)
+
+
+def test_summarize_constant_loop_ranges():
+    summaries = summarize_loop_structure(
+        """
+        def kernel(x):
+            for i in range(4):
+                x += i
+            for j in tl.range(2, 10, 2):
+                x += j
+            for k in tl.static_range(start=8, end=0, step=-2):
+                x += k
+        """
+    )
+
+    assert [
+        (summary.target, summary.range_type, summary.start, summary.stop, summary.step)
+        for summary in summaries
+    ] == [
+        ("i", "python_range", 0, 4, 1),
+        ("j", "tl_range", 2, 10, 2),
+        ("k", "tl_static_range", 8, 0, -2),
+    ]
+    assert [summary.trip_count for summary in summaries] == [4, 4, 4]
+
+
+def test_summarize_symbolic_loop_bounds_without_condensing():
+    summaries = summarize_loop_structure(
+        """
+        def kernel(x, n, block):
+            for i in tl.range(0, n, block):
+                x += i
+        """
+    )
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.range_type == "tl_range"
+    assert summary.start == 0
+    assert summary.stop is None
+    assert summary.step is None
+    assert not summary.is_constant_range
+    assert summary.trip_count is None
+
+
+def test_summarize_triton_jit_function():
+    summaries = summarize_loop_structure(_jit_loop_kernel)
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.target == "i"
+    assert summary.range_type == "tl_range"
+    assert summary.start == 0
+    assert summary.stop == 4
+    assert summary.step == 1
+
+
+def test_summarize_trace_like_kernel_wrapper():
+    summaries = summarize_loop_structure(_TraceLikeKernel())
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.target == "i"
+    assert summary.range_type == "python_range"
+    assert summary.start == 0
+    assert summary.stop == 2
+    assert summary.step == 1
+
+
+def test_summarize_unknown_iterable_as_non_constant():
+    summaries = summarize_loop_structure(
+        """
+        def kernel(values):
+            for value in values:
+                pass
+        """
+    )
+
+    assert len(summaries) == 1
+    summary = summaries[0]
+    assert summary.target == "value"
+    assert summary.range_type == "unknown"
+    assert not summary.is_constant_range

--- a/triton_viz/clients/sanitizer/ir_analysis.py
+++ b/triton_viz/clients/sanitizer/ir_analysis.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LoopRangeSummary:
+    lineno: int
+    target: str
+    range_type: str
+    start: int | None
+    stop: int | None
+    step: int | None
+
+    @property
+    def is_constant_range(self) -> bool:
+        return (
+            self.start is not None and self.stop is not None and self.step is not None
+        )
+
+    @property
+    def trip_count(self) -> int | None:
+        if not self.is_constant_range:
+            return None
+        assert self.start is not None
+        assert self.stop is not None
+        assert self.step is not None
+        return len(range(self.start, self.stop, self.step))
+
+
+def summarize_loop_structure(
+    fn_or_source: Callable[..., Any] | str,
+) -> list[LoopRangeSummary]:
+    source = _source_text(fn_or_source)
+    tree = ast.parse(source)
+    return [
+        _summarize_for(node) for node in ast.walk(tree) if isinstance(node, ast.For)
+    ]
+
+
+def _source_text(fn_or_source: Callable[..., Any] | str) -> str:
+    source_target = _source_target(fn_or_source)
+    if isinstance(source_target, str):
+        return textwrap.dedent(source_target)
+    return textwrap.dedent(inspect.getsource(source_target))
+
+
+def _source_target(
+    fn_or_source: Callable[..., Any] | str,
+    seen: set[int] | None = None,
+) -> Callable[..., Any] | str:
+    if isinstance(fn_or_source, str):
+        return fn_or_source
+
+    seen = set() if seen is None else seen
+    obj_id = id(fn_or_source)
+    if obj_id in seen:
+        return fn_or_source
+    seen.add(obj_id)
+
+    if inspect.isfunction(fn_or_source) or inspect.ismethod(fn_or_source):
+        return fn_or_source
+
+    for attr in ("base_fn", "fn"):
+        wrapped = getattr(fn_or_source, attr, None)
+        if wrapped is not None and wrapped is not fn_or_source:
+            return _source_target(wrapped, seen)
+
+    raw_src = getattr(fn_or_source, "raw_src", None)
+    if isinstance(raw_src, str):
+        return raw_src
+
+    return fn_or_source
+
+
+def _summarize_for(node: ast.For) -> LoopRangeSummary:
+    range_type, start, stop, step = _range_call_bounds(node.iter)
+    return LoopRangeSummary(
+        lineno=node.lineno,
+        target=ast.unparse(node.target),
+        range_type=range_type,
+        start=start,
+        stop=stop,
+        step=step,
+    )
+
+
+def _range_call_bounds(
+    node: ast.expr,
+) -> tuple[str, int | None, int | None, int | None]:
+    if not isinstance(node, ast.Call):
+        return "unknown", None, None, None
+
+    range_type = _range_type(node.func)
+    if range_type == "unknown":
+        return range_type, None, None, None
+
+    start, stop, step = _parse_range_args(node)
+    return range_type, start, stop, step
+
+
+def _range_type(func: ast.expr) -> str:
+    if isinstance(func, ast.Name) and func.id == "range":
+        return "python_range"
+    if (
+        isinstance(func, ast.Attribute)
+        and isinstance(func.value, ast.Name)
+        and func.value.id == "tl"
+    ):
+        if func.attr == "range":
+            return "tl_range"
+        if func.attr == "static_range":
+            return "tl_static_range"
+    return "unknown"
+
+
+def _parse_range_args(call: ast.Call) -> tuple[int | None, int | None, int | None]:
+    positional = [_literal_int(arg) for arg in call.args]
+    kwargs = {
+        kw.arg: _literal_int(kw.value) for kw in call.keywords if kw.arg is not None
+    }
+
+    start: int | None = 0
+    stop: int | None = None
+    step: int | None = 1
+
+    if len(positional) == 1:
+        stop = positional[0]
+    elif len(positional) == 2:
+        start, stop = positional
+    elif len(positional) >= 3:
+        start, stop, step = positional[:3]
+
+    if "start" in kwargs:
+        start = kwargs["start"]
+    if "stop" in kwargs:
+        stop = kwargs["stop"]
+    if "end" in kwargs:
+        stop = kwargs["end"]
+    if "step" in kwargs:
+        step = kwargs["step"]
+
+    return start, stop, step
+
+
+def _literal_int(node: ast.expr) -> int | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, int):
+        return int(node.value)
+    if (
+        isinstance(node, ast.UnaryOp)
+        and isinstance(node.op, ast.USub)
+        and isinstance(node.operand, ast.Constant)
+        and isinstance(node.operand.value, int)
+    ):
+        return -int(node.operand.value)
+    return None

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -9,6 +9,7 @@ from typing import (
 )
 import sys
 
+import numpy as np
 from torch import Tensor
 from triton.tools.tensor_descriptor import TensorDescriptor
 from z3 import And, BoolVal, Not, Or, sat
@@ -20,6 +21,7 @@ from ...core.data import (
     Op,
     Load,
     Store,
+    TensorPointerStore,
 )
 from ..symbolic_engine import (
     SymbolicExpr,
@@ -42,6 +44,7 @@ from .report import (
     print_oob_record_pdb_style,
 )
 from ...core.config import config as cfg
+from ...core.symbolic_metadata import SymbolicTensorValue
 
 SanitizerT = TypeVar("SanitizerT", bound="Sanitizer")
 
@@ -159,7 +162,11 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         SymbolicClient.grid_idx_callback(self, grid_idx)
 
     def finalize(self) -> list:
-        return SymbolicClient.finalize(self)
+        try:
+            return SymbolicClient.finalize(self)
+        finally:
+            self._clear_cache()
+            self._clear_symbolic_launch_state()
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
         return SymbolicClient.register_for_loop_callback(self)
@@ -171,7 +178,11 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         return SymbolicClient.register_op_callback(self, op_type)
 
     def post_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.post_run_callback(self, fn)
+        if self.need_full_grid is None:
+            self.need_full_grid = False
+        ret = self.need_full_grid
+        self.need_full_grid = None
+        return ret
 
     # ── Sanitizer-specific hook overrides ─────────────────────────
 
@@ -180,6 +191,12 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         # per-access push/pop scope, because it may need tensor-specific
         # ranges instead of the global union of all registered tensors.
         return BoolVal(True)
+
+    def _build_global_addr_ok_at_grid(self) -> bool:
+        # Sanitizer almost always checks tensor-specific ranges via
+        # ``_addr_ok_for_expr``. Defer the more expensive global union until an
+        # unresolved pointer expression actually needs the fallback.
+        return False
 
     def _cache_non_tensor_arg(self, name: str, arg: Any) -> None:
         # TODO: init a reserved_args field per frontend to filter out these args
@@ -211,6 +228,73 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         # the launch.
         self.cache_grid = tuple(int(g) for g in grid)
         SymbolicClient.grid_callback(self, grid)
+
+    def _op_store_overrider(self, ptr, value, mask, *args):
+        del value, args
+        ptr = self._materialize_memory_operand(ptr)
+        mask = self._materialize_memory_operand(mask)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
+        # Store values do not affect address validity. Avoiding the value
+        # subtree keeps sanitizer store checks focused on pointer + mask.
+        ret = SymbolicExpr.create("store", ptr_sym, None, mask_sym)
+
+        if self._check_concrete_ptr_access(ptr_sym, mask_sym, ret):
+            return ret
+
+        self._handle_access_check(ret, Store, "write")
+        return ret
+
+    def _op_tensor_pointer_store_overrider(
+        self, ptr, value, boundary_check, cache_modifier, eviction_policy
+    ):
+        del value, cache_modifier, eviction_policy
+        ptr = self._materialize_memory_operand(ptr)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        ret = SymbolicExpr.create("tensor_pointer_store", ptr_sym, None, boundary_check)
+        self._handle_access_check(ret, TensorPointerStore, "write")
+        return ret
+
+    def _check_concrete_ptr_access(
+        self,
+        ptr_sym: SymbolicExpr,
+        mask_sym: SymbolicExpr | None,
+        access_expr: SymbolicExpr,
+    ) -> bool:
+        concrete_addrs = self._concrete_ptr_addrs(ptr_sym, mask_sym)
+        if concrete_addrs is None:
+            return False
+        self._check_concrete_addr_values(concrete_addrs, access_expr, None)
+        return True
+
+    def _concrete_ptr_addrs(
+        self, ptr_sym: SymbolicExpr, mask_sym: SymbolicExpr | None
+    ) -> list[int] | None:
+        if ptr_sym.op != "const":
+            return None
+        ptr_value = getattr(ptr_sym, "value", None)
+        if not isinstance(ptr_value, SymbolicTensorValue):
+            return None
+
+        addrs = np.asarray(ptr_value.data, dtype=np.uint64).reshape(-1)
+        if mask_sym is None:
+            return [int(addr) for addr in addrs]
+
+        if mask_sym.op != "const":
+            return None
+        mask_value = getattr(mask_sym, "value", None)
+        if isinstance(mask_value, SymbolicTensorValue):
+            mask = np.asarray(mask_value.data, dtype=bool)
+        elif isinstance(mask_value, (bool, int, np.integer)):
+            mask = np.asarray(mask_value, dtype=bool)
+        else:
+            return None
+
+        try:
+            mask = np.broadcast_to(mask, ptr_value.data.shape).reshape(-1)
+        except ValueError:
+            return None
+        return [int(addr) for addr, active in zip(addrs, mask) if active]
 
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.cache_grid:
@@ -261,6 +345,8 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
 
         resolved_tensor = self._resolve_tensor(symbolic_expr)
         if resolved_tensor is None:
+            if self.addr_ok is None or self.addr_ok.eq(BoolVal(False)):
+                self.addr_ok = self._build_global_addr_ok(addr_sym)
             return self.addr_ok
 
         cache_key = id(resolved_tensor)
@@ -286,6 +372,19 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         symbolic_expr: SymbolicExpr,
         source_location: tuple[str, int, str] | None = None,
     ) -> None:
+        if (
+            expr_constraints is None
+            and (
+                isinstance(access_addr, IntNumRef)
+                or (
+                    isinstance(access_addr, list)
+                    and (not access_addr or isinstance(access_addr[0], IntNumRef))
+                )
+            )
+            and self._check_concrete_addr(access_addr, symbolic_expr, source_location)
+        ):
+            return
+
         # Use push/pop on persistent solver
         solver = self.solver
         addr_sym = self.addr_sym
@@ -332,6 +431,92 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         finally:
             solver.pop()
 
+    def _check_concrete_addr(
+        self,
+        access_addr: Z3Expr,
+        symbolic_expr: SymbolicExpr,
+        source_location: tuple[str, int, str] | None,
+    ) -> bool:
+        if isinstance(access_addr, list):
+            concrete_addrs = []
+            for addr in access_addr:
+                if not isinstance(addr, IntNumRef):
+                    return False
+                concrete_addrs.append(addr.as_long())
+        elif isinstance(access_addr, IntNumRef):
+            concrete_addrs = [access_addr.as_long()]
+        else:
+            return False
+        return self._check_concrete_addr_values(
+            concrete_addrs, symbolic_expr, source_location
+        )
+
+    def _check_concrete_addr_values(
+        self,
+        concrete_addrs: list[int],
+        symbolic_expr: SymbolicExpr,
+        source_location: tuple[str, int, str] | None,
+    ) -> bool:
+        if not concrete_addrs:
+            return True
+
+        min_addr = min(concrete_addrs)
+        max_addr = max(concrete_addrs)
+        tensor = self._resolve_tensor(symbolic_expr)
+        if tensor is None:
+            ranges = [(start, end, tensor) for start, end, tensor in self.tensor_addrs]
+        else:
+            ranges = [
+                (start, end, range_tensor)
+                for start, end, range_tensor in self.tensor_addrs
+                if range_tensor is tensor
+            ]
+        if not ranges:
+            return False
+
+        if len(ranges) == 1:
+            start, end, _ = ranges[0]
+            if min_addr >= start and max_addr <= end:
+                return True
+            violation_addr = next(
+                addr for addr in concrete_addrs if addr < start or addr > end
+            )
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, violation_addr)
+            )
+            op_type: type[Load] | type[Store]
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(
+                op_type,
+                report_tensor,
+                violation_addr,
+                symbolic_expr,
+                source_location,
+            )
+            return True
+
+        for addr in concrete_addrs:
+            if any(start <= addr <= end for start, end, _ in ranges):
+                continue
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, addr)
+            )
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(op_type, report_tensor, addr, symbolic_expr, source_location)
+            return True
+
+        return True
+
     def _handle_access_check(
         self,
         expr: SymbolicExpr,
@@ -345,11 +530,21 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         ``_check_range_satisfiable`` for historical compatibility, and it
         doesn't distinguish reads vs writes at the Z3 level.
         """
-        z3_addr, z3_constraints = expr.eval()
         if not self.loop_stack:
+            expr_signature = hash(("expr", expr.signature()))
+            if expr_signature in self.access_check_cache:
+                return
+            z3_addr, z3_constraints = expr.eval()
+            z3_signature = hash(("z3", _make_signature(z3_addr, z3_constraints)))
+            if z3_signature in self.access_check_cache:
+                self.access_check_cache.add(expr_signature)
+                return
+            self.access_check_cache.add(expr_signature)
+            self.access_check_cache.add(z3_signature)
             self._check_range_satisfiable(z3_addr, z3_constraints, expr)
             return
 
+        z3_addr, z3_constraints = expr.eval()
         ctx = self.loop_stack[-1]
         signature = _make_signature(z3_addr, z3_constraints)
         pending_idx = ctx.signature_cache.get(signature)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -203,6 +203,7 @@ class LoopContext:
     length: int
     idx: Any
     idx_z3: ArithRef
+    iterator_constraint: BoolRef
     start: int = 0
     stop: int = 0
     step: int = 1
@@ -325,6 +326,7 @@ class SymbolicExpr:
         "rsqrt",
         "negative",
     )
+    UNARY_OP_SET: ClassVar[frozenset[str]] = frozenset(UNARY_OPS)
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
         "sub": "-",
@@ -349,6 +351,7 @@ class SymbolicExpr:
         "umulhi": "umulhi",
     }
     BINARY_OPS: ClassVar[tuple[str, ...]] = tuple(BINARY_OP_SYMBOL_TABLE.keys())
+    BINARY_OP_SET: ClassVar[frozenset[str]] = frozenset(BINARY_OPS)
     TERNARY_OPS: ClassVar[tuple[str, ...]] = ("where", "fma")
     REDUCE_OPS: ClassVar[tuple[str, ...]] = (
         "sum",
@@ -389,6 +392,7 @@ class SymbolicExpr:
         + SORT_OPS
         + ATOMIC_OPS
     )
+    SUPPORTED_OP_SET: ClassVar[frozenset[str]] = frozenset(SUPPORTED_OPS)
 
     PID0: ClassVar[ArithRef] = Int("pid_0")
     PID1: ClassVar[ArithRef] = Int("pid_1")
@@ -422,7 +426,7 @@ class SymbolicExpr:
         """
         :param op: Operation type, e.g. "const", "add", "sub", "mul", "div", "pid", "arange"
         """
-        assert op in self.SUPPORTED_OPS, f"Unsupported op: {op}"
+        assert op in self.SUPPORTED_OP_SET, f"Unsupported op: {op}"
         self.op = op
         # Tensor-like attributes used by frontend runtimes.
         self.attr: dict[str, Any] = {}
@@ -445,6 +449,7 @@ class SymbolicExpr:
         self._simplified_z3: Z3Expr | None = None
         self._simplified_constraints: ConstraintConjunction | None = None
         self._has_op_cache: dict[str, bool] = {}
+        self.expr_signature: int | None = None
         self._data_wrapper: SymbolicExprDataWrapper | None = None
 
     @staticmethod
@@ -459,10 +464,66 @@ class SymbolicExpr:
         self.children[name] = child
         setattr(self, name, child)
         self._has_op_cache.clear()
+        self.expr_signature = None
         self._simplified_z3 = None
         self._simplified_constraints = None
         if self._data_wrapper is not None:
             self._data_wrapper.invalidate()
+
+    def signature(self) -> int:
+        """Return a structural hash for deduplicating equivalent expr trees."""
+        if self.expr_signature is not None:
+            return self.expr_signature
+
+        child_parts: list[tuple[str, Any]] = []
+        for name, child in self.children.items():
+            if child is None:
+                child_parts.append((name, None))
+            elif isinstance(child, tuple):
+                child_parts.append((name, tuple(item.signature() for item in child)))
+            else:
+                child_parts.append((name, child.signature()))
+
+        value_part: Any = None
+        if self.op == "const":
+            value_part = self._value_signature(getattr(self, "value", None))
+
+        self.expr_signature = hash(
+            (
+                self.op,
+                self.dtype,
+                self.shape,
+                value_part,
+                tuple(child_parts),
+            )
+        )
+        return self.expr_signature
+
+    @classmethod
+    def _value_signature(cls, value: Any) -> Any:
+        if isinstance(value, SymbolicTensorValue):
+            return (
+                "tensor",
+                value.dtype,
+                value.data.shape,
+                value.data.dtype.str,
+                hash(value.data.tobytes()),
+            )
+        if isinstance(value, np.ndarray):
+            return (
+                "ndarray",
+                value.shape,
+                value.dtype.str,
+                hash(value.tobytes()),
+            )
+        if isinstance(value, cls.tuple_types):
+            seq = cast(Sequence[Any], value)
+            return tuple(cls._value_signature(item) for item in seq)
+        if isinstance(
+            value, (int, np.integer, bool, float, np.floating, str, type(None))
+        ):
+            return value
+        return (type(value).__name__, repr(value))
 
     def __add__(self, other: SymbolicExpr) -> SymbolicExpr:
         return SymbolicExpr.create("add", self, other)
@@ -597,9 +658,27 @@ class SymbolicExpr:
     @classmethod
     def from_value(cls, var: Any) -> SymbolicExpr | tuple[SymbolicExpr, ...]:
         """Create a SymbolicExpr from a Python value."""
+        if isinstance(var, cls):  # if already SymbolicExpr
+            return var
+
+        if isinstance(var, (int, np.integer, bool)):
+            return cls.create("const", var, INT32)
+        if isinstance(var, (float, np.floating)):
+            return cls.create("const", var, FLOAT32)
+        if isinstance(var, SymbolicTensorValue):
+            if var.data.size != 1:
+                raise ValueError(
+                    "SymbolicExpr.from_value only supports scalar tensor values!"
+                )
+            return cls.create("const", var.data.item(), var.dtype)
+        if isinstance(var, (SymbolicScalarDType, SymbolicPointerDType)):
+            return cls.create("const", var, var)
+        if isinstance(var, SymbolicTypeSpec):
+            return cls.create("const", var, var)
+
         var = cls._NORMALIZE_VALUE(var)
 
-        if isinstance(var, cls):  # if already SymbolicExpr
+        if isinstance(var, cls):  # if frontend normalization returned SymbolicExpr
             return var
 
         if isinstance(var, SymbolicExpr.tuple_types):  # if a tuple
@@ -1008,7 +1087,7 @@ class UnarySymbolicExpr(SymbolicExpr):
     arg: SymbolicExpr
 
     def __init__(self, op: str, arg: Any):
-        if op not in SymbolicExpr.UNARY_OPS:
+        if op not in SymbolicExpr.UNARY_OP_SET:
             raise NotImplementedError(f"Unsupported unary op: {op}")
         super().__init__(op)
         self.add_child("arg", arg)
@@ -1075,7 +1154,7 @@ class BinarySymbolicExpr(SymbolicExpr):
     rhs: SymbolicExpr
 
     def __init__(self, op: str, lhs: Any, rhs: Any):
-        if op not in SymbolicExpr.BINARY_OPS:
+        if op not in SymbolicExpr.BINARY_OP_SET:
             raise NotImplementedError(f"Unsupported binary op: {op}")
         super().__init__(op)
         self.add_child("lhs", lhs)
@@ -2317,9 +2396,22 @@ class SymbolicClient(Client):
         self.last_grid: tuple[int, int, int] | None = None
         self.addr_ok: BoolRef | None = None
         self.pid_ok: BoolRef | None = None
-        self.solver: Solver | None = None
-        self.addr_sym: ArithRef | None = None
+        self.solver: Solver | None = Solver()
+        self.addr_sym: ArithRef | None = Int("addr")
         self.addr_ok_cache: dict[int, BoolRef] = {}
+        self.pid_ok_cache: dict[tuple[int, int, int], BoolRef] = {}
+        self.loop_iterator_constraint_cache: dict[
+            tuple[int, int, int, int], BoolRef
+        ] = {}
+        self.access_check_cache: set[int] = set()
+        self.op_overrider_map = self._build_op_overrider_map()
+        self.op_callback_cache: dict[type[Op], OpCallbacks] = {}
+        self.for_loop_callbacks = ForLoopCallbacks(
+            range_wrapper_factory=self.lock_fn(self._wrap_range),
+            before_loop_callback=self.lock_fn(self._loop_hook_before),
+            loop_iter_overrider=self.lock_fn(self._loop_hook_iter_overrider),
+            after_loop_callback=self.lock_fn(self._loop_hook_after),
+        )
         SymbolicExpr.set_loop_ctx_provider(
             lambda *_args, **_kwargs: (self.loop_stack[-1] if self.loop_stack else None)
         )
@@ -2579,11 +2671,16 @@ class SymbolicClient(Client):
         }
 
     def register_op_callback(self, op_type: type[Op], *args, **kwargs) -> OpCallbacks:
-        overrider_map = self._build_op_overrider_map()
-        overrider = overrider_map.get(op_type)
+        cached = self.op_callback_cache.get(op_type)
+        if cached is not None:
+            return cached
+        overrider = self.op_overrider_map.get(op_type)
         if overrider is not None:
-            return OpCallbacks(op_overrider=self.lock_fn(overrider))
-        return OpCallbacks()
+            callbacks = OpCallbacks(op_overrider=self.lock_fn(overrider))
+        else:
+            callbacks = OpCallbacks()
+        self.op_callback_cache[op_type] = callbacks
+        return callbacks
 
     # ── For-loop infrastructure ───────────────────────────────────
 
@@ -2711,11 +2808,22 @@ class SymbolicClient(Client):
         idx_z3 = Int(f"loop_i_{lineno}")
         sym = SymbolicExpr.create("const", idx_z3, INT32)
         idx = SymbolicExpr.wrap_loop_index(sym, INT32)
+        constraint_key = (lineno, iterable.start, iterable.stop, iterable.step)
+        iterator_constraint = self.loop_iterator_constraint_cache.get(constraint_key)
+        if iterator_constraint is None:
+            iterator_constraint = _range_to_iterator_constraint(
+                idx_z3,
+                start=iterable.start,
+                stop=iterable.stop,
+                step=iterable.step,
+            )
+            self.loop_iterator_constraint_cache[constraint_key] = iterator_constraint
         ctx = LoopContext(
             lineno,
             iterable.length,
             idx,
             idx_z3,
+            iterator_constraint,
             start=iterable.start,
             stop=iterable.stop,
             step=iterable.step,
@@ -2749,20 +2857,13 @@ class SymbolicClient(Client):
         all_iterator_constraints: list[BoolRef] = []
         if ctx.pending_checks:
             solver.push()
-            iterator_constraint = _range_to_iterator_constraint(
-                ctx.idx_z3, start=ctx.start, stop=ctx.stop, step=ctx.step
-            )
+            iterator_constraint = ctx.iterator_constraint
             solver.add(iterator_constraint)
             all_iterator_constraints.append(iterator_constraint)
 
             # Also add constraints for all outer loops that are still active.
             for outer_ctx in self.loop_stack:
-                outer_constraint = _range_to_iterator_constraint(
-                    outer_ctx.idx_z3,
-                    start=outer_ctx.start,
-                    stop=outer_ctx.stop,
-                    step=outer_ctx.step,
-                )
+                outer_constraint = outer_ctx.iterator_constraint
                 solver.add(outer_constraint)
                 all_iterator_constraints.append(outer_constraint)
 
@@ -2786,12 +2887,7 @@ class SymbolicClient(Client):
             )
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
-        return ForLoopCallbacks(
-            range_wrapper_factory=self.lock_fn(self._wrap_range),
-            before_loop_callback=self.lock_fn(self._loop_hook_before),
-            loop_iter_overrider=self.lock_fn(self._loop_hook_iter_overrider),
-            after_loop_callback=self.lock_fn(self._loop_hook_after),
-        )
+        return self.for_loop_callbacks
 
     # ── Tensor resolution helpers ─────────────────────────────────────
 
@@ -2965,6 +3061,18 @@ class SymbolicClient(Client):
         """
         return addr_ok
 
+    def _build_global_addr_ok_at_grid(self) -> bool:
+        """Return whether ``grid_callback`` should eagerly build global addr_ok."""
+        return True
+
+    def _build_global_addr_ok(self, addr: ArithRef) -> BoolRef:
+        addr_ok_expr = (
+            Or(*[And(addr >= s, addr <= e) for s, e, _ in self.tensor_addrs])
+            if self.tensor_addrs
+            else BoolVal(False)
+        )
+        return cast(BoolRef, addr_ok_expr)
+
     def _cache_non_tensor_arg(self, name: str, arg: Any) -> None:
         """Called from ``arg_callback`` for args without a ``data_ptr``."""
         pass
@@ -3007,6 +3115,7 @@ class SymbolicClient(Client):
         self.tensor_addrs.clear()
         self.tensor_names.clear()
         self.addr_ok_cache.clear()
+        self.access_check_cache.clear()
 
     # ── Client callbacks with shared defaults ─────────────────────────
 
@@ -3035,31 +3144,40 @@ class SymbolicClient(Client):
 
     def grid_callback(self, grid: tuple[int, ...]) -> None:
         grid = tuple(int(g) for g in grid)
+        grid_key = (grid[0], grid[1], grid[2])
         self.last_grid = (grid[0] - 1, grid[1] - 1, grid[2] - 1)
         self.grid = grid
-        addr = Int("addr")
+        addr = self.addr_sym
+        assert addr is not None
 
-        addr_ok_expr = (
-            Or(*[And(addr >= s, addr <= e) for s, e, _ in self.tensor_addrs])
-            if self.tensor_addrs
+        self.addr_ok = (
+            self._build_global_addr_ok(addr)
+            if self._build_global_addr_ok_at_grid()
             else BoolVal(False)
         )
-        self.addr_ok = cast(BoolRef, addr_ok_expr)
 
-        pid_ok_expr = And(
-            SymbolicExpr.PID0 < self.grid[0],
-            SymbolicExpr.PID1 < self.grid[1],
-            SymbolicExpr.PID2 < self.grid[2],
-            SymbolicExpr.PID0 >= 0,
-            SymbolicExpr.PID1 >= 0,
-            SymbolicExpr.PID2 >= 0,
-        )
-        self.pid_ok = cast(BoolRef, pid_ok_expr)
+        pid_ok = self.pid_ok_cache.get(grid_key)
+        if pid_ok is None:
+            pid_ok = cast(
+                BoolRef,
+                And(
+                    SymbolicExpr.PID0 < grid[0],
+                    SymbolicExpr.PID1 < grid[1],
+                    SymbolicExpr.PID2 < grid[2],
+                    SymbolicExpr.PID0 >= 0,
+                    SymbolicExpr.PID1 >= 0,
+                    SymbolicExpr.PID2 >= 0,
+                ),
+            )
+            self.pid_ok_cache[grid_key] = pid_ok
+        self.pid_ok = pid_ok
 
-        self.solver = Solver()
+        if self.solver is None:
+            self.solver = Solver()
+        else:
+            self.solver.reset()
         self.solver.add(self._addr_ok_premise(self.addr_ok))
         self.solver.add(self.pid_ok)
-        self.addr_sym = addr
 
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.need_full_grid is None:

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -118,6 +118,7 @@ class Client(ABC):
 class ClientManager:
     def __init__(self, clients: list[Client] | None = None):
         self.clients: dict[str, Client] = {}
+        self._client_values: tuple[Client, ...] = ()
         if clients:
             self.add_clients(clients)
         self.launch = Launch()
@@ -140,6 +141,7 @@ class ClientManager:
             )
             if not duplicate:
                 self.clients[new_client.NAME] = new_client
+        self._client_values = tuple(self.clients.values())
 
     @contextmanager
     def patch_warmup(self, jit_fn):
@@ -201,13 +203,27 @@ class ClientManager:
                 unpatch_lang(frontend_name)
 
     def pre_run_callback(self, fn: Callable) -> bool:
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                return self._client_values[0].pre_run_callback(fn)
+            rets = [client.pre_run_callback(fn) for client in self._client_values]
+            return all(rets) if rets else True
         with self._lock_context():
-            rets = [client.pre_run_callback(fn) for client in self.clients.values()]
+            if len(self._client_values) == 1:
+                return self._client_values[0].pre_run_callback(fn)
+            rets = [client.pre_run_callback(fn) for client in self._client_values]
             return all(rets) if rets else True
 
     def post_run_callback(self, fn: Callable) -> bool:
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                return self._client_values[0].post_run_callback(fn)
+            rets = [client.post_run_callback(fn) for client in self._client_values]
+            return any(rets)
         with self._lock_context():
-            rets = [client.post_run_callback(fn) for client in self.clients.values()]
+            if len(self._client_values) == 1:
+                return self._client_values[0].post_run_callback(fn)
+            rets = [client.post_run_callback(fn) for client in self._client_values]
             return any(rets)
 
     def finalize(self) -> None:
@@ -222,29 +238,43 @@ class ClientManager:
         with self._lock_context():
             if hasattr(arg, "data_ptr"):
                 self.launch.tensors.add(arg)
-            for client in self.clients.values():
+            for client in self._client_values:
                 client.arg_callback(name, arg, arg_cvt)
 
     def grid_callback(self, grid: tuple[int]):
         with self._lock_context():
             self.launch.grid = grid
-            for client in self.clients.values():
+            for client in self._client_values:
                 client.grid_callback(grid)
 
     def grid_idx_callback(self, grid_idx: tuple[int, ...]):
+        if cfg.num_sms <= 1:
+            if len(self._client_values) == 1:
+                self._client_values[0].grid_idx_callback(grid_idx)
+                return
+            for client in self._client_values:
+                client.grid_idx_callback(grid_idx)
+            return
         with self._lock_context():
-            for client in self.clients.values():
+            if len(self._client_values) == 1:
+                self._client_values[0].grid_idx_callback(grid_idx)
+                return
+            for client in self._client_values:
                 client.grid_idx_callback(grid_idx)
 
     # --- For-loop callback management ---
 
     def _clear_loop_hooks(self) -> None:
         self._range_type_hooks: list[Callable] = []
+        self._range_type_hook: Callable | None = None
         self._before: list[Callable] = []
+        self._before_hook: Callable | None = None
         self._iter_listeners: list[Callable] = []
+        self._iter_listener: Callable | None = None
         self._iter_overrider: Callable | None = None
         self._range_wrapper_factory: Callable | None = None
         self._after: list[Callable] = []
+        self._after_hook: Callable | None = None
 
     def _populate_loop_hooks(self, callbacks_list: list[ForLoopCallbacks]) -> None:
         self._clear_loop_hooks()
@@ -265,12 +295,26 @@ class ClientManager:
                 self._range_wrapper_factory = cb.range_wrapper_factory
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
+        if len(self._range_type_hooks) == 1:
+            self._range_type_hook = self._range_type_hooks[0]
+        if len(self._before) == 1:
+            self._before_hook = self._before[0]
+        if len(self._iter_listeners) == 1:
+            self._iter_listener = self._iter_listeners[0]
+        if len(self._after) == 1:
+            self._after_hook = self._after[0]
 
     def range_type(self, lineno: int, range_type: str) -> None:
+        if self._range_type_hook is not None:
+            self._range_type_hook(lineno, range_type)
+            return
         for hook in self._range_type_hooks:
             hook(lineno, range_type)
 
     def before_loop(self, lineno: int, iterable: Any) -> None:
+        if self._before_hook is not None:
+            self._before_hook(lineno, iterable)
+            return
         for hook in self._before:
             hook(lineno, iterable)
 
@@ -280,12 +324,18 @@ class ClientManager:
             if new_idx is not None:
                 idx = new_idx
 
-        for hook in self._iter_listeners:
-            hook(lineno, idx)
+        if self._iter_listener is not None:
+            self._iter_listener(lineno, idx)
+        else:
+            for hook in self._iter_listeners:
+                hook(lineno, idx)
 
         return idx
 
     def after_loop(self, lineno: int) -> None:
+        if self._after_hook is not None:
+            self._after_hook(lineno)
+            return
         for hook in self._after:
             hook(lineno)
 

--- a/triton_viz/core/frontend/base.py
+++ b/triton_viz/core/frontend/base.py
@@ -123,11 +123,14 @@ class Frontend:
         self,
         op: Callable,
         op_type: type[Op],
-        callbacks: Any,
+        op_overrider: Callable,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
-        return callbacks.op_overrider(*args, **kwargs)
+        return op_overrider(*args, **kwargs)
+
+    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
+        return True
 
     @staticmethod
     def concrete_fn_for_op_type(

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -32,7 +32,6 @@ from triton.runtime.interpreter import (
 )
 from triton.tools.tensor_descriptor import TensorDescriptor
 
-from ..callbacks import OpCallbacks
 from ..config import config as cfg
 from ..data import (
     AddPtr,
@@ -253,6 +252,11 @@ class TritonFrontend(Frontend):
         self._loop_ast_methods: dict[str, Callable | object] = {}
         self._loop_ast_patched = False
         self._patch_calls_scope = 0
+        self._triton_language_targets = tuple(self._triton_language_attr_targets())
+        self._triton_extra_modules = self._triton_extra_builtin_modules()
+        self._triton_builtin_attr_cache: dict[int, tuple[str, ...]] = {}
+        self._math_op_types = frozenset(self.namespaces[tl.math].values())
+        self._tl_op_types = frozenset(self.namespaces[tl].values())
         self._bind_interpreter_builder_thread_state()
 
     def _bind_interpreter_builder_thread_state(self) -> None:
@@ -421,10 +425,18 @@ class TritonFrontend(Frontend):
         # Triton's interpreter patch mutates global tl/tl.core objects. Snapshot
         # both unconditionally so nested or generated JIT functions without a
         # direct `tl` global still restore the language state after tracing.
-        for obj, attrs in self._triton_language_attr_targets():
-            for name, member in inspect.getmembers(obj):
-                if tl.core.is_builtin(member):
-                    scope.set_attr(obj, name, member)
+        for obj, attrs in self._triton_language_targets:
+            obj_id = id(obj)
+            builtin_names = self._triton_builtin_attr_cache.get(obj_id)
+            if builtin_names is None:
+                builtin_names = tuple(
+                    name
+                    for name, member in inspect.getmembers(obj)
+                    if tl.core.is_builtin(member)
+                )
+                self._triton_builtin_attr_cache[obj_id] = builtin_names
+            for name in builtin_names:
+                scope.set_attr(obj, name, getattr(obj, name))
             for attr in attrs:
                 if hasattr(obj, attr):
                     scope.set_attr(obj, attr, getattr(obj, attr))
@@ -727,6 +739,22 @@ class TritonFrontend(Frontend):
         return cls._to_triton_dtype(value)
 
     def normalize_symbolic_value(self, value: Any) -> Any:
+        if isinstance(
+            value,
+            (
+                SymbolicTensorValue,
+                SymbolicScalarDType,
+                SymbolicPointerDType,
+                SymbolicTypeSpec,
+                int,
+                np.integer,
+                bool,
+                float,
+                np.floating,
+                type(None),
+            ),
+        ):
+            return value
         if isinstance(value, tl.core.tensor):
             value = value.handle
         if isinstance(value, TensorHandle):
@@ -809,15 +837,13 @@ class TritonFrontend(Frontend):
         self,
         op: Callable,
         op_type: type[Op],
-        callbacks: OpCallbacks,
+        op_overrider: Callable,
         args: tuple[Any, ...],
         kwargs: dict[str, Any],
     ):
-        op_overrider = callbacks.op_overrider
-        assert op_overrider is not None
-        if op_type in self.namespaces[tl.math].values():
+        if op_type in self._math_op_types:
             raise NotImplementedError("Patching math ops not yet supported")
-        elif op_type in self.namespaces[tl].values():
+        elif op_type in self._tl_op_types:
             # see triton.runtime.interpreter:ReduceOps.sum
             # First, convert input from tl.tensor to TensorHandle. Here, input tensor is args[0]
             # Then, convert return value from TensorHandle to tl.tensor
@@ -825,6 +851,9 @@ class TritonFrontend(Frontend):
             return self._wrap_tl_ret(ret, args[0].dtype)
 
         return op_overrider(*args, **kwargs)
+
+    def can_call_op_overrider_directly(self, op_type: type[Op]) -> bool:
+        return op_type not in self._math_op_types and op_type not in self._tl_op_types
 
     def patch_for_loop(self) -> None:
         if self._loop_ast_patched:
@@ -869,7 +898,7 @@ class TritonFrontend(Frontend):
         # restore metadata for nested/generated kernels.
         scope = self._triton_snapshot_scope(fn)
         triton_patch_lang(fn)
-        for module in self._triton_extra_builtin_modules():
+        for module in self._triton_extra_modules:
             _patch_builtin(module, interpreter_builder, scope)
         self._patch_triton_inline_asm(scope)
         self._patch_triton_semantic_to_tensor(scope)
@@ -1001,8 +1030,19 @@ class TritonFrontend(Frontend):
             if cfg.enable_timing:
                 start_time = time.time()
 
+            disable_sanitize_overflow = (
+                client_manager.get_client("sanitizer") is not None
+            )
             old_num_warps = getattr(self.builder.options, "num_warps", _MISSING)
+            old_sanitize_overflow = getattr(
+                self.builder.options, "sanitize_overflow", _MISSING
+            )
             object.__setattr__(self.builder.options, "num_warps", launch_num_warps)
+            if disable_sanitize_overflow:
+                # Sanitizer validates memory addresses. Triton's interpreter
+                # integer-overflow device_asserts create extra symbolic trees
+                # unrelated to OOB reporting, so keep them off for this launch.
+                object.__setattr__(self.builder.options, "sanitize_overflow", False)
             try:
                 self._run_grid(
                     grid_executor,
@@ -1020,6 +1060,14 @@ class TritonFrontend(Frontend):
                         "num_warps",
                         old_num_warps,
                     )
+                if old_sanitize_overflow is _MISSING:
+                    object.__delattr__(self.builder.options, "sanitize_overflow")
+                else:
+                    object.__setattr__(
+                        self.builder.options,
+                        "sanitize_overflow",
+                        old_sanitize_overflow,
+                    )
 
             if cfg.enable_timing:
                 end_time = time.time()
@@ -1036,6 +1084,12 @@ class TritonFrontend(Frontend):
             self._current_client_manager = previous_client_manager
 
     def _jit_function_call(self, jit_function, *args, **kwargs):
+        if (
+            self._current_client_manager is not None
+            and not self._jit_function_needs_lang_patch(jit_function)
+        ):
+            return jit_function.fn(*args, **kwargs)
+
         scope = self.patch_lang(
             jit_function.fn,
             client_manager=self._current_client_manager,
@@ -1044,6 +1098,15 @@ class TritonFrontend(Frontend):
             return jit_function.fn(*args, **kwargs)
         finally:
             scope.restore()
+
+    @staticmethod
+    def _jit_function_needs_lang_patch(jit_function) -> bool:
+        langs = [
+            value
+            for value in jit_function.fn.__globals__.values()
+            if inspect.ismodule(value) and value in (tl, tl.core)
+        ]
+        return not langs or any(lang is tl.core for lang in langs)
 
     @contextmanager
     def patch_calls(self):

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -5,6 +5,7 @@ from typing import Any
 from .frontend.base import AdapterResult, LANG_PATCH_SCOPES
 from .frontend.base import get_frontend
 from .callbacks import OpCallbacks
+from .config import config as cfg
 from .data import Op
 
 
@@ -30,42 +31,73 @@ class PatchOp:
         callbacks: OpCallbacks,
         adapter: Callable[..., AdapterResult],
         frontend_name: str = "triton",
+        frontend: Any | None = None,
     ):
         self.op = op
         self.op_type = op_type
         self.callbacks = callbacks
+        self.before_callback = callbacks.before_callback
+        self.after_callback = callbacks.after_callback
+        self.op_overrider = callbacks.op_overrider
         self.adapter = adapter
         self.frontend_name = frontend_name
+        self.frontend = frontend if frontend is not None else _frontend(frontend_name)
+        self.maybe_yield_for_multism = (
+            self.frontend.maybe_yield_for_multism if cfg.num_sms > 1 else None
+        )
+        self.run_op_overrider = (
+            None
+            if self.op_overrider
+            and self.frontend.can_call_op_overrider_directly(op_type)
+            else self.frontend.run_op_overrider
+        )
+        self._has_callbacks = bool(
+            self.maybe_yield_for_multism or self.before_callback or self.after_callback
+        )
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self.op, name)
 
     def __call__(self, *args, **kwargs):
-        _frontend(self.frontend_name).maybe_yield_for_multism()
+        if not self._has_callbacks:
+            if self.op_overrider:
+                if self.run_op_overrider is None:
+                    return self.op_overrider(*args, **kwargs)
+                return self.run_op_overrider(
+                    self.op,
+                    self.op_type,
+                    self.op_overrider,
+                    args,
+                    kwargs,
+                )
+            return self.op(*args, **kwargs)
 
-        if self.callbacks.before_callback:
+        if self.maybe_yield_for_multism is not None:
+            self.maybe_yield_for_multism()
+
+        if self.before_callback:
             before_args = self.adapter(*args, **kwargs)
-            self.callbacks.before_callback(*before_args.args, **before_args.kwargs)
+            self.before_callback(*before_args.args, **before_args.kwargs)
 
-        if self.callbacks.op_overrider:
-            ret = self._run_op_overrider(args, kwargs)
+        if self.op_overrider:
+            if self.run_op_overrider is None:
+                ret = self.op_overrider(*args, **kwargs)
+            else:
+                ret = self.run_op_overrider(
+                    self.op,
+                    self.op_type,
+                    self.op_overrider,
+                    args,
+                    kwargs,
+                )
         else:
             ret = self.op(*args, **kwargs)
 
-        if self.callbacks.after_callback:
+        if self.after_callback:
             # Pass ret so that we don't have to derive output shape from args.
             after_args = self.adapter(*args, **kwargs)
-            self.callbacks.after_callback(ret, *after_args.args, **after_args.kwargs)
+            self.after_callback(ret, *after_args.args, **after_args.kwargs)
         return ret
-
-    def _run_op_overrider(self, args: tuple[Any, ...], kwargs: dict[str, Any]):
-        return _frontend(self.frontend_name).run_op_overrider(
-            self.op,
-            self.op_type,
-            self.callbacks,
-            args,
-            kwargs,
-        )
 
 
 def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: str):
@@ -96,6 +128,7 @@ def patch_op(namespace: Any, attr: str, callbacks: OpCallbacks, frontend_name: s
         callbacks,
         adapter,
         frontend_name=frontend_name,
+        frontend=frontend,
     )
     setattr(namespace, attr, patched_op)
 


### PR DESCRIPTION
Draft stacked PR 3/3. Base: `codex/sanitizer-symbolic-fastpaths`.

Summary:
- Add a first loop-structure analysis helper for sanitizer loop acceleration work.
- Summarize Python `range`, `tl.range`, and `tl.static_range` bounds from kernel source.
- Distinguish constant ranges that can be reasoned about from symbolic bounds that must not be condensed yet.

Tests:
- `/mnt/keren/env/bin/python -m pytest tests/unit/test_sanitizer_ir_analysis.py tests/unit/test_sanitizer.py tests/unit/test_symbolic_client.py tests/unit/test_patch_scope.py tests/unit/test_multithreading.py -q`
- `/mnt/keren/env/bin/pre-commit run --all-files` on the full stack