### PR TITLE
[PERF] Cache sanitizer symbolic access checks

### DIFF
--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,8 +1,17 @@
+import numpy as np
 import pytest
 import torch
 from typing import cast
 
 from triton_viz.core.config import config as cfg
+from triton_viz.core.data import Store
+from triton_viz.core.symbolic_metadata import (
+    INT1,
+    INT32,
+    SymbolicTensorValue,
+    pointer_type,
+    type_spec,
+)
 from triton_viz.clients import Sanitizer
 from triton_viz.clients.sanitizer.report import _classify_layout_and_segments
 from triton_viz.clients.sanitizer.sanitizer import (
@@ -10,6 +19,7 @@ from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicSanitizer,
     _fn_symbolic_cache_set,
 )
+from triton_viz.clients.symbolic_engine import SymbolicExpr
 
 
 # ======== Init Tests ===========
@@ -36,8 +46,8 @@ def test_sanitizer_init(_isolate_sanitizer_cfg):
 # These guard the two spots that break most easily when SymbolicClient's
 # launch-lifecycle machinery is reshuffled:
 #   1. the cross-launch fn cache (sanitizer's pre_run_callback short-circuit)
-#   2. the post_run_callback guard that must NOT wipe launch state mid-
-#      full-grid enumeration.
+#   2. launch cleanup happens at finalize, after concurrent block workers are
+#      done with the shared tensor registry.
 
 
 @pytest.fixture
@@ -123,8 +133,8 @@ def test_post_run_callback_preserves_state_mid_full_grid():
     assert sanitizer.cache_grid == (4, 1, 1)
 
 
-def test_post_run_callback_clears_state_on_last_block():
-    """On the final block we DO want launch state cleared."""
+def test_finalize_clears_state_after_last_block():
+    """Launch state is cleared at finalize, not inside a block callback."""
     sanitizer = SymbolicSanitizer(abort_on_error=False)
 
     sentinel_tensor = object()
@@ -138,13 +148,58 @@ def test_post_run_callback_clears_state_on_last_block():
     sanitizer.grid_idx = (3, 0, 0)  # final block
     sanitizer.need_full_grid = True
 
-    sanitizer.post_run_callback(lambda: None)
+    assert sanitizer.post_run_callback(lambda: None) is True
+
+    assert sanitizer.tensors == [sentinel_tensor]
+    assert sanitizer.tensor_addrs == [(0, 0, sentinel_tensor)]
+    assert sanitizer.tensor_names == {id(sentinel_tensor): {"X"}}
+    assert sanitizer.cache_args == [("fake",)]
+    assert sanitizer.cache_grid == (4, 1, 1)
+
+    sanitizer.finalize()
 
     assert sanitizer.tensors == []
     assert sanitizer.tensor_addrs == []
     assert sanitizer.tensor_names == {}
     assert sanitizer.cache_args == []
     assert sanitizer.cache_grid is None
+
+
+def test_concrete_ptr_access_respects_masked_lanes():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+
+    ptr_dtype = pointer_type(INT32)
+    ptr_value = SymbolicTensorValue(
+        np.array([base, end + tensor.element_size()], dtype=np.uint64),
+        ptr_dtype,
+    )
+    ptr_sym = SymbolicExpr.create("const", ptr_value, type_spec(ptr_dtype, (2,)))
+    inactive_oob_mask = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.array([True, False], dtype=bool), INT1),
+        type_spec(INT1, (2,)),
+    )
+    access_expr = SymbolicExpr.create("store", ptr_sym, None, inactive_oob_mask)
+
+    assert sanitizer._check_concrete_ptr_access(ptr_sym, inactive_oob_mask, access_expr)
+    assert sanitizer.records == []
+
+    active_oob_mask = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.array([True, True], dtype=bool), INT1),
+        type_spec(INT1, (2,)),
+    )
+    access_expr = SymbolicExpr.create("store", ptr_sym, None, active_oob_mask)
+
+    assert sanitizer._check_concrete_ptr_access(ptr_sym, active_oob_mask, access_expr)
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Store
+    assert sanitizer.records[0].violation_address == end + tensor.element_size()
 
 
 # ======== Report Layout Classification Tests ===========

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -9,6 +9,7 @@ from typing import (
 )
 import sys
 
