### PR TITLE
[PERF] Add sanitizer loop range summaries

### DIFF
--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -2,6 +2,7 @@ import numpy as np
 import pytest
 import torch
 from typing import cast
+from z3 import Int
 
 from triton_viz.core.config import config as cfg
 from triton_viz.core.data import Load, Store
@@ -19,7 +20,8 @@ from triton_viz.clients.sanitizer.sanitizer import (
     SymbolicSanitizer,
     _fn_symbolic_cache_set,
 )
-from triton_viz.clients.symbolic_engine import SymbolicExpr
+from triton_viz.clients.sanitizer.range_summary import IntRange, access_interval_summary
+from triton_viz.clients.symbolic_engine import LoopContext, PendingCheck, SymbolicExpr
 
 
 # ======== Init Tests ===========
@@ -261,6 +263,310 @@ def test_concrete_ptr_router_uses_concrete_path_for_large_multi_range_access():
     sanitizer._op_store_overrider(ptr_sym, 0, mask_sym)
 
     assert sanitizer.records == []
+
+
+def _make_loop_affine_access(
+    base: int,
+    element_size: int,
+    start: int,
+    stop: int,
+    step: int,
+) -> tuple[LoopContext, SymbolicExpr]:
+    idx_z3 = Int("loop_i_123")
+    idx_sym = SymbolicExpr.create("const", 0, INT32)
+    ctx = LoopContext(
+        lineno=123,
+        length=len(range(start, stop, step)),
+        idx=idx_sym,
+        idx_z3=idx_z3,
+        start=start,
+        stop=stop,
+        step=step,
+    )
+    idx_sym.loop_ctx = ctx
+
+    base_sym = SymbolicExpr.create("const", base, pointer_type(INT32))
+    scale_sym = SymbolicExpr.create("const", element_size, INT32)
+    offset_sym = SymbolicExpr.create("mul", idx_sym, scale_sym)
+    ptr_sym = SymbolicExpr.create("add", base_sym, offset_sym)
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    return ctx, access_expr
+
+
+def test_loop_range_summary_skips_z3_for_proven_safe_access():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    pending = PendingCheck(access_expr, Int("addr"), None)
+
+    def fail_z3_path(*_args, **_kwargs):
+        raise AssertionError("range summary should skip the Z3 check")
+
+    sanitizer._check_range_satisfiable = fail_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+
+def test_loop_range_summary_skips_z3_for_addptr_access():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, _access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    ptr_sym = SymbolicExpr.create(
+        "addptr",
+        SymbolicExpr.create("const", base, pointer_type(INT32)),
+        ctx.idx,
+    )
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+
+    def fail_z3_path(*_args, **_kwargs):
+        raise AssertionError("range summary should skip the Z3 check")
+
+    sanitizer._check_range_satisfiable = fail_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+
+def test_loop_range_summary_skips_z3_for_fma_affine_access():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    idx_sym = ctx.idx
+    scale_sym = SymbolicExpr.create("const", tensor.element_size(), INT32)
+    base_sym = SymbolicExpr.create("const", base, pointer_type(INT32))
+    ptr_sym = SymbolicExpr.create("fma", idx_sym, scale_sym, base_sym)
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+
+    def fail_z3_path(*_args, **_kwargs):
+        raise AssertionError("range summary should skip the Z3 check")
+
+    sanitizer._check_range_satisfiable = fail_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+
+def test_loop_range_summary_falls_back_when_interval_can_escape_tensor():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel() + 1,
+        step=1,
+    )
+    pending = PendingCheck(access_expr, Int("addr"), None)
+    calls = []
+
+    def record_z3_path(*args, **_kwargs):
+        calls.append(args)
+
+    sanitizer._check_range_satisfiable = record_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+    assert len(calls) == 1
+
+
+def test_loop_range_summary_handles_abs_without_sign_flip():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, _access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    base_sym = SymbolicExpr.create("const", base, pointer_type(INT32))
+    negative_offset = SymbolicExpr.create("const", -tensor.element_size(), INT32)
+    abs_offset = SymbolicExpr.create("abs", negative_offset)
+    ptr_sym = SymbolicExpr.create("sub", base_sym, abs_offset)
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+    calls = []
+
+    assert access_interval_summary(access_expr, sanitizer.grid) == IntRange(
+        base - tensor.element_size(),
+        base - tensor.element_size(),
+    )
+
+    def record_z3_path(*args, **_kwargs):
+        calls.append(args)
+
+    sanitizer._check_range_satisfiable = record_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+    assert len(calls) == 1
+
+
+def test_loop_range_summary_falls_back_for_forbidden_unary_address_op():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, _access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    floor_offset = SymbolicExpr.create(
+        "floor",
+        SymbolicExpr.create("const", tensor.element_size(), INT32),
+    )
+    ptr_sym = SymbolicExpr.create(
+        "add",
+        SymbolicExpr.create("const", base, pointer_type(INT32)),
+        floor_offset,
+    )
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+    calls = []
+
+    def record_z3_path(*args, **_kwargs):
+        calls.append(args)
+
+    sanitizer._check_range_satisfiable = record_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+    assert len(calls) == 1
+
+
+def test_loop_range_summary_falls_back_for_cast_address_op():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    ptr_sym = SymbolicExpr.create(
+        "bitcast",
+        access_expr.ptr,
+        pointer_type(INT32),
+    )
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+    calls = []
+
+    def record_z3_path(*args, **_kwargs):
+        calls.append(args)
+
+    sanitizer._check_range_satisfiable = record_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+    assert len(calls) == 1
+
+
+def test_loop_range_summary_falls_back_for_left_shift_address_op():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty(4, dtype=torch.int32)
+    base = tensor.data_ptr()
+    end = base + tensor.numel() * tensor.element_size() - 1
+    sanitizer.tensors.append(tensor)
+    sanitizer.tensor_addrs.append((base, end, tensor))
+    sanitizer.grid = (1, 1, 1)
+
+    ctx, _access_expr = _make_loop_affine_access(
+        base,
+        tensor.element_size(),
+        start=0,
+        stop=tensor.numel(),
+        step=1,
+    )
+    shifted = SymbolicExpr.create(
+        "left_shift",
+        SymbolicExpr.create("const", -1, INT32),
+        SymbolicExpr.create("const", 2, INT32),
+    )
+    offset = SymbolicExpr.create(
+        "add",
+        shifted,
+        SymbolicExpr.create("const", tensor.element_size(), INT32),
+    )
+    ptr_sym = SymbolicExpr.create(
+        "add",
+        SymbolicExpr.create("const", base, pointer_type(INT32)),
+        offset,
+    )
+    access_expr = SymbolicExpr.create("load", ptr_sym, None, None)
+    pending = PendingCheck(access_expr, Int("addr"), None)
+    calls = []
+
+    def record_z3_path(*args, **_kwargs):
+        calls.append(args)
+
+    sanitizer._check_range_satisfiable = record_z3_path  # type: ignore[method-assign]
+
+    sanitizer._process_pending_check(ctx, pending, [])
+
+    assert len(calls) == 1
 
 
 # ======== Report Layout Classification Tests ===========

