### PR TITLE
[PERF] Add sanitizer concrete access fast path

### DIFF
--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -1,8 +1,17 @@
+import numpy as np
 import pytest
 import torch
 from typing import cast
 
 from triton_viz.core.config import config as cfg
+from triton_viz.core.data import Load, Store
+from triton_viz.core.symbolic_metadata import (
+    INT1,
+    INT32,
+    SymbolicTensorValue,
+    pointer_type,
+    type_spec,
+)
 from triton_viz.clients import Sanitizer
 from triton_viz.clients.sanitizer.report import _classify_layout_and_segments
 from triton_viz.clients.sanitizer.sanitizer import (
@@ -10,6 +19,7 @@ from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicSanitizer,
     _fn_symbolic_cache_set,
 )
+from triton_viz.clients.symbolic_engine import SymbolicExpr
 
 
 # ======== Init Tests ===========
@@ -145,6 +155,112 @@ def test_post_run_callback_clears_state_on_last_block():
     assert sanitizer.tensor_names == {}
     assert sanitizer.cache_args == []
     assert sanitizer.cache_grid is None
+
+
+def _make_concrete_ptr_and_mask(
+    addrs: list[int],
+    mask_values: list[bool],
+) -> tuple[SymbolicExpr, SymbolicExpr]:
+    ptr_dtype = pointer_type(INT32)
+    ptr_sym = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.asarray(addrs, dtype=np.uint64), ptr_dtype),
+        type_spec(ptr_dtype, (len(addrs),)),
+    )
+    mask_sym = SymbolicExpr.create(
+        "const",
+        SymbolicTensorValue(np.asarray(mask_values, dtype=bool), INT1),
+        type_spec(INT1, (len(mask_values),)),
+    )
+    return ptr_sym, mask_sym
+
+
+def test_concrete_ptr_access_respects_masked_lanes_for_load_and_store():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+
+    ptr_sym, inactive_oob_mask = _make_concrete_ptr_and_mask(
+        [base, end + tensor.element_size()],
+        [True, False],
+    )
+
+    def fail_symbolic_path(*_args, **_kwargs):
+        raise AssertionError("concrete pointer access should not hit symbolic path")
+
+    sanitizer._handle_access_check = fail_symbolic_path  # type: ignore[method-assign]
+
+    sanitizer._op_store_overrider(ptr_sym, 0, inactive_oob_mask)
+    sanitizer._op_load_overrider(ptr_sym, inactive_oob_mask, None)
+    assert sanitizer.records == []
+
+    _ptr_sym, active_oob_mask = _make_concrete_ptr_and_mask(
+        [base, end + tensor.element_size()],
+        [True, True],
+    )
+
+    sanitizer._op_store_overrider(ptr_sym, 0, active_oob_mask)
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Store
+    assert sanitizer.records[0].violation_address == end + tensor.element_size()
+
+    sanitizer.records.clear()
+    sanitizer._op_load_overrider(ptr_sym, active_oob_mask, None)
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].violation_address == end + tensor.element_size()
+
+
+def test_concrete_ptr_router_uses_symbolic_path_inside_loops():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    ptr_sym, mask_sym = _make_concrete_ptr_and_mask([base], [True])
+
+    calls = []
+
+    def record_symbolic_path(expr, op_type, access_mode):
+        calls.append((expr.op, op_type, access_mode))
+
+    sanitizer._handle_access_check = record_symbolic_path  # type: ignore[method-assign]
+    sanitizer.loop_stack.append(object())  # type: ignore[arg-type]
+
+    sanitizer._op_load_overrider(ptr_sym, mask_sym, None)
+
+    assert calls == [("load", Load, "read")]
+    assert sanitizer.records == []
+
+
+def test_concrete_ptr_router_uses_concrete_path_for_large_multi_range_access():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(128, dtype=torch.int32)
+    base = tensor.data_ptr()
+    stride_bytes = tensor.element_size() * 2
+    ranges = [
+        (base + i * stride_bytes, base + i * stride_bytes + tensor.element_size() - 1)
+        for i in range(64)
+    ]
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.extend((start, end, tensor) for start, end in ranges)
+    ptr_sym, mask_sym = _make_concrete_ptr_and_mask(
+        [start for start, _end in ranges],
+        [True] * len(ranges),
+    )
+
+    def fail_symbolic_path(*_args, **_kwargs):
+        raise AssertionError("large concrete access should not hit symbolic path")
+
+    sanitizer._handle_access_check = fail_symbolic_path  # type: ignore[method-assign]
+
+    sanitizer._op_store_overrider(ptr_sym, 0, mask_sym)
+
+    assert sanitizer.records == []
 
 
 # ======== Report Layout Classification Tests ===========

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -9,6 +9,7 @@ from typing import (
 )
 import sys
 