+import numpy as np
 from torch import Tensor
 from triton.tools.tensor_descriptor import TensorDescriptor
 from z3 import And, BoolVal, Not, Or, sat
@@ -20,6 +21,7 @@ from ...core.data import (
     Op,
     Load,
     Store,
+    TensorPointerStore,
 )
 from ..symbolic_engine import (
     SymbolicExpr,
@@ -42,6 +44,7 @@ from .report import (
     print_oob_record_pdb_style,
 )
 from ...core.config import config as cfg
+from ...core.symbolic_metadata import SymbolicTensorValue
 
 SanitizerT = TypeVar("SanitizerT", bound="Sanitizer")
 
@@ -159,7 +162,11 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         SymbolicClient.grid_idx_callback(self, grid_idx)
 
     def finalize(self) -> list:
-        return SymbolicClient.finalize(self)
+        try:
+            return SymbolicClient.finalize(self)
+        finally:
+            self._clear_cache()
+            self._clear_symbolic_launch_state()
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
         return SymbolicClient.register_for_loop_callback(self)
@@ -171,7 +178,11 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         return SymbolicClient.register_op_callback(self, op_type)
 
     def post_run_callback(self, fn: Callable) -> bool:
-        return SymbolicClient.post_run_callback(self, fn)
+        if self.need_full_grid is None:
+            self.need_full_grid = False
+        ret = self.need_full_grid
+        self.need_full_grid = None
+        return ret
 
     # ── Sanitizer-specific hook overrides ─────────────────────────
 
@@ -180,6 +191,12 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         # per-access push/pop scope, because it may need tensor-specific
         # ranges instead of the global union of all registered tensors.
         return BoolVal(True)
+
+    def _build_global_addr_ok_at_grid(self) -> bool:
+        # Sanitizer almost always checks tensor-specific ranges via
+        # ``_addr_ok_for_expr``. Defer the more expensive global union until an
+        # unresolved pointer expression actually needs the fallback.
+        return False
 
     def _cache_non_tensor_arg(self, name: str, arg: Any) -> None:
         # TODO: init a reserved_args field per frontend to filter out these args
@@ -211,6 +228,73 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         # the launch.
         self.cache_grid = tuple(int(g) for g in grid)
         SymbolicClient.grid_callback(self, grid)
+
+    def _op_store_overrider(self, ptr, value, mask, *args):
+        del value, args
+        ptr = self._materialize_memory_operand(ptr)
+        mask = self._materialize_memory_operand(mask)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
+        # Store values do not affect address validity. Avoiding the value
+        # subtree keeps sanitizer store checks focused on pointer + mask.
+        ret = SymbolicExpr.create("store", ptr_sym, None, mask_sym)
+
+        if self._check_concrete_ptr_access(ptr_sym, mask_sym, ret):
+            return ret
+
+        self._handle_access_check(ret, Store, "write")
+        return ret
+
+    def _op_tensor_pointer_store_overrider(
+        self, ptr, value, boundary_check, cache_modifier, eviction_policy
+    ):
+        del value, cache_modifier, eviction_policy
+        ptr = self._materialize_memory_operand(ptr)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        ret = SymbolicExpr.create("tensor_pointer_store", ptr_sym, None, boundary_check)
+        self._handle_access_check(ret, TensorPointerStore, "write")
+        return ret
+
+    def _check_concrete_ptr_access(
+        self,
+        ptr_sym: SymbolicExpr,
+        mask_sym: SymbolicExpr | None,
+        access_expr: SymbolicExpr,
+    ) -> bool:
+        concrete_addrs = self._concrete_ptr_addrs(ptr_sym, mask_sym)
+        if concrete_addrs is None:
+            return False
+        self._check_concrete_addr_values(concrete_addrs, access_expr, None)
+        return True
+
+    def _concrete_ptr_addrs(
+        self, ptr_sym: SymbolicExpr, mask_sym: SymbolicExpr | None
+    ) -> list[int] | None:
+        if ptr_sym.op != "const":
+            return None
+        ptr_value = getattr(ptr_sym, "value", None)
+        if not isinstance(ptr_value, SymbolicTensorValue):
+            return None
+
+        addrs = np.asarray(ptr_value.data, dtype=np.uint64).reshape(-1)
+        if mask_sym is None:
+            return [int(addr) for addr in addrs]
+
+        if mask_sym.op != "const":
+            return None
+        mask_value = getattr(mask_sym, "value", None)
+        if isinstance(mask_value, SymbolicTensorValue):
+            mask = np.asarray(mask_value.data, dtype=bool)
+        elif isinstance(mask_value, (bool, int, np.integer)):
+            mask = np.asarray(mask_value, dtype=bool)
+        else:
+            return None
+
+        try:
+            mask = np.broadcast_to(mask, ptr_value.data.shape).reshape(-1)
+        except ValueError:
+            return None
+        return [int(addr) for addr, active in zip(addrs, mask) if active]
 
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.cache_grid:
@@ -261,6 +345,8 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
 
         resolved_tensor = self._resolve_tensor(symbolic_expr)
         if resolved_tensor is None:
+            if self.addr_ok is None or self.addr_ok.eq(BoolVal(False)):
+                self.addr_ok = self._build_global_addr_ok(addr_sym)
             return self.addr_ok
 
         cache_key = id(resolved_tensor)
@@ -286,6 +372,19 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         symbolic_expr: SymbolicExpr,
         source_location: tuple[str, int, str] | None = None,
     ) -> None:
