### PR TITLE
[FIX] Detect nested JIT tl.core access

### DIFF
--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -26,11 +26,16 @@ def _uses_tl_core_alias():
     return _TL_CORE_ALIAS.full([1], 0, tl.float32)
 
 
+def _uses_tl_dot_core():
+    return tl.core.full([1], 0, tl.float32)
+
+
 def test_jit_function_core_module_check_is_function_specific():
     uses_core = triton_frontend.frontend._jit_function_uses_core_module
 
     assert not uses_core(SimpleNamespace(fn=_uses_tl_language_module))
     assert uses_core(SimpleNamespace(fn=_uses_tl_core_alias))
+    assert uses_core(SimpleNamespace(fn=_uses_tl_dot_core))
     assert uses_core(tl.zeros)
     assert not uses_core(tl.cdiv)
 

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -2,6 +2,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass
+import dis
 from functools import partial
 import ast
 import inspect
@@ -1102,7 +1103,23 @@ class TritonFrontend(Frontend):
         # JIT helpers that call tl.core directly need a fresh language patch for
         # semantic injection. Plain user/device JIT helpers can reuse the active
         # top-level launch patch and skip another scope.
-        return any(fn.__globals__.get(name) is tl.core for name in fn.__code__.co_names)
+        if any(fn.__globals__.get(name) is tl.core for name in fn.__code__.co_names):
+            return True
+
+        loaded_tl_global = False
+        for instruction in dis.get_instructions(fn):
+            if instruction.opname == "LOAD_GLOBAL":
+                loaded_tl_global = fn.__globals__.get(instruction.argval) is tl
+            elif (
+                loaded_tl_global
+                and instruction.opname == "LOAD_ATTR"
+                and instruction.argval == "core"
+            ):
+                return True
+            else:
+                loaded_tl_global = False
+
+        return False
 
     @contextmanager
     def patch_calls(self):


### PR DESCRIPTION
## Summary

Extends frontend patch-scope detection so nested Triton JIT helpers that access `tl.core` are detected and patched correctly.

## Validation

- `python -m pytest tests/unit/test_patch_scope.py` (7 passed)
- `uv run pytest tests/unit/test_patch_scope.py` was not run because `uv` is not installed in this environment.