--- a/triton_viz/clients/sanitizer/range_summary.py
+++ b/triton_viz/clients/sanitizer/range_summary.py
@@ -1,0 +1,297 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from ...core.symbolic_metadata import SymbolicTensorValue, element_bytewidth
+from ..symbolic_engine import LoopContext, SymbolicExpr
+
+
+_UNARY_INTERVAL_OPS = frozenset({"abs", "fabs", "negative"})
+_BINARY_INTERVAL_OPS = frozenset({"add", "sub", "mul", "maximum", "minimum"})
+_TERNARY_INTERVAL_OPS = frozenset({"where", "fma"})
+
+# These ops only change tensor shape/layout in the symbolic engine's Z3 path.
+# Value-changing ops, especially casts and bitcasts, must not be added here.
+_VALUE_PRESERVING_RESHAPE_OPS = frozenset(
+    {"broadcast", "expand_dims", "reshape", "splat", "trans", "unsplat"}
+)
+
+
+@dataclass(frozen=True)
+class IntRange:
+    lower: int
+    upper: int
+
+    @staticmethod
+    def constant(value: int) -> "IntRange":
+        return IntRange(value, value)
+
+    def contains(self, other: "IntRange") -> bool:
+        return self.lower <= other.lower and other.upper <= self.upper
+
+
+def access_interval_summary(
+    symbolic_expr: SymbolicExpr,
+    grid: tuple[int, ...] | None,
+) -> IntRange | None:
+    """Return a conservative integer interval for one memory access address.
+
+    The summary is intentionally small and sound: unsupported expressions return
+    ``None`` so sanitizer falls back to the existing Z3 check.
+    """
+    ptr = getattr(symbolic_expr, "ptr", symbolic_expr)
+    if not isinstance(ptr, SymbolicExpr):
+        return None
+    return _expr_interval(ptr, grid)
+
+
+def access_range_proves_in_bounds(
+    symbolic_expr: SymbolicExpr,
+    ranges: Sequence[tuple[int, int, Any]],
+    grid: tuple[int, ...] | None,
+) -> bool:
+    interval = access_interval_summary(symbolic_expr, grid)
+    if interval is None:
+        return False
+
+    for start, end, _tensor in ranges:
+        valid = IntRange(int(start), int(end))
+        if valid.contains(interval):
+            return True
+    return False
+
+
+def _expr_interval(expr: SymbolicExpr, grid: tuple[int, ...] | None) -> IntRange | None:
+    if expr.loop_ctx is not None:
+        return _loop_interval(expr.loop_ctx)
+
+    if expr.op == "const":
+        return _value_interval(getattr(expr, "value", None))
+
+    if expr.op == "pid":
+        return _pid_interval(expr, grid)
+
+    if expr.op == "arange":
+        start = _literal_int(getattr(expr, "start", None))
+        end = _literal_int(getattr(expr, "end", None))
+        if start is None or end is None:
+            return None
+        return _range_interval(start, end, 1)
+
+    if expr.op == "addptr":
+        return _addptr_interval(expr, grid)
+
+    if expr.op in _UNARY_INTERVAL_OPS:
+        return _unary_interval(expr, grid)
+
+    if expr.op in _BINARY_INTERVAL_OPS:
+        return _binary_interval(expr, grid)
+
+    if expr.op in _TERNARY_INTERVAL_OPS:
+        return _ternary_interval(expr, grid)
+
+    if expr.op in _VALUE_PRESERVING_RESHAPE_OPS:
+        passthrough = _passthrough_child(expr)
+        if passthrough is not None:
+            return _expr_interval(passthrough, grid)
+
+    # Every other op keeps the existing Z3 path. This avoids false negatives for
+    # ops with bitvector wrapping, division/mod semantics, or value-changing casts.
+    return None
+
+
+def _unary_interval(
+    expr: SymbolicExpr, grid: tuple[int, ...] | None
+) -> IntRange | None:
+    child = getattr(expr, "arg", None)
+    if not isinstance(child, SymbolicExpr):
+        return None
+    arg = _expr_interval(child, grid)
+    if arg is None:
+        return None
+
+    if expr.op in {"abs", "fabs"}:
+        return _abs_interval(arg)
+    if expr.op == "negative":
+        return IntRange(-arg.upper, -arg.lower)
+    return None
+
+
+def _binary_interval(
+    expr: SymbolicExpr, grid: tuple[int, ...] | None
+) -> IntRange | None:
+    lhs_child = getattr(expr, "lhs", None)
+    rhs_child = getattr(expr, "rhs", None)
+    if not isinstance(lhs_child, SymbolicExpr) or not isinstance(
+        rhs_child, SymbolicExpr
+    ):
+        return None
+    lhs = _expr_interval(lhs_child, grid)
+    rhs = _expr_interval(rhs_child, grid)
+    if lhs is None or rhs is None:
+        return None
+
+    if expr.op == "add":
+        return IntRange(lhs.lower + rhs.lower, lhs.upper + rhs.upper)
+    if expr.op == "sub":
+        return IntRange(lhs.lower - rhs.upper, lhs.upper - rhs.lower)
+    if expr.op == "mul":
+        return _mul_interval(lhs, rhs)
+    if expr.op == "maximum":
+        return IntRange(max(lhs.lower, rhs.lower), max(lhs.upper, rhs.upper))
+    if expr.op == "minimum":
+        return IntRange(min(lhs.lower, rhs.lower), min(lhs.upper, rhs.upper))
+    return None
+
+
+def _ternary_interval(
+    expr: SymbolicExpr, grid: tuple[int, ...] | None
+) -> IntRange | None:
+    if expr.op == "where":
+        lhs = _child_interval(expr, "lhs", grid)
+        rhs = _child_interval(expr, "rhs", grid)
+        return None if lhs is None or rhs is None else _merge(lhs, rhs)
+
+    if expr.op == "fma":
+        x = _child_interval(expr, "x", grid)
+        y = _child_interval(expr, "y", grid)
+        z = _child_interval(expr, "z", grid)
+        if x is None or y is None or z is None:
+            return None
+        product = _mul_interval(x, y)
+        return IntRange(product.lower + z.lower, product.upper + z.upper)
+
+    return None
+
+
+def _addptr_interval(
+    expr: SymbolicExpr, grid: tuple[int, ...] | None
+) -> IntRange | None:
+    ptr = _child_interval(expr, "ptr", grid)
+    offset = _child_interval(expr, "offset", grid)
+    if ptr is None or offset is None:
+        return None
+
+    ptr_child = getattr(expr, "ptr", None)
+    if not isinstance(ptr_child, SymbolicExpr):
+        return None
+    try:
+        element_size = element_bytewidth(ptr_child.dtype)
+    except (TypeError, ValueError):
+        return None
+
+    scaled = _mul_interval(offset, IntRange.constant(element_size))
+    return IntRange(ptr.lower + scaled.lower, ptr.upper + scaled.upper)
+
+
+def _child_interval(
+    expr: SymbolicExpr, attr: str, grid: tuple[int, ...] | None
+) -> IntRange | None:
+    child = getattr(expr, attr, None)
+    if not isinstance(child, SymbolicExpr):
+        return None
+    return _expr_interval(child, grid)
+
+
+def _passthrough_child(expr: SymbolicExpr) -> SymbolicExpr | None:
+    for attr in ("arg", "src"):
+        child = getattr(expr, attr, None)
+        if isinstance(child, SymbolicExpr):
+            return child
+    return None
+
+
+def _abs_interval(arg: IntRange) -> IntRange:
+    if arg.lower <= 0 <= arg.upper:
+        return IntRange(0, max(-arg.lower, arg.upper))
+    if arg.upper < 0:
+        return IntRange(-arg.upper, -arg.lower)
+    return arg
+
+
+def _pid_interval(expr: SymbolicExpr, grid: tuple[int, ...] | None) -> IntRange | None:
+    if grid is None:
+        return None
+    axis = _literal_int(getattr(expr, "axis", None))
+    if axis is None or axis < 0 or axis >= len(grid):
+        return None
+    return IntRange(0, max(0, int(grid[axis]) - 1))
+
+
+def _loop_interval(ctx: LoopContext) -> IntRange | None:
+    return _range_interval(ctx.start, ctx.stop, ctx.step)
+
+
+def _range_interval(start: int, stop: int, step: int) -> IntRange | None:
+    if step == 0:
+        return None
+    values = range(int(start), int(stop), int(step))
+    if not values:
+        return None
+    first = values[0]
+    last = values[-1]
+    return IntRange(min(first, last), max(first, last))
+
+
+def _value_interval(value: Any) -> IntRange | None:
+    if isinstance(value, SymbolicTensorValue):
+        return _array_interval(value.data)
+    if isinstance(value, np.ndarray):
+        return _array_interval(value)
+    if isinstance(value, (list, tuple)):
+        return _sequence_interval(value)
+    if isinstance(value, (int, np.integer, bool)):
+        return IntRange.constant(int(value))
+    if isinstance(value, (float, np.floating)) and float(value).is_integer():
+        return IntRange.constant(int(value))
+    return None
+
+
+def _array_interval(array: np.ndarray) -> IntRange | None:
+    if array.size == 0 or not np.issubdtype(array.dtype, np.number):
+        return None
+    return IntRange(int(array.min()), int(array.max()))
+
+
+def _sequence_interval(values: Sequence[Any]) -> IntRange | None:
+    if not values:
+        return None
+    intervals = [_value_interval(value) for value in values]
+    if any(interval is None for interval in intervals):
+        return None
+    concrete = [interval for interval in intervals if interval is not None]
+    return IntRange(
+        min(interval.lower for interval in concrete),
+        max(interval.upper for interval in concrete),
+    )
+
+
+def _literal_int(value: Any) -> int | None:
+    if isinstance(value, SymbolicExpr) and value.op == "const":
+        interval = _value_interval(getattr(value, "value", None))
+        if interval is not None and interval.lower == interval.upper:
+            return interval.lower
+    if isinstance(value, (int, np.integer, bool)):
+        return int(value)
+    return None
+
+
+def _merge(lhs: IntRange, rhs: IntRange) -> IntRange:
+    return IntRange(min(lhs.lower, rhs.lower), max(lhs.upper, rhs.upper))
+
+
+def _mul_interval(lhs: IntRange, rhs: IntRange) -> IntRange:
+    return _from_candidates(
+        lhs.lower * rhs.lower,
+        lhs.lower * rhs.upper,
+        lhs.upper * rhs.lower,
+        lhs.upper * rhs.upper,
+    )
+
+
+def _from_candidates(*values: int) -> IntRange:
+    return IntRange(min(values), max(values))

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -42,6 +42,7 @@ from .report import (
     print_oob_record,
     print_oob_record_pdb_style,
 )