+        if (
+            expr_constraints is None
+            and (
+                isinstance(access_addr, IntNumRef)
+                or (
+                    isinstance(access_addr, list)
+                    and (not access_addr or isinstance(access_addr[0], IntNumRef))
+                )
+            )
+            and self._check_concrete_addr(access_addr, symbolic_expr, source_location)
+        ):
+            return
+
         # Use push/pop on persistent solver
         solver = self.solver
         addr_sym = self.addr_sym
@@ -332,6 +431,92 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         finally:
             solver.pop()
 
+    def _check_concrete_addr(
+        self,
+        access_addr: Z3Expr,
+        symbolic_expr: SymbolicExpr,
+        source_location: tuple[str, int, str] | None,
+    ) -> bool:
+        if isinstance(access_addr, list):
+            concrete_addrs = []
+            for addr in access_addr:
+                if not isinstance(addr, IntNumRef):
+                    return False
+                concrete_addrs.append(addr.as_long())
+        elif isinstance(access_addr, IntNumRef):
+            concrete_addrs = [access_addr.as_long()]
+        else:
+            return False
+        return self._check_concrete_addr_values(
+            concrete_addrs, symbolic_expr, source_location
+        )
+
+    def _check_concrete_addr_values(
+        self,
+        concrete_addrs: list[int],
+        symbolic_expr: SymbolicExpr,
+        source_location: tuple[str, int, str] | None,
+    ) -> bool:
+        if not concrete_addrs:
+            return True
+
+        min_addr = min(concrete_addrs)
+        max_addr = max(concrete_addrs)
+        tensor = self._resolve_tensor(symbolic_expr)
+        if tensor is None:
+            ranges = [(start, end, tensor) for start, end, tensor in self.tensor_addrs]
+        else:
+            ranges = [
+                (start, end, range_tensor)
+                for start, end, range_tensor in self.tensor_addrs
+                if range_tensor is tensor
+            ]
+        if not ranges:
+            return False
+
+        if len(ranges) == 1:
+            start, end, _ = ranges[0]
+            if min_addr >= start and max_addr <= end:
+                return True
+            violation_addr = next(
+                addr for addr in concrete_addrs if addr < start or addr > end
+            )
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, violation_addr)
+            )
+            op_type: type[Load] | type[Store]
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(
+                op_type,
+                report_tensor,
+                violation_addr,
+                symbolic_expr,
+                source_location,
+            )
+            return True
+
+        for addr in concrete_addrs:
+            if any(start <= addr <= end for start, end, _ in ranges):
+                continue
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, addr)
+            )
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(op_type, report_tensor, addr, symbolic_expr, source_location)
+            return True
+
+        return True
+
     def _handle_access_check(
         self,
         expr: SymbolicExpr,
@@ -345,11 +530,21 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         ``_check_range_satisfiable`` for historical compatibility, and it
         doesn't distinguish reads vs writes at the Z3 level.
         """
-        z3_addr, z3_constraints = expr.eval()
         if not self.loop_stack:
+            expr_signature = hash(("expr", expr.signature()))
+            if expr_signature in self.access_check_cache:
+                return
+            z3_addr, z3_constraints = expr.eval()
+            z3_signature = hash(("z3", _make_signature(z3_addr, z3_constraints)))
+            if z3_signature in self.access_check_cache:
+                self.access_check_cache.add(expr_signature)
+                return
+            self.access_check_cache.add(expr_signature)
+            self.access_check_cache.add(z3_signature)
             self._check_range_satisfiable(z3_addr, z3_constraints, expr)
             return
 
+        z3_addr, z3_constraints = expr.eval()
         ctx = self.loop_stack[-1]
         signature = _make_signature(z3_addr, z3_constraints)
         pending_idx = ctx.signature_cache.get(signature)

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -203,6 +203,7 @@ class LoopContext:
     length: int
     idx: Any
     idx_z3: ArithRef
+    iterator_constraint: BoolRef
     start: int = 0
     stop: int = 0
     step: int = 1
@@ -325,6 +326,7 @@ class SymbolicExpr:
         "rsqrt",
         "negative",
     )
+    UNARY_OP_SET: ClassVar[frozenset[str]] = frozenset(UNARY_OPS)
     BINARY_OP_SYMBOL_TABLE: ClassVar[dict[str, str]] = {
         "add": "+",
         "sub": "-",
@@ -349,6 +351,7 @@ class SymbolicExpr:
         "umulhi": "umulhi",
     }
     BINARY_OPS: ClassVar[tuple[str, ...]] = tuple(BINARY_OP_SYMBOL_TABLE.keys())
+    BINARY_OP_SET: ClassVar[frozenset[str]] = frozenset(BINARY_OPS)
     TERNARY_OPS: ClassVar[tuple[str, ...]] = ("where", "fma")
     REDUCE_OPS: ClassVar[tuple[str, ...]] = (
         "sum",
@@ -389,6 +392,7 @@ class SymbolicExpr:
         + SORT_OPS
         + ATOMIC_OPS
     )
+    SUPPORTED_OP_SET: ClassVar[frozenset[str]] = frozenset(SUPPORTED_OPS)
 
     PID0: ClassVar[ArithRef] = Int("pid_0")
     PID1: ClassVar[ArithRef] = Int("pid_1")
@@ -422,7 +426,7 @@ class SymbolicExpr:
         """
         :param op: Operation type, e.g. "const", "add", "sub", "mul", "div", "pid", "arange"
         """
-        assert op in self.SUPPORTED_OPS, f"Unsupported op: {op}"
+        assert op in self.SUPPORTED_OP_SET, f"Unsupported op: {op}"
         self.op = op
         # Tensor-like attributes used by frontend runtimes.
         self.attr: dict[str, Any] = {}
@@ -445,6 +449,7 @@ class SymbolicExpr:
         self._simplified_z3: Z3Expr | None = None
         self._simplified_constraints: ConstraintConjunction | None = None
         self._has_op_cache: dict[str, bool] = {}
+        self.expr_signature: int | None = None
         self._data_wrapper: SymbolicExprDataWrapper | None = None
 
     @staticmethod
@@ -459,10 +464,66 @@ class SymbolicExpr:
         self.children[name] = child
         setattr(self, name, child)
         self._has_op_cache.clear()
+        self.expr_signature = None
         self._simplified_z3 = None
         self._simplified_constraints = None
         if self._data_wrapper is not None:
             self._data_wrapper.invalidate()
+
+    def signature(self) -> int:
+        """Return a structural hash for deduplicating equivalent expr trees."""
+        if self.expr_signature is not None:
+            return self.expr_signature
+
+        child_parts: list[tuple[str, Any]] = []
+        for name, child in self.children.items():
+            if child is None:
+                child_parts.append((name, None))
+            elif isinstance(child, tuple):
+                child_parts.append((name, tuple(item.signature() for item in child)))
+            else:
+                child_parts.append((name, child.signature()))
+
+        value_part: Any = None
+        if self.op == "const":
+            value_part = self._value_signature(getattr(self, "value", None))
+
+        self.expr_signature = hash(
+            (
+                self.op,
+                self.dtype,
+                self.shape,
+                value_part,
+                tuple(child_parts),
+            )
+        )
+        return self.expr_signature
+
+    @classmethod
+    def _value_signature(cls, value: Any) -> Any:
+        if isinstance(value, SymbolicTensorValue):
+            return (
+                "tensor",
+                value.dtype,
+                value.data.shape,
+                value.data.dtype.str,
+                hash(value.data.tobytes()),
+            )
+        if isinstance(value, np.ndarray):
+            return (
+                "ndarray",
+                value.shape,
+                value.dtype.str,
+                hash(value.tobytes()),
+            )
+        if isinstance(value, cls.tuple_types):
+            seq = cast(Sequence[Any], value)
+            return tuple(cls._value_signature(item) for item in seq)
+        if isinstance(
+            value, (int, np.integer, bool, float, np.floating, str, type(None))
+        ):
+            return value
+        return (type(value).__name__, repr(value))
 
     def __add__(self, other: SymbolicExpr) -> SymbolicExpr:
         return SymbolicExpr.create("add", self, other)
@@ -597,9 +658,27 @@ class SymbolicExpr:
     @classmethod
     def from_value(cls, var: Any) -> SymbolicExpr | tuple[SymbolicExpr, ...]:
         """Create a SymbolicExpr from a Python value."""
+        if isinstance(var, cls):  # if already SymbolicExpr
+            return var
+
+        if isinstance(var, (int, np.integer, bool)):
+            return cls.create("const", var, INT32)
+        if isinstance(var, (float, np.floating)):
+            return cls.create("const", var, FLOAT32)
+        if isinstance(var, SymbolicTensorValue):
+            if var.data.size != 1:
+                raise ValueError(
+                    "SymbolicExpr.from_value only supports scalar tensor values!"
+                )
+            return cls.create("const", var.data.item(), var.dtype)
+        if isinstance(var, (SymbolicScalarDType, SymbolicPointerDType)):
+            return cls.create("const", var, var)
+        if isinstance(var, SymbolicTypeSpec):
+            return cls.create("const", var, var)
+
         var = cls._NORMALIZE_VALUE(var)
 
-        if isinstance(var, cls):  # if already SymbolicExpr
+        if isinstance(var, cls):  # if frontend normalization returned SymbolicExpr
             return var
 
         if isinstance(var, SymbolicExpr.tuple_types):  # if a tuple
@@ -1008,7 +1087,7 @@ class UnarySymbolicExpr(SymbolicExpr):
     arg: SymbolicExpr
 
     def __init__(self, op: str, arg: Any):
-        if op not in SymbolicExpr.UNARY_OPS:
+        if op not in SymbolicExpr.UNARY_OP_SET:
             raise NotImplementedError(f"Unsupported unary op: {op}")
         super().__init__(op)
         self.add_child("arg", arg)
@@ -1075,7 +1154,7 @@ class BinarySymbolicExpr(SymbolicExpr):
     rhs: SymbolicExpr
 
     def __init__(self, op: str, lhs: Any, rhs: Any):
-        if op not in SymbolicExpr.BINARY_OPS:
+        if op not in SymbolicExpr.BINARY_OP_SET:
             raise NotImplementedError(f"Unsupported binary op: {op}")
         super().__init__(op)
         self.add_child("lhs", lhs)
@@ -2317,9 +2396,22 @@ class SymbolicClient(Client):
         self.last_grid: tuple[int, int, int] | None = None
         self.addr_ok: BoolRef | None = None
         self.pid_ok: BoolRef | None = None
-        self.solver: Solver | None = None
-        self.addr_sym: ArithRef | None = None
+        self.solver: Solver | None = Solver()
+        self.addr_sym: ArithRef | None = Int("addr")
         self.addr_ok_cache: dict[int, BoolRef] = {}
+        self.pid_ok_cache: dict[tuple[int, int, int], BoolRef] = {}
+        self.loop_iterator_constraint_cache: dict[
+            tuple[int, int, int, int], BoolRef
+        ] = {}
+        self.access_check_cache: set[int] = set()
+        self.op_overrider_map = self._build_op_overrider_map()
+        self.op_callback_cache: dict[type[Op], OpCallbacks] = {}
+        self.for_loop_callbacks = ForLoopCallbacks(
+            range_wrapper_factory=self.lock_fn(self._wrap_range),
+            before_loop_callback=self.lock_fn(self._loop_hook_before),
+            loop_iter_overrider=self.lock_fn(self._loop_hook_iter_overrider),
+            after_loop_callback=self.lock_fn(self._loop_hook_after),
+        )
         SymbolicExpr.set_loop_ctx_provider(
             lambda *_args, **_kwargs: (self.loop_stack[-1] if self.loop_stack else None)
         )
@@ -2579,11 +2671,16 @@ class SymbolicClient(Client):
         }
 
     def register_op_callback(self, op_type: type[Op], *args, **kwargs) -> OpCallbacks:
-        overrider_map = self._build_op_overrider_map()
-        overrider = overrider_map.get(op_type)
+        cached = self.op_callback_cache.get(op_type)
+        if cached is not None:
+            return cached
+        overrider = self.op_overrider_map.get(op_type)
         if overrider is not None:
-            return OpCallbacks(op_overrider=self.lock_fn(overrider))
-        return OpCallbacks()
+            callbacks = OpCallbacks(op_overrider=self.lock_fn(overrider))
+        else:
+            callbacks = OpCallbacks()
+        self.op_callback_cache[op_type] = callbacks
+        return callbacks
 
     # ── For-loop infrastructure ───────────────────────────────────
 
@@ -2711,11 +2808,22 @@ class SymbolicClient(Client):
         idx_z3 = Int(f"loop_i_{lineno}")
         sym = SymbolicExpr.create("const", idx_z3, INT32)
         idx = SymbolicExpr.wrap_loop_index(sym, INT32)
+        constraint_key = (lineno, iterable.start, iterable.stop, iterable.step)
+        iterator_constraint = self.loop_iterator_constraint_cache.get(constraint_key)
+        if iterator_constraint is None:
+            iterator_constraint = _range_to_iterator_constraint(
+                idx_z3,
+                start=iterable.start,
+                stop=iterable.stop,
+                step=iterable.step,
+            )
+            self.loop_iterator_constraint_cache[constraint_key] = iterator_constraint
         ctx = LoopContext(
             lineno,
             iterable.length,
             idx,
             idx_z3,
+            iterator_constraint,
             start=iterable.start,
             stop=iterable.stop,
             step=iterable.step,
@@ -2749,20 +2857,13 @@ class SymbolicClient(Client):
         all_iterator_constraints: list[BoolRef] = []
         if ctx.pending_checks:
             solver.push()
-            iterator_constraint = _range_to_iterator_constraint(
-                ctx.idx_z3, start=ctx.start, stop=ctx.stop, step=ctx.step
-            )
+            iterator_constraint = ctx.iterator_constraint
             solver.add(iterator_constraint)
             all_iterator_constraints.append(iterator_constraint)
 
             # Also add constraints for all outer loops that are still active.
             for outer_ctx in self.loop_stack:
-                outer_constraint = _range_to_iterator_constraint(
-                    outer_ctx.idx_z3,
-                    start=outer_ctx.start,
-                    stop=outer_ctx.stop,
-                    step=outer_ctx.step,
-                )
+                outer_constraint = outer_ctx.iterator_constraint
                 solver.add(outer_constraint)
                 all_iterator_constraints.append(outer_constraint)
 
@@ -2786,12 +2887,7 @@ class SymbolicClient(Client):
             )
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
-        return ForLoopCallbacks(
-            range_wrapper_factory=self.lock_fn(self._wrap_range),
-            before_loop_callback=self.lock_fn(self._loop_hook_before),
-            loop_iter_overrider=self.lock_fn(self._loop_hook_iter_overrider),
-            after_loop_callback=self.lock_fn(self._loop_hook_after),
-        )
+        return self.for_loop_callbacks
 
     # ── Tensor resolution helpers ─────────────────────────────────────
 
@@ -2965,6 +3061,18 @@ class SymbolicClient(Client):
         """
         return addr_ok
 
+    def _build_global_addr_ok_at_grid(self) -> bool:
+        """Return whether ``grid_callback`` should eagerly build global addr_ok."""
+        return True
+
+    def _build_global_addr_ok(self, addr: ArithRef) -> BoolRef:
+        addr_ok_expr = (
+            Or(*[And(addr >= s, addr <= e) for s, e, _ in self.tensor_addrs])
+            if self.tensor_addrs
+            else BoolVal(False)
+        )
+        return cast(BoolRef, addr_ok_expr)
+
     def _cache_non_tensor_arg(self, name: str, arg: Any) -> None:
         """Called from ``arg_callback`` for args without a ``data_ptr``."""
         pass
@@ -3007,6 +3115,7 @@ class SymbolicClient(Client):
         self.tensor_addrs.clear()
         self.tensor_names.clear()
         self.addr_ok_cache.clear()
+        self.access_check_cache.clear()
 
     # ── Client callbacks with shared defaults ─────────────────────────
 
@@ -3035,31 +3144,40 @@ class SymbolicClient(Client):
 
     def grid_callback(self, grid: tuple[int, ...]) -> None:
         grid = tuple(int(g) for g in grid)
+        grid_key = (grid[0], grid[1], grid[2])
         self.last_grid = (grid[0] - 1, grid[1] - 1, grid[2] - 1)
         self.grid = grid
-        addr = Int("addr")
+        addr = self.addr_sym
+        assert addr is not None
 
-        addr_ok_expr = (
-            Or(*[And(addr >= s, addr <= e) for s, e, _ in self.tensor_addrs])
-            if self.tensor_addrs
+        self.addr_ok = (
+            self._build_global_addr_ok(addr)
+            if self._build_global_addr_ok_at_grid()
             else BoolVal(False)
         )
-        self.addr_ok = cast(BoolRef, addr_ok_expr)
 
-        pid_ok_expr = And(
-            SymbolicExpr.PID0 < self.grid[0],
-            SymbolicExpr.PID1 < self.grid[1],
-            SymbolicExpr.PID2 < self.grid[2],
-            SymbolicExpr.PID0 >= 0,
-            SymbolicExpr.PID1 >= 0,
-            SymbolicExpr.PID2 >= 0,
-        )
-        self.pid_ok = cast(BoolRef, pid_ok_expr)
+        pid_ok = self.pid_ok_cache.get(grid_key)
+        if pid_ok is None:
+            pid_ok = cast(
+                BoolRef,
+                And(
+                    SymbolicExpr.PID0 < grid[0],
+                    SymbolicExpr.PID1 < grid[1],
+                    SymbolicExpr.PID2 < grid[2],
+                    SymbolicExpr.PID0 >= 0,
+                    SymbolicExpr.PID1 >= 0,
+                    SymbolicExpr.PID2 >= 0,
+                ),
+            )
+            self.pid_ok_cache[grid_key] = pid_ok
+        self.pid_ok = pid_ok
 
-        self.solver = Solver()
+        if self.solver is None:
+            self.solver = Solver()
+        else:
+            self.solver.reset()
         self.solver.add(self._addr_ok_premise(self.addr_ok))
         self.solver.add(self.pid_ok)
-        self.addr_sym = addr
 
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.need_full_grid is None:


### PR DESCRIPTION
## Summary

Adds caching for sanitizer symbolic access checks so repeated equivalent address expressions and constraints do not redo solver work unnecessarily.

## Validation

- `python -m pytest tests/unit/test_sanitizer.py` (12 passed)
- `uv run pytest tests/unit/test_sanitizer.py` was not run because `uv` is not installed in this environment.