+import numpy as np
 from torch import Tensor
 from triton.tools.tensor_descriptor import TensorDescriptor
 from z3 import And, BoolVal, Not, Or, sat
@@ -42,6 +43,11 @@ from .report import (
     print_oob_record_pdb_style,
 )
 from ...core.config import config as cfg
+from ...core.symbolic_metadata import (
+    ConcreteAccessRoute,
+    ConcreteRangeInfo,
+    SymbolicTensorValue,
+)
 
 SanitizerT = TypeVar("SanitizerT", bound="Sanitizer")
 
@@ -212,6 +218,114 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         self.cache_grid = tuple(int(g) for g in grid)
         SymbolicClient.grid_callback(self, grid)
 
+    def _op_load_overrider(self, ptr, mask, other, *args):
+        del args
+        ptr = self._materialize_memory_operand(ptr)
+        mask = self._materialize_memory_operand(mask)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
+        other_sym = SymbolicExpr.from_value(other) if other is not None else None
+        ret = SymbolicExpr.create("load", ptr_sym, mask_sym, other_sym)
+
+        self._route_pointer_access(ret, ptr_sym, mask_sym, Load, "read")
+        return ret
+
+    def _op_store_overrider(self, ptr, value, mask, *args):
+        del value, args
+        ptr = self._materialize_memory_operand(ptr)
+        mask = self._materialize_memory_operand(mask)
+        ptr_sym = SymbolicExpr.from_value(ptr)
+        mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
+        # Store values do not affect address validity. Avoiding the value
+        # subtree keeps sanitizer store checks focused on pointer + mask.
+        ret = SymbolicExpr.create("store", ptr_sym, None, mask_sym)
+
+        self._route_pointer_access(ret, ptr_sym, mask_sym, Store, "write")
+        return ret
+
+    def _route_pointer_access(
+        self,
+        access_expr: SymbolicExpr,
+        ptr_sym: SymbolicExpr,
+        mask_sym: SymbolicExpr | None,
+        op_type: type[Op],
+        access_mode: AccessMode,
+    ) -> None:
+        concrete_route = self._concrete_ptr_access_route(access_expr, ptr_sym, mask_sym)
+        if concrete_route is not None:
+            self._check_concrete_addr_values(
+                concrete_route.addrs,
+                access_expr,
+                None,
+                concrete_route.range_info,
+            )
+            return
+
+        self._handle_access_check(access_expr, op_type, access_mode)
+
+    def _concrete_ptr_access_route(
+        self,
+        access_expr: SymbolicExpr,
+        ptr_sym: SymbolicExpr,
+        mask_sym: SymbolicExpr | None,
+    ) -> ConcreteAccessRoute | None:
+        if self.loop_stack:
+            return None
+
+        concrete_addrs = self._concrete_ptr_addrs(ptr_sym, mask_sym)
+        if concrete_addrs is None:
+            return None
+
+        range_info = self._concrete_addr_range_info(access_expr)
+        if range_info is None:
+            return None
+        return ConcreteAccessRoute(concrete_addrs, range_info)
+
+    def _concrete_ptr_addrs(
+        self, ptr_sym: SymbolicExpr, mask_sym: SymbolicExpr | None
+    ) -> list[int] | None:
+        if ptr_sym.op != "const":
+            return None
+        ptr_value = getattr(ptr_sym, "value", None)
+        if not isinstance(ptr_value, SymbolicTensorValue):
+            return None
+
+        addrs = np.asarray(ptr_value.data, dtype=np.uint64).reshape(-1)
+        if mask_sym is None:
+            return [int(addr) for addr in addrs]
+
+        if mask_sym.op != "const":
+            return None
+        mask_value = getattr(mask_sym, "value", None)
+        if isinstance(mask_value, SymbolicTensorValue):
+            mask = np.asarray(mask_value.data, dtype=bool)
+        elif isinstance(mask_value, (bool, int, np.integer)):
+            mask = np.asarray(mask_value, dtype=bool)
+        else:
+            return None
+
+        try:
+            mask = np.broadcast_to(mask, ptr_value.data.shape).reshape(-1)
+        except ValueError:
+            return None
+        return [int(addr) for addr, active in zip(addrs, mask) if active]
+
+    def _concrete_addr_range_info(
+        self, symbolic_expr: SymbolicExpr
+    ) -> ConcreteRangeInfo | None:
+        tensor = self._resolve_tensor(symbolic_expr)
+        if tensor is None:
+            ranges = [(start, end, tensor) for start, end, tensor in self.tensor_addrs]
+        else:
+            ranges = [
+                (start, end, range_tensor)
+                for start, end, range_tensor in self.tensor_addrs
+                if range_tensor is tensor
+            ]
+        if not ranges:
+            return None
+        return ConcreteRangeInfo(tensor, ranges)
+
     def pre_run_callback(self, fn: Callable) -> bool:
         if self.cache_grid:
             fn_cache = _FnSymbolicCache(fn, self.cache_grid, tuple(self.cache_args))