+from .range_summary import access_range_proves_in_bounds
 from ...core.config import config as cfg
 from ...core.symbolic_metadata import (
     ConcreteAccessRoute,
@@ -332,7 +333,7 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
             self._clear_cache()
             if fn_cache not in _fn_symbolic_cache_set:
                 _fn_symbolic_cache_set.add(fn_cache)
-                return True
+                return SymbolicClient.pre_run_callback(self, fn)
             return False
         return SymbolicClient.pre_run_callback(self, fn)
 
@@ -503,6 +504,20 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
 
         return True
 
+    def _range_summary_proves_safe(self, symbolic_expr: SymbolicExpr) -> bool:
+        resolved_tensor = self._resolve_tensor(symbolic_expr)
+        if resolved_tensor is None:
+            ranges = self.tensor_addrs
+        else:
+            ranges = [
+                (start, end, tensor)
+                for start, end, tensor in self.tensor_addrs
+                if tensor is resolved_tensor
+            ]
+        if not ranges:
+            return False
+        return access_range_proves_in_bounds(symbolic_expr, ranges, self.grid)
+
     def _handle_access_check(
         self,
         expr: SymbolicExpr,
@@ -558,6 +573,8 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         iter_constraints: list[BoolRef],
     ) -> None:
         del ctx, iter_constraints  # verbose logging is handled by the base
+        if self._range_summary_proves_safe(pending.symbolic_expr):
+            return
         self._check_range_satisfiable(
             pending.addr_expr,
             pending.constraints,

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -2376,6 +2376,9 @@ class SymbolicClient(Client):
         self.tensor_names: dict[int, set[str]] = {}
         self.need_full_grid: bool | None = None
         self.last_grid: tuple[int, int, int] | None = None
+        self._active_blocks: int = 0
+        self._launch_should_stop: bool = False
+        self._pending_launch_clear: bool = False
         self.addr_ok: BoolRef | None = None
         self.pid_ok: BoolRef | None = None
         self.solver: Solver | None = Solver()
@@ -3129,6 +3132,9 @@ class SymbolicClient(Client):
         grid = tuple(int(g) for g in grid)
         self.last_grid = (grid[0] - 1, grid[1] - 1, grid[2] - 1)
         self.grid = grid
+        self._active_blocks = 0
+        self._launch_should_stop = False
+        self._pending_launch_clear = False
         self.addr_ok = None
         self.pid_ok = cast(
             BoolRef,
@@ -3150,16 +3156,27 @@ class SymbolicClient(Client):
         self.solver.add(self.pid_ok)
 
     def pre_run_callback(self, fn: Callable) -> bool:
-        if self.need_full_grid is None:
-            return True
-        return self.need_full_grid
+        if self._launch_should_stop:
+            return False
+        should_run = True if self.need_full_grid is None else self.need_full_grid
+        if should_run:
+            self._active_blocks += 1
+        return should_run
 
     def post_run_callback(self, fn: Callable) -> bool:
         if self.need_full_grid is None:
             self.need_full_grid = False
         if self.grid_idx == self.last_grid or not self.need_full_grid:
+            # Under concurrent block execution, another block may already be
+            # running in this launch. Defer clearing tensor/solver caches until
+            # every block that passed pre_run_callback has reached post_run.
+            self._launch_should_stop = True
+            self._pending_launch_clear = True
+        self._active_blocks = max(0, self._active_blocks - 1)
+        if self._pending_launch_clear and self._active_blocks == 0:
             self._clear_cache()
             self._clear_symbolic_launch_state()
+            self._pending_launch_clear = False
         ret = self.need_full_grid
         self.need_full_grid = None
         return ret


### PR DESCRIPTION
## Summary

Adds a conservative range-summary fast path for loop-deferred sanitizer address checks. The sanitizer can now prove simple loop address ranges safe before invoking the existing Z3 path, reducing repeated solver work for in-bounds loop accesses.

Supported summary rules are explicit: constants, loop iterators, `pid`, `arange`, `addptr`, arithmetic interval ops (`add`, `sub`, `mul`, `negative`, `abs`/`fabs`, `minimum`, `maximum`), `where`, `fma`, and value-preserving shape/layout ops. Unsupported expressions return `None` and fall back to the existing Z3 sanitizer check.

The fast path intentionally does not summarize risky/value-changing ops such as casts/bitcasts, shifts, bitwise ops, division, mod, or generic unary math ops. This keeps the optimization from hiding out-of-bounds accesses when symbolic semantics involve bitvector wrapping, reinterpretation, or non-integer behavior.

Also fixes symbolic-client launch cleanup under concurrent block execution: cleanup is now deferred until all blocks that already passed `pre_run_callback` have reached `post_run_callback`, and sanitizer cache misses route through the shared pre-run lifecycle.

## Validation

- `python -m pytest tests/unit/test_multithreading.py::test_sanitizer_handles_concurrent_blocks tests/unit/test_multithreading.py::test_sanitizer_handles_serial_blocks -q` -> `2 passed`
- `python -m pytest tests/unit/test_multithreading.py tests/unit/test_sanitizer.py tests/unit/test_symbolic_client.py tests/unit/test_race_detector.py` -> `102 passed`
- `pre-commit run --all-files` -> passed

## Benchmark Smoke Check

One-sample sanitizer benchmark comparison from the earlier branch check:

- main: `1.786s`
- branch: `1.560s`
- delta: `-12.6%`

This is a smoke result only, not a statistically rigorous benchmark run.