@@ -331,6 +445,64 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
             _report_if_sat()
         finally:
             solver.pop()
+
+    def _check_concrete_addr_values(
+        self,
+        concrete_addrs: list[int],
+        symbolic_expr: SymbolicExpr,
+        source_location: tuple[str, int, str] | None,
+        range_info: ConcreteRangeInfo,
+    ) -> bool:
+        if not concrete_addrs:
+            return True
+
+        min_addr = min(concrete_addrs)
+        max_addr = max(concrete_addrs)
+        tensor = range_info.tensor
+        ranges = range_info.ranges
+
+        if len(ranges) == 1:
+            start, end, _ = ranges[0]
+            if min_addr >= start and max_addr <= end:
+                return True
+            violation_addr = next(
+                addr for addr in concrete_addrs if addr < start or addr > end
+            )
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, violation_addr)
+            )
+            op_type: type[Load] | type[Store]
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(
+                op_type,
+                report_tensor,
+                violation_addr,
+                symbolic_expr,
+                source_location,
+            )
+            return True
+
+        for addr in concrete_addrs:
+            if any(start <= addr <= end for start, end, _ in ranges):
+                continue
+            report_tensor = (
+                tensor
+                if tensor is not None
+                else self._find_tensor_for_expr(symbolic_expr, addr)
+            )
+            if symbolic_expr.op in ("store", "tensor_pointer_store"):
+                op_type = Store
+            else:
+                op_type = Load
+            self._report(op_type, report_tensor, addr, symbolic_expr, source_location)
+            return True
+
+        return True
 
     def _handle_access_check(
         self,

--- a/triton_viz/core/symbolic_metadata.py
+++ b/triton_viz/core/symbolic_metadata.py
@@ -2,11 +2,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 from dataclasses import dataclass, field
-from typing import Any, TypeAlias, cast
+from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 import numpy as np
 
 from triton_viz.utils.dtypes import STORAGE_DTYPES
+
+if TYPE_CHECKING:
+    from torch import Tensor
 
 
 @dataclass(frozen=True)
@@ -58,6 +61,18 @@ class SymbolicTensorValue:
     @property
     def shape(self) -> tuple[int, ...]:
         return tuple(int(dim) for dim in self.data.shape)
+
+
+@dataclass(frozen=True)
+class ConcreteRangeInfo:
+    tensor: Tensor | None
+    ranges: list[tuple[int, int, Tensor]]
+
+
+@dataclass(frozen=True)
+class ConcreteAccessRoute:
+    addrs: list[int]
+    range_info: ConcreteRangeInfo
 
 
 INT1 = SymbolicScalarDType("int1", 1, np.dtype(bool))


### PR DESCRIPTION
## Summary

Adds a routed concrete-address fast path for sanitizer memory checks. Masked constant pointer loads and stores can be validated directly against registered tensor address ranges before building or querying a Z3 range check.

The router stays conservative where the old path is known to help:

- use the symbolic/Z3 path inside loops so loop access deduplication still wins for cases like ragged metadata memset
- otherwise, use concrete checking whenever pointer/mask addresses are already concrete
- resolve concrete addresses and address ranges once in the router and pass them into the concrete checker

This also keeps sanitizer store checks focused on pointer and mask operands, since store values do not affect address validity.

## Validation

- `python -m pytest tests/unit/test_sanitizer.py` (14 passed)
- `python -m pytest tests/unit/test_symbolic_client.py` (67 passed)
- `PYTHONPATH=/mnt/keren/triton/python:$PYTHONPATH python -m pytest tests/end_to_end/test_triton_kernels.py::test_triton_viz_sanitizer_make_ragged_tensor_metadata -q --tb=short -rx` (5 xfailed, expected by existing test markers)
- `pre-commit run --all-files` (passed)
- `uv run pytest ...` was not run because `uv` is not installed in this environment.