### PR TITLE
[FEAT] Add Gluon tracing and sanitizer support

### DIFF
--- a/examples/sanitizer/gluon_tma_oob.py
+++ b/examples/sanitizer/gluon_tma_oob.py
@@ -1,0 +1,56 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.nvidia.hopper import mbarrier, tma
+
+import triton_viz
+from triton_viz.clients.sanitizer.sanitizer import Sanitizer
+
+
+BLOCK_M = 16
+BLOCK_N = 16
+
+
+@gluon.jit
+def gluon_tma_oob_kernel(
+    x,
+    m: gl.constexpr,
+    n: gl.constexpr,
+    block_m: gl.constexpr,
+    block_n: gl.constexpr,
+    layout: gl.constexpr,
+):
+    desc = tma.make_tensor_descriptor(
+        x,
+        [m, n],
+        [n, 1],
+        [block_m, block_n],
+        layout,
+    )
+    smem = gl.allocate_shared_memory(gl.float32, [block_m, block_n], layout)
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, desc.nbytes_per_cta)
+    tma.async_load(desc, [m, 0], bar, smem)  # OOB: row coordinate starts past x.
+
+
+def run(abort_on_error: bool = True):
+    x = torch.zeros((BLOCK_M, BLOCK_N), device="cuda", dtype=torch.float32)
+    layout = gl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_N], gl.float32)
+    kernel = triton_viz.trace(
+        client=Sanitizer(abort_on_error=abort_on_error),
+        frontend="gluon",
+    )(gluon_tma_oob_kernel)
+    return kernel[(1,)](
+        x,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_M,
+        BLOCK_N,
+        layout,
+        num_warps=4,
+    )
+
+
+if __name__ == "__main__":
+    run()

--- a/tests/end_to_end/test_core.py
+++ b/tests/end_to_end/test_core.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 import triton_viz
 from triton_viz.clients import Profiler, Sanitizer
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
 
 
 # ======== Trace Decorator Tests =========
@@ -44,6 +46,120 @@ def test_trace_decorator_add_clients():
     assert sum(c == "sanitizer" for c in clients) == 1
     assert sum(c == "profiler" for c in clients) == 1
     assert sum(c == "tracer" for c in clients) == 1
+
+
+def test_trace_decorator_supports_gluon_frontend():
+    from triton.experimental import gluon
+    from triton.experimental.gluon import language as ttgl
+    from triton_viz.core.trace import GluonTrace
+
+    @triton_viz.trace("tracer", frontend="gluon")
+    @gluon.jit
+    def my_gluon_kernel(out):
+        pid = ttgl.program_id(0)
+        ttgl.store(out + pid, pid)
+
+    assert isinstance(my_gluon_kernel, GluonTrace)
+    assert my_gluon_kernel.client_manager.get_client("tracer") is not None
+
+
+def test_gluon_sanitizer_run_preserves_instrumentation_mode(monkeypatch):
+    from triton import knobs
+    from triton.experimental import gluon
+    from triton.experimental.gluon import language as ttgl
+
+    @triton_viz.trace(client=Sanitizer(abort_on_error=False), frontend="gluon")
+    @gluon.jit
+    def my_gluon_kernel(out):
+        pid = ttgl.program_id(0)
+        ttgl.store(out + pid, pid)
+
+    seen_modes = []
+    saved_mode = knobs.compilation.instrumentation_mode
+
+    def fake_run(*args, **kwargs):
+        seen_modes.append(knobs.compilation.instrumentation_mode)
+        return "compiled"
+
+    monkeypatch.setattr(my_gluon_kernel.runner, "run", fake_run)
+
+    try:
+        ret = my_gluon_kernel[(1,)](object())
+    finally:
+        knobs.compilation.instrumentation_mode = saved_mode
+
+    assert ret == "compiled"
+    assert seen_modes == [saved_mode]
+    assert knobs.compilation.instrumentation_mode == saved_mode
+
+
+class _PreRunSkippingClient(Client):
+    NAME = "pre_run_skipping"
+
+    def __init__(self):
+        super().__init__()
+        self.pre_run_calls = 0
+        self.post_run_calls = 0
+
+    def pre_run_callback(self, fn):
+        self.pre_run_calls += 1
+        return False
+
+    def post_run_callback(self, fn):
+        self.post_run_calls += 1
+        return True
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return False
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+
+def test_gluon_run_does_not_use_pre_run_as_launch_gate(monkeypatch):
+    from triton.experimental import gluon
+    from triton.experimental.gluon import language as ttgl
+
+    client = _PreRunSkippingClient()
+
+    @triton_viz.trace(client=client, frontend="gluon")
+    @gluon.jit
+    def my_gluon_kernel(out):
+        pid = ttgl.program_id(0)
+        ttgl.store(out + pid, pid)
+
+    run_calls = []
+
+    def fake_run(*args, **kwargs):
+        run_calls.append((args, kwargs))
+        return "compiled"
+
+    monkeypatch.setattr(my_gluon_kernel.runner, "run", fake_run)
+
+    ret = my_gluon_kernel[(1,)](object())
+
+    assert ret == "compiled"
+    assert len(run_calls) == 1
+    assert client.pre_run_calls == 0
+    assert client.post_run_calls == 1
 
 
 # ======== Unpatch Tests =========

--- a/tests/end_to_end/test_gluon.py
+++ b/tests/end_to_end/test_gluon.py
@@ -1,0 +1,135 @@
+import pytest
+import torch
+from triton import knobs
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
+from triton_viz.core.data import Load
+
+
+def _has_cuda_device() -> bool:
+    try:
+        return torch.cuda.is_available()
+    except RuntimeError:
+        return False
+
+
+def _has_tma_device() -> bool:
+    if not _has_cuda_device():
+        return False
+    try:
+        return torch.cuda.get_device_capability()[0] >= 9
+    except RuntimeError:
+        return False
+
+
+@gluon.jit
+def _copy_scalar_kernel(in_ptr, out_ptr):
+    value = gl.load(in_ptr)
+    gl.store(out_ptr, value)
+
+
+@gluon.jit
+def _oob_scalar_offset_kernel(in_ptr, out_ptr):
+    value = gl.load(in_ptr + 1)
+    gl.store(out_ptr, value)
+
+
+@gluon.jit
+def _masked_safe_kernel(
+    in_ptr,
+    out_ptr,
+    n: gl.constexpr,
+    BLOCK: gl.constexpr,
+    layout: gl.constexpr,
+):
+    offs = gl.arange(0, BLOCK, layout=layout)
+    mask = offs < n
+    value = gl.load(in_ptr + offs, mask=mask, other=0.0)
+    gl.store(out_ptr + offs, value, mask=mask)
+
+
+@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
+def test_gluon_trace_runs_copy_scalar_kernel():
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_copy_scalar_kernel)
+
+    inp = torch.tensor([42.0], device="cuda")
+    out = torch.empty_like(inp)
+    kernel[(1,)](inp, out, num_warps=1)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out, inp, atol=0, rtol=0)
+    assert kernel.client_manager.launch.grid == (1, 1, 1)
+    assert len(kernel.client_manager.launch.records) >= 1
+
+
+@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
+def test_gluon_sanitizer_allows_in_bounds_kernel():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    kernel = triton_viz.trace(
+        client=sanitizer,
+        frontend="gluon",
+    )(_copy_scalar_kernel)
+
+    inp = torch.tensor([42.0], device="cuda")
+    out = torch.empty_like(inp)
+    ret = kernel[(1,)](inp, out, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert ret is not None
+    assert sanitizer.records == []
+    torch.testing.assert_close(out, inp, atol=0, rtol=0)
+
+
+@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
+def test_gluon_sanitizer_reports_real_oob_load_kernel(monkeypatch):
+    monkeypatch.setattr(knobs.compilation, "always_compile", True)
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    kernel = triton_viz.trace(
+        client=sanitizer,
+        frontend="gluon",
+    )(_oob_scalar_offset_kernel)
+    kernel.runner.device_caches.clear()
+
+    inp = torch.tensor([42.0], device="cuda")
+    out = torch.empty_like(inp)
+    ret = kernel[(1,)](inp, out, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert ret is not None
+    assert sanitizer.records
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].violation_address == inp.data_ptr() + inp.element_size()
+
+
+@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
+def test_gluon_sanitizer_allows_masked_in_bounds_kernel():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    kernel = triton_viz.trace(
+        client=sanitizer,
+        frontend="gluon",
+    )(_masked_safe_kernel)
+
+    inp = torch.arange(4, dtype=torch.float32, device="cuda")
+    out = torch.empty((8,), dtype=torch.float32, device="cuda")
+    layout = gl.BlockedLayout([1], [32], [1], [0])
+    ret = kernel[(1,)](inp, out, 4, 8, layout, num_warps=1)
+    torch.cuda.synchronize()
+
+    assert ret is not None
+    assert sanitizer.records == []
+
+
+@pytest.mark.skipif(not _has_tma_device(), reason="CUDA TMA device required")
+def test_gluon_tma_oob_example_reports(capsys):
+    from examples.sanitizer import gluon_tma_oob
+
+    with pytest.raises(SystemExit):
+        gluon_tma_oob.run()
+
+    output = capsys.readouterr().out
+    assert "ILLEGAL MEMORY ACCESS" in output
+    assert "gluon_tma_oob.py" in output
+    assert "descriptor_access" in output

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -4,8 +4,10 @@ import triton.language as tl
 from triton.runtime.interpreter import TensorHandle
 
 from triton_viz.core.callbacks import OpCallbacks
+from triton_viz.core.client import Client, ClientManager
 from triton_viz.core.data import (
     AddPtr,
+    BinaryOp,
     CastImpl,
     IntToPtr,
     Load,
@@ -13,6 +15,7 @@ from triton_viz.core.data import (
     PtrToInt,
     ReduceSum,
     Store,
+    UnaryOp,
 )
 
 from triton_viz.core.frontend.base import AdapterResult, get_frontend
@@ -24,6 +27,7 @@ from triton_viz.core.symbolic_metadata import (
     INT32,
     SymbolicTensorValue,
     SymbolicTypeSpec,
+    TensorDescriptorAccess,
     pointer_type,
 )
 
@@ -32,6 +36,8 @@ from triton_viz.core.patch import PatchOp
 TRITON_FRONTEND = get_frontend("triton")
 TRITON_ADAPTERS = TRITON_FRONTEND.adapters
 NKI_ADAPTERS = get_frontend("nki").adapters
+GLUON_FRONTEND = get_frontend("gluon")
+GLUON_ADAPTERS = GLUON_FRONTEND.adapters
 
 
 def test_adapter_result_kwargs_copy():
@@ -52,6 +58,39 @@ def test_adapter_result_kwargs_copy():
     ] = "after"  # result.kwargs["named"] is mutable so it DOES change from this
     assert result.args == (1,)
     assert result.kwargs["named"][0] == "after"
+
+
+def test_patch_op_preserves_descriptor_binding():
+    seen = []
+
+    class Target:
+        def op(self, value):
+            return ("ret", self, value)
+
+    def adapter(instance, value):
+        return AdapterResult(instance, value)
+
+    original = Target.op
+    callbacks = OpCallbacks(
+        before_callback=lambda instance, value: seen.append((instance, value))
+    )
+    Target.op = PatchOp(
+        original,
+        ProgramId,
+        callbacks,
+        adapter,
+        run_op_overrider=lambda op, _op_type, _op_overrider, args, kwargs: op(
+            *args,
+            **kwargs,
+        ),
+        maybe_yield_for_multism=lambda: None,
+    )
+    try:
+        instance = Target()
+        assert instance.op(7) == ("ret", instance, 7)
+        assert seen == [(instance, 7)]
+    finally:
+        Target.op = original
 
 
 def test_triton_store_adapter_handles_keys():
@@ -138,6 +177,267 @@ def test_program_id_adapter_returns_axis_only():
     result = adapter(program_id)
     assert result.args == (program_id,)
     assert result.kwargs == {}
+
+
+def test_gluon_descriptor_memory_adapters_accept_async_signatures():
+    load = GLUON_ADAPTERS[Load]
+    store = GLUON_ADAPTERS[Store]
+    desc = type("TensorDescriptor", (), {"block_shape": (1,)})()
+
+    def assert_descriptor_access(result, coords, mask=None):
+        access, result_mask, other = result.args
+        assert access.descriptor is desc
+        assert access.coords == coords
+        assert access.pred == mask
+        assert result_mask == mask
+        assert other is None
+
+    assert load("ptr", "mask").args == ("ptr", "mask", None)
+    assert_descriptor_access(load(desc, "coord", "bar", "result"), "coord")
+    assert_descriptor_access(load(desc, "coord", "bar", "result", "pred"), "coord")
+    assert_descriptor_access(
+        load(
+            desc,
+            "coord",
+            "offsets",
+            "bar",
+            "result",
+            "pred",
+        ),
+        "coord",
+    )
+    assert_descriptor_access(load(desc, "offsets", "dest"), "offsets")
+    assert_descriptor_access(load(desc, "offsets", "dest", "pred"), "offsets")
+    assert_descriptor_access(
+        load(desc, "coord", "bar", "result", pred="pred"),
+        "coord",
+        "pred",
+    )
+
+    assert store("ptr", "value", "mask").args == ("ptr", "mask", None)
+    assert_descriptor_access(store(desc, "coord", "src"), "coord")
+    assert_descriptor_access(
+        store(desc, "values", "indices", "axis", "mask"),
+        "values",
+    )
+    assert_descriptor_access(
+        store(desc, "values", "indices", "axis", mask="mask"),
+        "values",
+        "mask",
+    )
+
+
+def test_gluon_descriptor_load_adapters_honor_positional_predicates():
+    from triton_viz.core.frontend import gluon as gluon_frontend
+
+    desc = type("TensorDescriptor", (), {"block_shape": (1,)})()
+    normal_load = gluon_frontend._gluon_descriptor_load_adapter(3)
+    im2col_load = gluon_frontend._gluon_descriptor_load_adapter(4)
+    tdm_load = gluon_frontend._gluon_descriptor_load_adapter(2)
+
+    access, mask, other = normal_load(desc, "coord", "barrier", "result", False).args
+    assert access.pred is False
+    assert mask is False
+    assert other is None
+
+    access, mask, other = im2col_load(
+        desc, "coord", "offsets", "barrier", "result"
+    ).args
+    assert access.pred is None
+    assert mask is None
+    assert other is None
+
+    access, mask, other = im2col_load(
+        desc, "coord", "offsets", "barrier", "result", False
+    ).args
+    assert access.pred is False
+    assert mask is False
+    assert other is None
+
+    access, mask, other = tdm_load(desc, "offsets", "dest", False).args
+    assert access.pred is False
+    assert mask is False
+    assert other is None
+
+
+def test_gluon_shared_memory_descriptor_is_not_patched():
+    from triton.experimental.gluon.language import _core as gluon_core
+
+    assert gluon_core.shared_memory_descriptor not in GLUON_FRONTEND.namespaces
+
+
+def test_gluon_load_store_adapters_keep_first_positional_mask():
+    load = GLUON_ADAPTERS[Load]
+    store = GLUON_ADAPTERS[Store]
+
+    assert load("ptr", "mask", "other", "boundary_check").args == (
+        "ptr",
+        "mask",
+        None,
+    )
+    assert store("ptr", "value", "mask", "boundary_check").args == (
+        "ptr",
+        "mask",
+        None,
+    )
+
+
+def test_gluon_frontend_routes_tensor_descriptor_access_to_overrider():
+    class FakeTensor:
+        dtype = "float32"
+
+        def data_ptr(self):
+            return 4096
+
+    class FakeDescriptor:
+        base = FakeTensor()
+        shape = (4, 4)
+        strides = (4, 1)
+        block_shape = (2, 2)
+
+    calls = []
+
+    def original(desc, coords):
+        raise AssertionError("run_op_overrider should not call the original op")
+
+    def overrider(ptr, mask, other):
+        calls.append((ptr, mask, other))
+        return "overridden"
+
+    desc = FakeDescriptor()
+    result = GLUON_FRONTEND.run_op_overrider(
+        original,
+        Load,
+        overrider,
+        (desc, (3, 0)),
+        {},
+    )
+
+    assert result == "overridden"
+    assert len(calls) == 1
+    ptr, mask, other = calls[0]
+    assert isinstance(ptr, TensorDescriptorAccess)
+    assert ptr.descriptor is desc
+    assert ptr.coords == (3, 0)
+    assert ptr.pred is None
+    assert mask is None
+    assert other is None
+
+
+def test_gluon_binary_op_adapter_binds_original_callable():
+    from triton.experimental.gluon import language as ttgl
+
+    calls = []
+
+    def overrider(lhs, rhs, op):
+        calls.append((lhs, rhs, op))
+        return "overridden"
+
+    result = GLUON_FRONTEND.run_op_overrider(
+        ttgl.add,
+        BinaryOp,
+        overrider,
+        ("lhs", "rhs"),
+        {},
+    )
+
+    assert result == "overridden"
+    assert calls == [("lhs", "rhs", np.add)]
+
+
+def test_gluon_unary_op_adapter_binds_original_callable():
+    from triton.experimental.gluon import language as ttgl
+
+    calls = []
+
+    def overrider(arg, op):
+        calls.append((arg, op))
+        return "overridden"
+
+    result = GLUON_FRONTEND.run_op_overrider(
+        ttgl.exp,
+        UnaryOp,
+        overrider,
+        ("arg",),
+        {},
+    )
+
+    assert result == "overridden"
+    assert calls == [("arg", np.exp)]
+
+
+def test_gluon_frontend_wraps_symbolic_concrete_fn():
+    calls = []
+
+    def concrete_fn(arg, *, named):
+        calls.append((arg, named))
+        return [arg, named]
+
+    arg = object()
+    named = object()
+    wrapped = GLUON_FRONTEND.wrap_symbolic_concrete_fn(concrete_fn)
+
+    assert wrapped(arg, named=named) == [arg, named]
+    assert calls == [(arg, named)]
+
+
+def test_gluon_language_ops_patch_and_delegate_to_semantics():
+    from triton.experimental.gluon import language as ttgl
+
+    seen_axes = []
+    original_program_id = ttgl.program_id
+
+    class RecordingClient(Client):
+        NAME = "recording"
+
+        def pre_run_callback(self, fn):
+            return True
+
+        def post_run_callback(self, fn):
+            return True
+
+        def arg_callback(self, name, arg, arg_cvt):
+            pass
+
+        def grid_callback(self, grid):
+            pass
+
+        def grid_idx_callback(self, grid_idx):
+            pass
+
+        def register_op_callback(self, op_type):
+            if op_type is ProgramId:
+                return OpCallbacks(before_callback=lambda axis: seen_axes.append(axis))
+            return OpCallbacks()
+
+        def register_for_loop_callback(self):
+            from triton_viz.core.callbacks import ForLoopCallbacks
+
+            return ForLoopCallbacks()
+
+        def finalize(self):
+            return []
+
+        def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+            return False
+
+        def post_warmup_callback(self, jit_fn, ret):
+            pass
+
+    class FakeSemantic:
+        def program_id(self, axis):
+            return ("pid", axis)
+
+    def kernel():
+        pass
+
+    manager = ClientManager([RecordingClient()])
+    with manager.patch_run(kernel, frontend_name="gluon"):
+        assert ttgl.program_id is not original_program_id
+        assert ttgl.program_id(2, _semantic=FakeSemantic()) == ("pid", 2)
+
+    assert ttgl.program_id is original_program_id
+    assert seen_axes == [2]
 
 
 def test_triton_pointer_cast_aliases_have_distinct_op_types():

--- a/tests/unit/test_patch_scope.py
+++ b/tests/unit/test_patch_scope.py
@@ -62,6 +62,27 @@ def test_scope_restores_tensor_magic_methods():
         assert getattr(tensor, attr) is original
 
 
+def test_scope_removes_tensor_magic_methods_added_by_interpreter():
+    tensor = tl.tensor
+    attr = "__bool__"
+    had_original = hasattr(tensor, attr)
+    original = getattr(tensor, attr, None)
+    replacement = lambda self: True
+
+    try:
+        if had_original:
+            delattr(tensor, attr)
+
+        scope = triton_frontend.frontend._triton_snapshot_scope(_dummy_kernel)
+        setattr(tensor, attr, replacement)
+        scope.restore()
+
+        assert not hasattr(tensor, attr)
+    finally:
+        if had_original:
+            setattr(tensor, attr, original)
+
+
 def test_scope_restores_tensor_descriptor_base_builtins(monkeypatch):
     """Scope must restore descriptor builtins on tensor_descriptor_base."""
     if not hasattr(tl.core, "tensor_descriptor_base"):

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -10,6 +10,7 @@ from triton_viz.core.symbolic_metadata import (
     INT1,
     INT32,
     SymbolicTensorValue,
+    TensorDescriptorAccess,
     pointer_type,
     type_spec,
 )
@@ -22,6 +23,7 @@ from triton_viz.clients.sanitizer.sanitizer import (
 )
 from triton_viz.clients.sanitizer.range_summary import IntRange, access_interval_summary
 from triton_viz.clients.symbolic_engine import LoopContext, PendingCheck, SymbolicExpr
+from triton_viz.clients.symbolic_engine import symbolic_tensor_descriptor_access
 
 
 # ======== Init Tests ===========
@@ -236,6 +238,122 @@ def test_concrete_ptr_router_uses_symbolic_path_inside_loops():
     sanitizer._op_load_overrider(ptr_sym, mask_sym, None)
 
     assert calls == [("load", Load, "read")]
+    assert sanitizer.records == []
+
+
+class _HostTensorDescriptor:
+    def __init__(self, base, shape, strides, block_shape):
+        self.base = base
+        self.shape = shape
+        self.strides = strides
+        self.block_shape = block_shape
+
+
+def test_symbolic_tensor_descriptor_access_reports_block_oob():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty((4, 4), dtype=torch.int32)
+    desc = _HostTensorDescriptor(
+        tensor,
+        shape=(4, 4),
+        strides=(4, 1),
+        block_shape=(2, 2),
+    )
+    sanitizer.arg_callback("input_desc", desc, None)
+    sanitizer.grid_callback((1, 1, 1))
+
+    ptr = symbolic_tensor_descriptor_access(desc, (3, 0))
+    assert ptr.op == "descriptor_access"
+    assert not ptr.has_op("addptr")
+    sanitizer._op_load_overrider(ptr, None, None)
+
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].tensor is tensor
+    assert sanitizer.records[0].violation_address == (
+        tensor.data_ptr() + 12 * tensor.element_size()
+    )
+
+
+def test_tensor_descriptor_access_record_reports_block_oob():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty((4, 4), dtype=torch.int32)
+    desc = _HostTensorDescriptor(
+        tensor,
+        shape=(4, 4),
+        strides=(4, 1),
+        block_shape=(2, 2),
+    )
+    sanitizer.arg_callback("input_desc", desc, None)
+    sanitizer.grid_callback((1, 1, 1))
+
+    sanitizer._op_load_overrider(TensorDescriptorAccess(desc, (3, 0)), None, None)
+
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].tensor is tensor
+
+
+def test_tensor_descriptor_created_in_kernel_reports_block_oob():
+    class _GluonDescriptor:
+        pass
+
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty((4, 4), dtype=torch.int32)
+    desc = _GluonDescriptor()
+    sanitizer.arg_callback("input_desc", tensor, None)
+    sanitizer.grid_callback((1, 1, 1))
+    sanitizer._op_allocate_after_callback(
+        desc,
+        tensor,
+        (4, 4),
+        (4, 1),
+        (2, 2),
+    )
+
+    sanitizer._op_load_overrider(TensorDescriptorAccess(desc, (3, 0)), None, None)
+
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].tensor is tensor
+
+
+def test_tensor_descriptor_access_record_ignores_inactive_predicate():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty((4, 4), dtype=torch.int32)
+    desc = _HostTensorDescriptor(
+        tensor,
+        shape=(4, 4),
+        strides=(4, 1),
+        block_shape=(2, 2),
+    )
+    sanitizer.arg_callback("input_desc", desc, None)
+    sanitizer.grid_callback((1, 1, 1))
+
+    ret = sanitizer._op_load_overrider(
+        TensorDescriptorAccess(desc, (3, 0), pred=False),
+        False,
+        None,
+    )
+
+    assert ret.op == "load"
+    assert sanitizer.records == []
+
+
+def test_symbolic_tensor_descriptor_access_allows_in_bounds_block():
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    tensor = torch.empty((4, 4), dtype=torch.int32)
+    desc = _HostTensorDescriptor(
+        tensor,
+        shape=(4, 4),
+        strides=(4, 1),
+        block_shape=(2, 2),
+    )
+    sanitizer.arg_callback("input_desc", desc, None)
+    sanitizer.grid_callback((1, 1, 1))
+
+    ptr = symbolic_tensor_descriptor_access(desc, (2, 2))
+    sanitizer._op_load_overrider(ptr, None, None)
+
     assert sanitizer.records == []
 
 

--- a/tests/unit/test_wrapper.py
+++ b/tests/unit/test_wrapper.py
@@ -41,6 +41,22 @@ def test_sanitizer_wrapper_applies_trace():
         assert result == "wrapped_kernel"
 
 
+def test_sanitizer_wrapper_accepts_frontend():
+    mock_kernel = MagicMock()
+    mock_kernel.__name__ = "test_kernel"
+
+    with patch("triton_viz.wrapper.triton_viz.trace") as mock_trace:
+        mock_decorator = MagicMock()
+        mock_trace.return_value = mock_decorator
+        mock_decorator.return_value = "wrapped_kernel"
+
+        result = sanitizer_wrapper(mock_kernel, frontend="gluon")
+
+        assert mock_trace.call_args.kwargs["frontend"] == "gluon"
+        mock_decorator.assert_called_once_with(mock_kernel)
+        assert result == "wrapped_kernel"
+
+
 def test_profiler_wrapper_applies_trace():
     mock_kernel = MagicMock()
     mock_kernel.__name__ = "test_kernel"
@@ -65,15 +81,18 @@ def test_create_patched_jit_direct_decorator():
     mock_wrapper = MagicMock(return_value="final_kernel")
     mock_original_jit = MagicMock(return_value="jit_kernel")
 
-    with patch("triton_viz.wrapper._original_jit", mock_original_jit):
-        patched_jit = create_patched_jit(mock_wrapper)
+    patched_jit = create_patched_jit(
+        mock_wrapper,
+        mock_original_jit,
+        frontend="triton",
+    )
 
-        mock_fn = MagicMock()
-        result = patched_jit(mock_fn)
+    mock_fn = MagicMock()
+    result = patched_jit(mock_fn)
 
-        mock_original_jit.assert_called_once_with(mock_fn)
-        mock_wrapper.assert_called_once_with("jit_kernel")
-        assert result == "final_kernel"
+    mock_original_jit.assert_called_once_with(mock_fn)
+    mock_wrapper.assert_called_once_with("jit_kernel", frontend="triton")
+    assert result == "final_kernel"
 
 
 def test_create_patched_jit_with_kwargs():
@@ -82,19 +101,63 @@ def test_create_patched_jit_with_kwargs():
     mock_jit_decorator = MagicMock(return_value="jit_kernel")
     mock_original_jit = MagicMock(return_value=mock_jit_decorator)
 
-    with patch("triton_viz.wrapper._original_jit", mock_original_jit):
-        patched_jit = create_patched_jit(mock_wrapper)
+    patched_jit = create_patched_jit(
+        mock_wrapper,
+        mock_original_jit,
+        frontend="triton",
+    )
 
-        decorator = patched_jit(do_not_specialize=["n"])
-        assert callable(decorator)
+    decorator = patched_jit(do_not_specialize=["n"])
+    assert callable(decorator)
 
-        mock_fn = MagicMock()
-        result = decorator(mock_fn)
+    mock_fn = MagicMock()
+    result = decorator(mock_fn)
 
-        mock_original_jit.assert_called_once_with(do_not_specialize=["n"])
-        mock_jit_decorator.assert_called_once_with(mock_fn)
-        mock_wrapper.assert_called_once_with("jit_kernel")
-        assert result == "final_kernel"
+    mock_original_jit.assert_called_once_with(do_not_specialize=["n"])
+    mock_jit_decorator.assert_called_once_with(mock_fn)
+    mock_wrapper.assert_called_once_with("jit_kernel", frontend="triton")
+    assert result == "final_kernel"
+
+
+def test_create_patched_jit_direct_decorator_with_custom_original_jit():
+    mock_wrapper = MagicMock(return_value="final_kernel")
+    mock_original_jit = MagicMock(return_value="custom_jit_kernel")
+
+    patched_jit = create_patched_jit(
+        mock_wrapper,
+        mock_original_jit,
+        frontend="gluon",
+    )
+
+    mock_fn = MagicMock()
+    result = patched_jit(mock_fn)
+
+    mock_original_jit.assert_called_once_with(mock_fn)
+    mock_wrapper.assert_called_once_with("custom_jit_kernel", frontend="gluon")
+    assert result == "final_kernel"
+
+
+def test_create_patched_jit_with_kwargs_and_custom_original_jit():
+    mock_wrapper = MagicMock(return_value="final_kernel")
+    mock_jit_decorator = MagicMock(return_value="custom_jit_kernel")
+    mock_original_jit = MagicMock(return_value=mock_jit_decorator)
+
+    patched_jit = create_patched_jit(
+        mock_wrapper,
+        mock_original_jit,
+        frontend="gluon",
+    )
+
+    decorator = patched_jit(debug=True)
+    assert callable(decorator)
+
+    mock_fn = MagicMock()
+    result = decorator(mock_fn)
+
+    mock_original_jit.assert_called_once_with(debug=True)
+    mock_jit_decorator.assert_called_once_with(mock_fn)
+    mock_wrapper.assert_called_once_with("custom_jit_kernel", frontend="gluon")
+    assert result == "final_kernel"
 
 
 # ======== create_patched_autotune Tests ===========

--- a/triton_viz/clients/sanitizer/sanitizer.py
+++ b/triton_viz/clients/sanitizer/sanitizer.py
@@ -19,6 +19,7 @@ from ...core.client import Client
 from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import (
     Op,
+    Allocate,
     Load,
     Store,
 )
@@ -31,6 +32,7 @@ from ..symbolic_engine import (
     Z3Expr,
     ConstraintConjunction,
     AccessMode,
+    symbolic_tensor_descriptor_value,
 )
 from .data import OutOfBoundsRecordZ3
 from ...utils.traceback_utils import (
@@ -175,12 +177,36 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         SymbolicClient.arg_callback(self, name, arg, arg_cvt)
 
     def register_op_callback(self, op_type: type[Op]) -> OpCallbacks:
+        if op_type is Allocate:
+            cached = self.op_callback_cache.get(op_type)
+            if cached is None:
+                cached = OpCallbacks(
+                    after_callback=self.lock_fn(self._op_allocate_after_callback)
+                )
+                self.op_callback_cache[op_type] = cached
+            return cached
         return SymbolicClient.register_op_callback(self, op_type)
 
     def post_run_callback(self, fn: Callable) -> bool:
         return SymbolicClient.post_run_callback(self, fn)
 
     # ── Sanitizer-specific hook overrides ─────────────────────────
+
+    def _op_allocate_after_callback(
+        self,
+        ret: Any,
+        base: Any,
+        shape: Any,
+        strides: Any,
+        block_shape: Any,
+    ) -> None:
+        symbolic_tensor_descriptor_value(
+            ret,
+            base=base,
+            shape=shape,
+            strides=strides,
+            block_shape=block_shape,
+        )
 
     def _addr_ok_premise(self) -> BoolRef:
         # Sanitizer adds the actual invalid-address premise under the
@@ -219,11 +245,10 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         self.cache_grid = tuple(int(g) for g in grid)
         SymbolicClient.grid_callback(self, grid)
 
-    def _op_load_overrider(self, ptr, mask, other, *args):
-        del args
+    def _op_load_overrider(self, ptr, mask, other, *_args):
         ptr = self._materialize_memory_operand(ptr)
         mask = self._materialize_memory_operand(mask)
-        ptr_sym = SymbolicExpr.from_value(ptr)
+        ptr_sym = self._symbolic_memory_ptr(ptr)
         mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
         other_sym = SymbolicExpr.from_value(other) if other is not None else None
         ret = SymbolicExpr.create("load", ptr_sym, mask_sym, other_sym)
@@ -231,11 +256,10 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         self._route_pointer_access(ret, ptr_sym, mask_sym, Load, "read")
         return ret
 
-    def _op_store_overrider(self, ptr, value, mask, *args):
-        del value, args
+    def _op_store_overrider(self, ptr, _value, mask, *_args):
         ptr = self._materialize_memory_operand(ptr)
         mask = self._materialize_memory_operand(mask)
-        ptr_sym = SymbolicExpr.from_value(ptr)
+        ptr_sym = self._symbolic_memory_ptr(ptr)
         mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
         # Store values do not affect address validity. Avoiding the value
         # subtree keeps sanitizer store checks focused on pointer + mask.
@@ -371,6 +395,12 @@ class SymbolicSanitizer(Sanitizer, SymbolicClient):
         originates from. The global ``addr_ok`` union is only a fallback for
         expressions whose base tensor cannot be resolved.
         """
+        ptr = cast(Any, symbolic_expr).ptr
+        if ptr.op == "descriptor_access":
+            # Descriptor/TMA accesses need descriptor-coordinate bounds, not
+            # just the final pointer address range inside the backing tensor.
+            return ptr.addr_ok
+
         resolved_tensor = self._resolve_tensor(symbolic_expr)
         if resolved_tensor is None:
             return self._addr_ok_expr()

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import math
 import warnings
+import weakref
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
 from functools import reduce
@@ -31,6 +32,7 @@ from z3 import (
     BitVecRef,
     LShR,
     BoolVal,
+    Not,
 )
 from z3.z3 import BoolRef, ArithRef, IntNumRef, ExprRef, Tactic, Probe
 
@@ -87,16 +89,19 @@ from ..core.symbolic_metadata import (
     FLOAT32,
     INT1,
     INT32,
+    DTYPE_BY_NAME,
     SymbolicDType,
     SymbolicPointerDType,
     SymbolicScalarDType,
     SymbolicTensorValue,
     SymbolicTypeSpec,
+    TensorDescriptorAccess,
     dtype_to_numpy,
     element_bytewidth,
     is_pointer_dtype,
     normalize_symbolic_value,
     pointee_dtype,
+    pointer_type,
     type_spec,
     unpack_type_spec,
 )
@@ -177,14 +182,26 @@ def _range_to_iterator_constraint(
     return And(bounds, (var - start) % abs_step == 0)
 
 
+def _literal_int(value: Any) -> int | None:
+    if isinstance(value, SymbolicExpr):
+        if value.op != "const":
+            return None
+        return _literal_int(value.to_py())
+    if isinstance(value, (bool, int)):
+        return int(value)
+    return None
+
+
 def _shape_to_tuple(shape: Any) -> tuple[int, ...]:
+    if hasattr(shape, "handle"):
+        shape = shape.handle
     if hasattr(shape, "to_py"):
         shape = shape.to_py()
     if isinstance(shape, np.ndarray):
         shape = shape.tolist()
     if isinstance(shape, (int, np.integer)):
         return (int(shape),)
-    return tuple(int(x.to_py()) if hasattr(x, "to_py") else int(x) for x in shape)
+    return tuple(cast(int, _literal_int(x)) for x in shape)
 
 
 @dataclass
@@ -303,6 +320,24 @@ class SymbolicExprDataWrapper:
         return self._ensure_value()
 
 
+@dataclass(frozen=True)
+class SymbolicTensorDescriptorValue:
+    base: Any
+    shape: tuple[int, ...]
+    strides: tuple[int, ...]
+    block_shape: tuple[int, ...]
+    base_offset: int = 0
+
+
+# Gluon descriptor objects are created during frontend codegen and may be
+# short-lived. Keep their symbolic metadata in a weak map so this module-level
+# registry does not extend descriptor lifetime after the launch/codegen state is
+# released.
+_SYMBOLIC_TENSOR_DESCRIPTORS: weakref.WeakKeyDictionary[
+    Any, SymbolicTensorDescriptorValue
+] = weakref.WeakKeyDictionary()
+
+
 class SymbolicExpr:
     BASIC_OPS: ClassVar[tuple[str, ...]] = ("const", "pid", "arange")
     INDIRECT_OPS: ClassVar[tuple[str, ...]] = (
@@ -365,7 +400,12 @@ class SymbolicExpr:
     )
     SCAN_OPS: ClassVar[tuple[str, ...]] = ("cumsum",)
     SORT_OPS: ClassVar[tuple[str, ...]] = ("sort",)
-    POINTER_OPS: ClassVar[tuple[str, ...]] = ("make_block_ptr", "addptr", "advance")
+    POINTER_OPS: ClassVar[tuple[str, ...]] = (
+        "make_block_ptr",
+        "addptr",
+        "advance",
+        "descriptor_access",
+    )
     RESHAPE_OPS: ClassVar[tuple[str, ...]] = (
         "splat",
         "unsplat",
@@ -1787,6 +1827,29 @@ class MakeBlockPtrSymbolicExpr(SymbolicExpr):
         )
 
 
+def _offset_pointer_to_z3(
+    ptr_expr: SymbolicExpr,
+    offset_expr: SymbolicExpr,
+) -> tuple[Z3Expr, ConstraintConjunction]:
+    ptr_z3, constraints_ptr = ptr_expr._to_z3()
+    offset_z3, constraints_offset = offset_expr._to_z3()
+    constraints = _and_constraints(constraints_ptr, constraints_offset)
+    element_size = element_bytewidth(ptr_expr.dtype)
+    if not isinstance(ptr_z3, list) and not isinstance(offset_z3, list):  # hot path
+        z3_expr = ptr_z3 + offset_z3 * element_size
+    elif isinstance(ptr_z3, list) and isinstance(offset_z3, list):
+        if len(ptr_z3) != len(offset_z3):
+            raise ValueError(
+                f"ptr {ptr_z3} and offset {offset_z3} don't have the same length!"
+            )
+        z3_expr = [p + o * element_size for p, o in zip(ptr_z3, offset_z3)]
+    elif isinstance(ptr_z3, list):
+        z3_expr = [p + offset_z3 * element_size for p in ptr_z3]
+    else:  # isinstance(offset_z3, list):
+        z3_expr = [ptr_z3 + o * element_size for o in offset_z3]
+    return z3_expr, constraints
+
+
 class AddPtrSymbolicExpr(SymbolicExpr):
     ptr: SymbolicExpr
     offset: SymbolicExpr
@@ -1799,28 +1862,86 @@ class AddPtrSymbolicExpr(SymbolicExpr):
         self.shape = self.ptr.shape
 
     def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
-        ptr_expr = self.ptr
-        offset_expr = self.offset
-        ptr_z3, constraints_ptr = ptr_expr._to_z3()
-        offset_z3, constraints_offset = offset_expr._to_z3()
-        constraints = _and_constraints(constraints_ptr, constraints_offset)
-        element_size = element_bytewidth(ptr_expr.dtype)
-        if not isinstance(ptr_z3, list) and not isinstance(offset_z3, list):  # hot path
-            z3_expr = ptr_z3 + offset_z3 * element_size
-        elif isinstance(ptr_z3, list) and isinstance(offset_z3, list):
-            if len(ptr_z3) != len(offset_z3):
-                raise ValueError(
-                    f"ptr {ptr_z3} and offset {offset_z3} don't have the same length!"
-                )
-            z3_expr = [p + o * element_size for p, o in zip(ptr_z3, offset_z3)]
-        elif isinstance(ptr_z3, list):
-            z3_expr = [p + offset_z3 * element_size for p in ptr_z3]
-        else:  # isinstance(offset_z3, list):
-            z3_expr = [ptr_z3 + o * element_size for o in offset_z3]
-        return z3_expr, constraints
+        return _offset_pointer_to_z3(self.ptr, self.offset)
 
     def concretize(self) -> Any:
         return self.concrete_fn(self.ptr.concretize(), self.offset.concretize())  # type: ignore
+
+
+class DescriptorAccessSymbolicExpr(SymbolicExpr):
+    base: SymbolicExpr
+    offset: SymbolicExpr
+    coords: tuple[SymbolicExpr, ...]
+    extents: tuple[SymbolicExpr, ...]
+    block_extents: tuple[SymbolicExpr, ...]
+    pred: SymbolicExpr | None
+
+    def __init__(
+        self,
+        op: str,
+        base: Any,
+        offset: Any,
+        coords: Any,
+        extents: Any,
+        block_extents: Any,
+        pred: Any = None,
+    ):
+        super().__init__(op)
+        self.add_child("base", base)
+        self.add_child("offset", offset)
+        self.add_child("coords", coords)
+        self.add_child("extents", extents)
+        self.add_child("block_extents", block_extents)
+        self.add_child("pred", pred)
+        self.dtype = self.base.dtype
+        self.shape = self.base.shape
+        self._addr_ok_cache: BoolRef | None = None
+
+    def _to_z3_impl(self) -> tuple[Z3Expr, ConstraintConjunction]:
+        return _offset_pointer_to_z3(self.base, self.offset)
+
+    def concretize(self) -> Any:
+        return self.concrete_fn(self.base.concretize(), self.offset.concretize())  # type: ignore
+
+    @property
+    def addr_ok(self) -> BoolRef | None:
+        if self._addr_ok_cache is not None:
+            return self._addr_ok_cache
+        if _descriptor_predicate_is_false(self.pred):
+            self._addr_ok_cache = BoolVal(True)
+            return self._addr_ok_cache
+
+        constraints: list[ConstraintExpr] = []
+        bounds: list[BoolRef] = []
+        for coord, extent, block_extent in zip(
+            self.coords,
+            self.extents,
+            self.block_extents,
+        ):
+            coord_z3, coord_constraints = coord.eval()
+            if isinstance(coord_z3, list):
+                return None
+            extent_value = _literal_int(extent)
+            block_extent_value = _literal_int(block_extent)
+            if extent_value is None or block_extent_value is None:
+                return None
+            bounds.append(cast(BoolRef, coord_z3 >= 0))
+            bounds.append(cast(BoolRef, coord_z3 + block_extent_value <= extent_value))
+            if coord_constraints is not None:
+                constraints.append(coord_constraints)
+
+        ok = And(*bounds) if len(bounds) > 1 else bounds[0]
+        pred_bool, pred_constraints = _predicate_bool(self.pred)
+        if pred_bool is not None:
+            ok = Or(Not(pred_bool), ok)
+        if pred_constraints is not None:
+            constraints.append(pred_constraints)
+        addr_ok = _and_constraints(*constraints, ok)
+        self._addr_ok_cache = cast(
+            BoolRef,
+            addr_ok if addr_ok is not None else BoolVal(True),
+        )
+        return self._addr_ok_cache
 
 
 class AdvanceSymbolicExpr(SymbolicExpr):
@@ -2275,6 +2396,7 @@ SymbolicExpr.register_op_class(DotSymbolicExpr, ("dot",))
 SymbolicExpr.register_op_class(CumsumSymbolicExpr, ("cumsum",))
 SymbolicExpr.register_op_class(MakeBlockPtrSymbolicExpr, ("make_block_ptr",))
 SymbolicExpr.register_op_class(AddPtrSymbolicExpr, ("addptr",))
+SymbolicExpr.register_op_class(DescriptorAccessSymbolicExpr, ("descriptor_access",))
 SymbolicExpr.register_op_class(AdvanceSymbolicExpr, ("advance",))
 SymbolicExpr.register_op_class(SplatSymbolicExpr, ("splat",))
 SymbolicExpr.register_op_class(UnsplatSymbolicExpr, ("unsplat",))
@@ -2333,6 +2455,118 @@ _BINARY_NUMPY_TO_SYM_OP: dict[Callable[..., Any], str] = {
     np.right_shift: "right_shift",
     np.left_shift: "left_shift",
 }
+
+
+def symbolic_tensor_descriptor_value(
+    descriptor: Any,
+    *,
+    base: Any = None,
+    shape: Any = None,
+    strides: Any = None,
+    block_shape: Any = None,
+) -> SymbolicTensorDescriptorValue:
+    registered = _SYMBOLIC_TENSOR_DESCRIPTORS.get(descriptor)
+    if registered is not None:
+        return registered
+
+    if base is None:
+        base = descriptor.base
+        shape = descriptor.shape
+        strides = descriptor.strides
+        block_shape = descriptor.block_shape
+
+    value = SymbolicTensorDescriptorValue(
+        base=base,
+        shape=_shape_to_tuple(shape),
+        strides=_shape_to_tuple(strides),
+        block_shape=_shape_to_tuple(block_shape),
+        base_offset=int(getattr(descriptor, "base_offset", 0)),
+    )
+    # The weak-key registry follows the frontend descriptor object's lifetime.
+    _SYMBOLIC_TENSOR_DESCRIPTORS[descriptor] = value
+    return value
+
+
+def _descriptor_base_ptr(base: Any) -> SymbolicExpr:
+    if isinstance(base, Tensor):
+        dtype_name = str(base.dtype).removeprefix("torch.")
+        return SymbolicExpr.create(
+            "const",
+            int(base.data_ptr()),
+            pointer_type(DTYPE_BY_NAME.get(dtype_name, FLOAT32)),
+        )
+    return cast(SymbolicExpr, SymbolicExpr.from_value(base))
+
+
+def _descriptor_coords(coords: Any) -> tuple[Any, ...]:
+    if isinstance(coords, (tuple, list)) or _is_triton_tuple(coords):
+        return tuple(coords)
+    return (coords,)
+
+
+def _is_triton_tuple(value: Any) -> bool:
+    # Keep symbolic_engine import-light; importing triton.language here breaks
+    # clients that only need the shared symbolic model.
+    value_type = type(value)
+    return (
+        value_type.__module__ == "triton.language.core"
+        and value_type.__name__ == "tuple"
+    )
+
+
+def _descriptor_predicate_is_false(pred: Any) -> bool:
+    if pred is None:
+        return False
+    value = _literal_int(pred)
+    return value == 0
+
+
+def _predicate_bool(pred: Any) -> tuple[BoolRef | None, ConstraintConjunction]:
+    if pred is None:
+        return None, None
+    pred_expr = cast(SymbolicExpr, SymbolicExpr.from_value(pred))
+    pred_z3, pred_constraints = pred_expr.eval()
+    if isinstance(pred_z3, list):
+        pred_bool = Or(*(_constraint_to_bool(item) for item in pred_z3))
+    else:
+        pred_bool = _constraint_to_bool(pred_z3)
+    return pred_bool, pred_constraints
+
+
+def _descriptor_offset(
+    descriptor: SymbolicTensorDescriptorValue, coords: tuple[Any, ...]
+) -> Any:
+    offset: Any = SymbolicExpr.create("const", int(descriptor.base_offset), INT32)
+    for coord, stride in zip(coords, descriptor.strides):
+        term = coord
+        if stride != 1:
+            term = SymbolicExpr.create(
+                "mul", coord, SymbolicExpr.create("const", int(stride), INT32)
+            )
+        offset = SymbolicExpr.create("add", offset, term)
+    return offset
+
+
+def symbolic_tensor_descriptor_access(
+    descriptor: Any,
+    coords: Any,
+    *,
+    pred: Any = None,
+) -> SymbolicExpr:
+    descriptor_value = symbolic_tensor_descriptor_value(descriptor)
+    coord_values = _descriptor_coords(coords)
+
+    offset = _descriptor_offset(descriptor_value, coord_values)
+    base_ptr = _descriptor_base_ptr(descriptor_value.base)
+    return SymbolicExpr.create(
+        "descriptor_access",
+        base_ptr,
+        offset,
+        coord_values,
+        descriptor_value.shape,
+        descriptor_value.block_shape,
+        pred,
+    )
 
 
 @dataclass
@@ -2690,6 +2924,15 @@ class SymbolicClient(Client):
 
         return expr
 
+    def _symbolic_memory_ptr(self, ptr: Any) -> SymbolicExpr:
+        if isinstance(ptr, TensorDescriptorAccess):
+            return symbolic_tensor_descriptor_access(
+                ptr.descriptor,
+                ptr.coords,
+                pred=ptr.pred,
+            )
+        return cast(SymbolicExpr, SymbolicExpr.from_value(ptr))
+
     def _should_skip_loop_hooks(self) -> bool:
         """Return True to skip loop hook processing."""
         return False
@@ -2961,7 +3204,7 @@ class SymbolicClient(Client):
     def _op_load_overrider(self, ptr, mask, other, *args):
         ptr = self._materialize_memory_operand(ptr)
         mask = self._materialize_memory_operand(mask)
-        ptr_sym = SymbolicExpr.from_value(ptr)
+        ptr_sym = self._symbolic_memory_ptr(ptr)
         mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
         other_sym = SymbolicExpr.from_value(other) if other is not None else None
         ret = SymbolicExpr.create("load", ptr_sym, mask_sym, other_sym)
@@ -2972,7 +3215,7 @@ class SymbolicClient(Client):
     def _op_store_overrider(self, ptr, value, mask, *args):
         ptr = self._materialize_memory_operand(ptr)
         mask = self._materialize_memory_operand(mask)
-        ptr_sym = SymbolicExpr.from_value(ptr)
+        ptr_sym = self._symbolic_memory_ptr(ptr)
         value_sym = SymbolicExpr.from_value(value)
         mask_sym = SymbolicExpr.from_value(mask) if mask is not None else None
         ret = SymbolicExpr.create("store", ptr_sym, value_sym, mask_sym)
@@ -3117,11 +3360,11 @@ class SymbolicClient(Client):
                 self.arg_callback(f"{name}[{idx}]", item, None)
             self._cache_non_tensor_arg(name, tuple(type(item).__name__ for item in arg))
             return
+        if hasattr(arg, "base") and hasattr(arg.base, "data_ptr"):
+            arg = arg.base
         if not hasattr(arg, "data_ptr"):
             self._cache_non_tensor_arg(name, arg)
             return
-        if hasattr(arg, "base") and hasattr(arg.base, "data_ptr"):
-            arg = arg.base
         tensor_physical_addresses = self._tensor_physical_addresses(name, arg)
         self._record_tensor_name(arg, name)
         self._cache_tensor_arg(arg)

--- a/triton_viz/core/frontend/base.py
+++ b/triton_viz/core/frontend/base.py
@@ -21,6 +21,10 @@ class _LangPatchScope:
         self._changes.append(("attr", obj, name, original))
         setattr(obj, name, value)
 
+    def save_attr(self, obj: object, name: str) -> None:
+        original = getattr(obj, name, _MISSING)
+        self._changes.append(("attr", obj, name, original))
+
     def set_item(self, mapping: dict[str, Any], key: str, value: object) -> None:
         original = mapping.get(key, _MISSING)
         self._changes.append(("item", mapping, key, original))
@@ -36,7 +40,8 @@ class _LangPatchScope:
                 else:
                     mapping[name] = original
             elif original is _MISSING:
-                delattr(obj, name)
+                if hasattr(obj, name):
+                    delattr(obj, name)
             else:
                 setattr(obj, name, original)
 

--- a/triton_viz/core/frontend/gluon.py
+++ b/triton_viz/core/frontend/gluon.py
@@ -1,0 +1,467 @@
+from collections.abc import Callable
+from typing import Any
+
+import numpy as np
+import triton.language as tl
+import triton.experimental.gluon.language as gluon_lang  # type: ignore
+from triton.experimental.gluon.language import _core as gluon_core  # type: ignore
+from triton.experimental.gluon.language import _math as gluon_math  # type: ignore
+from triton.experimental.gluon.language import _semantic as gluon_semantic  # type: ignore
+from triton.experimental.gluon.language.amd.gfx1250 import (  # type: ignore
+    tdm as gluon_amd_tdm,
+)
+from triton.experimental.gluon.language.nvidia.blackwell import (  # type: ignore
+    tma as gluon_blackwell_tma,
+)
+from triton.experimental.gluon.language.nvidia.hopper import (  # type: ignore
+    tma as gluon_hopper_tma,
+)
+
+from ..data import (
+    AddPtr,
+    Allocate,
+    BinaryOp,
+    Broadcast,
+    Dot,
+    ExpandDims,
+    Fma,
+    Join,
+    Load,
+    MakeRange,
+    Op,
+    ProgramId,
+    Reshape,
+    Rsqrt,
+    Splat,
+    Store,
+    TernaryOp,
+    UnaryOp,
+)
+from ..symbolic_metadata import (
+    INT32,
+    SymbolicTensorValue,
+    SymbolicTypeSpec,
+    TensorDescriptorAccess,
+)
+
+from .base import AdapterResult, Frontend, _LangPatchScope, register_frontend
+from .triton import TritonFrontend
+
+
+def _gluon_load_adapter(
+    ptr: Any,
+    *_args: Any,
+    mask: Any = None,
+    other: Any = None,
+    pred: Any = None,
+    **_kwargs: Any,
+) -> AdapterResult:
+    if mask is None:
+        mask = pred
+    if _is_global_tensor_descriptor_like(ptr) and _args:
+        return AdapterResult(TensorDescriptorAccess(ptr, _args[0], mask), mask, None)
+    if mask is None and not _is_descriptor_like(ptr):
+        if _args:
+            mask = _args[0]
+    return AdapterResult(ptr, mask, None)
+
+
+def _gluon_descriptor_load_adapter(
+    pred_arg_index: int,
+) -> Callable[..., AdapterResult]:
+    def adapter(
+        ptr: Any,
+        *_args: Any,
+        mask: Any = None,
+        pred: Any = None,
+        **_kwargs: Any,
+    ) -> AdapterResult:
+        if mask is None:
+            mask = pred
+        if mask is None and len(_args) > pred_arg_index:
+            mask = _args[pred_arg_index]
+        if _is_global_tensor_descriptor_like(ptr) and _args:
+            return AdapterResult(
+                TensorDescriptorAccess(ptr, _args[0], mask), mask, None
+            )
+        return _gluon_load_adapter(ptr, *_args, mask=mask)
+
+    return adapter
+
+
+def _set_descriptor_load_adapter(op: Callable, pred_arg_index: int) -> None:
+    GLUON_CALLABLE_ADAPTERS[op] = _gluon_descriptor_load_adapter(pred_arg_index)
+
+
+def _gluon_store_adapter(
+    ptr: Any,
+    value: Any = None,
+    *_args: Any,
+    mask: Any = None,
+    pred: Any = None,
+    **_kwargs: Any,
+) -> AdapterResult:
+    if mask is None:
+        mask = pred
+    if _is_global_tensor_descriptor_like(ptr) and value is not None:
+        return AdapterResult(TensorDescriptorAccess(ptr, value, mask), mask, None)
+    if mask is None and not _is_descriptor_like(ptr):
+        if _args:
+            mask = _args[0]
+    return AdapterResult(ptr, mask, None)
+
+
+def _is_descriptor_like(value: Any) -> bool:
+    type_name = type(value).__name__
+    return type_name in {
+        "shared_memory_descriptor",
+        "tensor_descriptor",
+        "tensor_descriptor_im2col",
+        "TensorDescriptor",
+        "TensorDescriptorIm2Col",
+    } or hasattr(value, "block_shape")
+
+
+def _is_shared_memory_descriptor_like(value: Any) -> bool:
+    return type(value).__name__ == "shared_memory_descriptor"
+
+
+def _is_global_tensor_descriptor_like(value: Any) -> bool:
+    # Shared-memory descriptor accesses are not modeled yet; only global tensor
+    # descriptors become TensorDescriptorAccess records for symbolic checking.
+    return _is_descriptor_like(value) and not _is_shared_memory_descriptor_like(value)
+
+
+def _gluon_binary_adapter(
+    lhs: Any,
+    rhs: Any,
+    *_args: Any,
+    **_kwargs: Any,
+) -> AdapterResult:
+    return AdapterResult(lhs, rhs)
+
+
+def _gluon_unary_adapter(arg: Any, *_args: Any, **_kwargs: Any) -> AdapterResult:
+    return AdapterResult(arg)
+
+
+def _gluon_binary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
+    def adapter(lhs: Any, rhs: Any, *_args: Any, **_kwargs: Any) -> AdapterResult:
+        return AdapterResult(lhs, rhs, op)
+
+    return adapter
+
+
+def _gluon_unary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
+    def adapter(arg: Any, *_args: Any, **_kwargs: Any) -> AdapterResult:
+        return AdapterResult(arg, op)
+
+    return adapter
+
+
+def _gluon_where_adapter(
+    condition: Any,
+    x: Any,
+    y: Any,
+    *_args: Any,
+    **_kwargs: Any,
+) -> AdapterResult:
+    return AdapterResult(condition, x, y, np.where)
+
+
+def _gluon_allocate_adapter(*args: Any, **_kwargs: Any) -> AdapterResult:
+    return AdapterResult(*args[:4])
+
+
+def _gluon_make_range_adapter(start: Any, end: Any, *_args: Any, **_kwargs: Any):
+    start_value = int(start)
+    end_value = int(end)
+    return AdapterResult(
+        SymbolicTypeSpec(INT32, (end_value - start_value,)), start_value, end_value
+    )
+
+
+def _gluon_semantic_addptr_adapter(
+    _semantic: Any,
+    lhs: Any,
+    rhs: Any,
+    *_args: Any,
+    **_kwargs: Any,
+) -> AdapterResult:
+    return AdapterResult(lhs, rhs)
+
+
+def _gluon_semantic_binary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
+    def adapter(
+        _semantic: Any,
+        lhs: Any,
+        rhs: Any,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AdapterResult:
+        return AdapterResult(lhs, rhs, op)
+
+    return adapter
+
+
+def _existing_ops(namespace: Any, attrs: dict[str, type[Op]]) -> dict[str, type[Op]]:
+    if namespace is None:
+        return {}
+    return {
+        attr: op_type for attr, op_type in attrs.items() if hasattr(namespace, attr)
+    }
+
+
+GLUON_CORE_OPS: dict[str, type[Op]] = {
+    "program_id": ProgramId,
+    "load": Load,
+    "store": Store,
+    "arange": MakeRange,
+    "full": Splat,
+    "dot_fma": Dot,
+    "expand_dims": ExpandDims,
+    "reshape": Reshape,
+    "broadcast": Broadcast,
+    "join": Join,
+    "add": BinaryOp,
+    "sub": BinaryOp,
+    "mul": BinaryOp,
+    "where": TernaryOp,
+}
+
+
+GLUON_MATH_OPS: dict[str, type[Op]] = {
+    "exp": UnaryOp,
+    "exp2": UnaryOp,
+    "fma": Fma,
+    "log": UnaryOp,
+    "log2": UnaryOp,
+    "cos": UnaryOp,
+    "rsqrt": Rsqrt,
+    "sin": UnaryOp,
+    "sqrt": UnaryOp,
+    "abs": UnaryOp,
+    "floor": UnaryOp,
+    "ceil": UnaryOp,
+}
+
+
+GLUON_NAMESPACES: dict[Any, dict[str, type[Op]]] = {
+    gluon_core: dict(GLUON_CORE_OPS),
+    gluon_lang: dict(GLUON_CORE_OPS),
+    gluon_math: GLUON_MATH_OPS,
+    gluon_semantic.GluonSemantic: {
+        "add": AddPtr,
+        "less_than": BinaryOp,
+        "less_equal": BinaryOp,
+        "greater_than": BinaryOp,
+        "greater_equal": BinaryOp,
+    },
+}
+_TMA_NAMESPACES: tuple[tuple[Any, dict[str, type[Op]]], ...] = (
+    (
+        gluon_hopper_tma,
+        {
+            "make_tensor_descriptor": Allocate,
+            "async_load": Load,
+            "async_load_im2col": Load,
+            "async_store": Store,
+            "async_copy_global_to_shared": Load,
+            "async_copy_global_to_shared_im2col": Load,
+            "async_copy_shared_to_global": Store,
+            "async_atomic_add": Store,
+            "async_atomic_min": Store,
+            "async_atomic_max": Store,
+            "async_atomic_and": Store,
+            "async_atomic_or": Store,
+            "async_atomic_xor": Store,
+        },
+    ),
+    (
+        gluon_blackwell_tma,
+        {
+            "make_tensor_descriptor": Allocate,
+            "async_load": Load,
+            "async_load_im2col": Load,
+            "async_store": Store,
+            "async_copy_global_to_shared": Load,
+            "async_copy_global_to_shared_im2col": Load,
+            "async_copy_shared_to_global": Store,
+            "async_atomic_add": Store,
+            "async_atomic_min": Store,
+            "async_atomic_max": Store,
+            "async_atomic_and": Store,
+            "async_atomic_or": Store,
+            "async_atomic_xor": Store,
+        },
+    ),
+    (
+        gluon_amd_tdm,
+        {
+            "make_tensor_descriptor": Allocate,
+            "update_tensor_descriptor": Allocate,
+            "async_load": Load,
+            "async_store": Store,
+        },
+    ),
+)
+for namespace, attrs in _TMA_NAMESPACES:
+    existing = _existing_ops(namespace, attrs)
+    if existing:
+        GLUON_NAMESPACES[namespace] = existing
+
+_GLUON_BINARY_NUMPY_OPS: dict[str, Callable] = {
+    "add": np.add,
+    "sub": np.subtract,
+    "mul": np.multiply,
+}
+_GLUON_UNARY_NUMPY_OPS: dict[str, Callable] = {
+    "abs": np.abs,
+    "ceil": np.ceil,
+    "cos": np.cos,
+    "exp": np.exp,
+    "exp2": np.exp2,
+    "floor": np.floor,
+    "log": np.log,
+    "log2": np.log2,
+    "sin": np.sin,
+    "sqrt": np.sqrt,
+}
+_TMA_LOAD_PRED_ARG_INDICES: dict[str, int] = {
+    "async_load": 3,
+    "async_load_im2col": 4,
+    "async_copy_global_to_shared": 3,
+    "async_copy_global_to_shared_im2col": 4,
+}
+GLUON_CALLABLE_ADAPTERS: dict[Callable, Callable[..., AdapterResult]] = {}
+for namespace, attrs in GLUON_NAMESPACES.items():
+    for attr, op_type in attrs.items():
+        original = getattr(namespace, attr)
+        if op_type is BinaryOp and attr in _GLUON_BINARY_NUMPY_OPS:
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_binary_op_adapter(
+                _GLUON_BINARY_NUMPY_OPS[attr]
+            )
+        elif op_type is UnaryOp and attr in _GLUON_UNARY_NUMPY_OPS:
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_unary_op_adapter(
+                _GLUON_UNARY_NUMPY_OPS[attr]
+            )
+        if namespace is gluon_amd_tdm and attr == "async_load":
+            _set_descriptor_load_adapter(original, 2)
+        elif attr in _TMA_LOAD_PRED_ARG_INDICES:
+            _set_descriptor_load_adapter(original, _TMA_LOAD_PRED_ARG_INDICES[attr])
+
+GLUON_ADAPTERS: dict[type[Op], Callable[..., AdapterResult]] = {
+    ProgramId: lambda axis, *_args, **_kwargs: AdapterResult(axis),
+    Load: _gluon_load_adapter,
+    Store: _gluon_store_adapter,
+    MakeRange: _gluon_make_range_adapter,
+    Splat: lambda shape, value, *_args, **_kwargs: AdapterResult(shape, value),
+    Allocate: _gluon_allocate_adapter,
+    Dot: lambda a, b, acc, *_args, **_kwargs: AdapterResult(a, b, acc, None, None),
+    BinaryOp: _gluon_binary_adapter,
+    AddPtr: _gluon_binary_adapter,
+    UnaryOp: _gluon_unary_adapter,
+    TernaryOp: _gluon_where_adapter,
+    Fma: lambda x, y, z, *_args, **_kwargs: AdapterResult(x, y, z),
+    Rsqrt: lambda arg, *_args, **_kwargs: AdapterResult(arg),
+}
+GLUON_CALLABLE_ADAPTERS[
+    getattr(gluon_semantic.GluonSemantic, "add")
+] = _gluon_semantic_addptr_adapter
+_GLUON_SEMANTIC_BINARY_NUMPY_OPS: dict[str, Callable] = {
+    "less_than": np.less,
+    "less_equal": np.less_equal,
+    "greater_than": np.greater,
+    "greater_equal": np.greater_equal,
+}
+for attr, op in _GLUON_SEMANTIC_BINARY_NUMPY_OPS.items():
+    GLUON_CALLABLE_ADAPTERS[
+        getattr(gluon_semantic.GluonSemantic, attr)
+    ] = _gluon_semantic_binary_op_adapter(op)
+
+
+class GluonFrontend(Frontend):
+    def __init__(self):
+        definition = Frontend.from_namespaces(
+            name="gluon",
+            builder=None,
+            namespaces=GLUON_NAMESPACES,
+            adapters=GLUON_ADAPTERS,
+        )
+        super().__init__(
+            name=definition.name,
+            builder=definition.builder,
+            original_ops=definition.original_ops,
+            adapters=definition.adapters,
+            namespaces=definition.namespaces,
+        )
+
+    @staticmethod
+    def symbolic_ops_for_op_type(op_type: type[Op]) -> tuple[str, ...]:
+        return TritonFrontend.symbolic_ops_for_op_type(op_type)
+
+    def run_op_overrider(
+        self,
+        op: Callable,
+        op_type: type[Op],
+        op_overrider: Callable,
+        args: tuple[Any, ...],
+        kwargs: dict[str, Any],
+    ):
+        adapter = GLUON_CALLABLE_ADAPTERS.get(op, self.adapters[op_type])
+        adapter_result = adapter(*args, **kwargs)
+        return op_overrider(*adapter_result.args, **adapter_result.kwargs)
+
+    def normalize_symbolic_value(self, value: Any) -> Any:
+        if type(value).__name__ == "constexpr" and hasattr(value, "value"):
+            return value.value
+        if isinstance(value, gluon_core.tensor):
+            value = value.handle
+        if isinstance(value, (tl.block_type, tl.pointer_type, tl.core.dtype)):
+            return TritonFrontend._normalize_triton_type(value)
+        if isinstance(value, SymbolicTensorValue):
+            return value
+        return super().normalize_symbolic_value(value)
+
+    def to_frontend_symbolic_value(self, value: Any) -> Any:
+        if isinstance(value, tuple):
+            return tuple(self.to_frontend_symbolic_value(item) for item in value)
+        if isinstance(value, list):
+            return [self.to_frontend_symbolic_value(item) for item in value]
+        return value
+
+    def from_frontend_symbolic_value(self, value: Any) -> Any:
+        if isinstance(value, gluon_core.tensor):
+            value = value.handle
+        if isinstance(value, tuple):
+            return tuple(self.from_frontend_symbolic_value(item) for item in value)
+        if isinstance(value, list):
+            return [self.from_frontend_symbolic_value(item) for item in value]
+        return value
+
+    def wrap_symbolic_concrete_fn(self, concrete_fn: Callable) -> Callable:
+        def wrapped(*args: Any, **kwargs: Any) -> Any:
+            frontend_args = tuple(self.to_frontend_symbolic_value(arg) for arg in args)
+            frontend_kwargs = {
+                key: self.to_frontend_symbolic_value(value)
+                for key, value in kwargs.items()
+            }
+            ret = concrete_fn(*frontend_args, **frontend_kwargs)
+            return self.from_frontend_symbolic_value(ret)
+
+        return wrapped
+
+    def patch_lang(self, fn, client_manager: Any = None) -> _LangPatchScope:
+        scope = _LangPatchScope()
+        globals_dict = getattr(fn, "__globals__", {})
+        for namespace, attrs in self.namespaces.items():
+            for attr in attrs:
+                original = self.original_ops[namespace][attr]
+                patched = getattr(namespace, attr)
+                for name, value in list(globals_dict.items()):
+                    if value is original:
+                        scope.set_item(globals_dict, name, patched)
+        return scope
+
+
+frontend = register_frontend(GluonFrontend())

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -443,8 +443,7 @@ class TritonFrontend(Frontend):
             for name in builtin_names:
                 scope.set_attr(obj, name, getattr(obj, name))
             for attr in attrs:
-                if hasattr(obj, attr):
-                    scope.set_attr(obj, attr, getattr(obj, attr))
+                scope.save_attr(obj, attr)
 
         return scope
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from contextlib import contextmanager
+from functools import wraps
 from typing import Any
 
 from .frontend.base import AdapterResult, LANG_PATCH_SCOPES
@@ -46,7 +47,21 @@ class PatchOp:
         self.run_op_overrider = run_op_overrider
 
     def __getattr__(self, name: str) -> Any:
+        # Module-level patched ops are PatchOp instances; preserve access to
+        # attributes exposed by the original callable.
         return getattr(self.op, name)
+
+    def __get__(self, instance: Any, owner: type | None = None) -> Any:
+        # PatchOp can be installed on classes, e.g. Gluon shared-memory
+        # descriptor methods. Preserve normal method binding so self is passed.
+        if instance is None:
+            return self
+
+        @wraps(self.op)
+        def bound(*args: Any, **kwargs: Any) -> Any:
+            return self(instance, *args, **kwargs)
+
+        return bound
 
     def __call__(self, *args, **kwargs):
         self.maybe_yield_for_multism()

--- a/triton_viz/core/symbolic_metadata.py
+++ b/triton_viz/core/symbolic_metadata.py
@@ -75,6 +75,13 @@ class ConcreteAccessRoute:
     range_info: ConcreteRangeInfo
 
 
+@dataclass(frozen=True)
+class TensorDescriptorAccess:
+    descriptor: Any
+    coords: Any
+    pred: Any = None
+
+
 INT1 = SymbolicScalarDType("int1", 1, np.dtype(bool))
 INT8 = SymbolicScalarDType("int8", 8, np.dtype(np.int8))
 INT16 = SymbolicScalarDType("int16", 16, np.dtype(np.int16))

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -9,6 +9,7 @@ from ..clients.race_detector.race_detector import NullRaceDetector
 from .client import ClientManager, Client
 from .data import Launch
 import types
+import inspect
 
 
 launches: list[Launch] = []
@@ -281,6 +282,88 @@ class NKITrace(LaunchInterface, TraceInterface):
             return ret
 
 
+class GluonTrace(LaunchInterface, TraceInterface):
+    def __init__(self, runner: Any, client: str | Client) -> None:
+        from triton.experimental import gluon
+
+        # Gluon has exposed different JIT class names across Triton versions.
+        # Treat an object that already has the JIT runner protocol as compiled,
+        # and only call gluon.jit for raw Python functions.
+        if not all(hasattr(runner, attr) for attr in ("fn", "run", "arg_names")):
+            runner = gluon.jit(runner)
+
+        self.runner = runner
+        self.fn = runner
+        self.base_fn = runner.fn
+        self.arg_names = runner.arg_names
+
+        TraceInterface.__init__(self, client)
+
+        for attr in ("__name__", "__module__", "__doc__", "__qualname__"):
+            if hasattr(runner, attr):
+                setattr(self, attr, getattr(runner, attr))
+            elif hasattr(self.base_fn, attr):
+                setattr(self, attr, getattr(self.base_fn, attr))
+
+        if hasattr(runner, "src"):
+            self.src = runner.src
+
+    def _bound_call_args(
+        self, args: tuple[Any, ...], kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
+        try:
+            return inspect.getcallargs(self.base_fn, *args, **kwargs)
+        except TypeError:
+            bound = {name: arg for name, arg in zip(self.arg_names, args)}
+            bound.update(kwargs)
+            return bound
+
+    @staticmethod
+    def _canonical_grid(grid: Any, bound_args: dict[str, Any]) -> tuple[int, int, int]:
+        if callable(grid):
+            grid = grid(bound_args)
+        if isinstance(grid, int):
+            grid = (grid,)
+        grid = tuple(int(dim) for dim in grid)
+        if len(grid) > 3:
+            raise ValueError(
+                f"Expected Gluon launch grid with at most 3 dims, got {grid}"
+            )
+        return grid + (1,) * (3 - len(grid))
+
+    def run(self, *args, **kwargs):
+        grid = kwargs.get("grid")
+        if grid is None:
+            raise TypeError(
+                "GluonTrace.run() missing required keyword argument: 'grid'"
+            )
+
+        launch_kwargs = dict(kwargs)
+        launch_kwargs.pop("warmup", None)
+        launch_kwargs.pop("grid", None)
+        bound_args = self._bound_call_args(args, launch_kwargs)
+        canonical_grid = self._canonical_grid(grid, bound_args)
+
+        for name, arg in bound_args.items():
+            self.client_manager.arg_callback(name, arg, None)
+        self.client_manager.grid_callback(canonical_grid)
+        self.client_manager.grid_idx_callback((0, 0, 0))
+
+        with self.client_manager.patch_run(self.base_fn, frontend_name="gluon"):
+            try:
+                ret = self.runner.run(*args, **kwargs)
+            finally:
+                self.client_manager.post_run_callback(self.base_fn)
+            self.finalize()
+            return ret
+
+    def __call__(self, *args, **kwargs):
+        return self.runner(*args, **kwargs)
+
+    def warmup(self, *args, **kwargs):
+        return self.run(*args, warmup=True, **kwargs)
+
+
 def trace_source(kernel):
     """
     Add the kernel code to be traceable within stack traces for clients
@@ -326,7 +409,7 @@ def trace(client: str | Client | None = None, frontend: str = "triton"):
         # test_flag_off_does_not_swallow_explicit_instance.
         return isinstance(selected, NullRaceDetector)
 
-    def decorator(kernel) -> TritonTrace | NKITrace | Any:
+    def decorator(kernel) -> TritonTrace | NKITrace | GluonTrace | Any:
         if cfg.cli_active and isinstance(kernel, TraceInterface):
             raise RuntimeError(
                 "@triton_viz.trace() decorator cannot be used together with "
@@ -356,6 +439,8 @@ def trace(client: str | Client | None = None, frontend: str = "triton"):
         # First-time wrapping
         if frontend in ("nki", "nki_beta2"):
             return NKITrace(kernel, client, beta2=("beta2" in frontend))
+        elif frontend == "gluon":
+            return GluonTrace(kernel, client)
         elif frontend == "triton":
             return TritonTrace(kernel, client)
         else:

--- a/triton_viz/wrapper.py
+++ b/triton_viz/wrapper.py
@@ -5,7 +5,8 @@ import sys
 import pytest
 import triton
 import triton_viz
-from triton_viz.clients import Sanitizer, Profiler, RaceDetector
+from triton.experimental import gluon as _gluon
+from triton_viz.clients import Profiler, RaceDetector, Sanitizer
 from triton_viz.core.config import config as cfg
 
 
@@ -17,36 +18,40 @@ RACE_DETECTOR_COMMAND = "triton-race-detector"
 # store the original triton.jit
 _original_jit = triton.jit
 _original_autotune = triton.autotune
+_original_gluon_jit = _gluon.jit
 
 
-def sanitizer_wrapper(kernel):
+def sanitizer_wrapper(kernel, *, frontend: str = "triton"):
     abort_on_error = True
-    tracer = triton_viz.trace(client=Sanitizer(abort_on_error=abort_on_error))
+    tracer = triton_viz.trace(
+        client=Sanitizer(abort_on_error=abort_on_error),
+        frontend=frontend,
+    )
     return tracer(kernel)
 
 
-def profiler_wrapper(kernel):
-    tracer = triton_viz.trace(client=Profiler())
+def profiler_wrapper(kernel, *, frontend: str = "triton"):
+    tracer = triton_viz.trace(client=Profiler(), frontend=frontend)
     return tracer(kernel)
 
 
-def race_detector_wrapper(kernel):
-    tracer = triton_viz.trace(client=RaceDetector())
+def race_detector_wrapper(kernel, *, frontend: str = "triton"):
+    tracer = triton_viz.trace(client=RaceDetector(), frontend=frontend)
     return tracer(kernel)
 
 
-def create_patched_jit(wrapper_func):
+def create_patched_jit(wrapper_func, original_jit, *, frontend: str):
     def _patched_jit(fn=None, **jit_kw):
         if fn is None:  # @triton.jit(**opts)
 
             def _decorator(f):
-                k = _original_jit(**jit_kw)(f)
-                return wrapper_func(k)
+                k = original_jit(**jit_kw)(f)
+                return wrapper_func(k, frontend=frontend)
 
             return _decorator
         else:  # @triton.jit
-            k = _original_jit(fn)
-            return wrapper_func(k)
+            k = original_jit(fn)
+            return wrapper_func(k, frontend=frontend)
 
     return _patched_jit
 
@@ -79,19 +84,27 @@ def _apply_wrapper(wrapper_func, command_name, usage_msg):
 
     cfg.cli_active = True
 
-    # Create patched functions with the specific wrapper
-    _patched_jit = create_patched_jit(wrapper_func)
+    # Patch Triton kernels with the Triton frontend.
+    _patched_jit = create_patched_jit(
+        wrapper_func,
+        _original_jit,
+        frontend="triton",
+    )
     _patched_autotune = create_patched_autotune(wrapper_func)
 
-    # patching the original triton.jit
     triton.jit = _patched_jit
     triton.language.jit = _patched_jit
     import triton.runtime.interpreter as _interp
 
     _interp.jit = _patched_jit
-
-    # patching triton.autotune
     triton.autotune = _patched_autotune
+
+    # Patch Gluon kernels with the Gluon frontend.
+    _gluon.jit = create_patched_jit(
+        wrapper_func,
+        _original_gluon_jit,
+        frontend="gluon",
+    )
 
     # run user script
     if len(sys.argv) < 2:


### PR DESCRIPTION
## Summary
- Add Gluon frontend tracing/sanitizer integration and wrapper `gluon.jit` patching.
- Add Gluon op adapters, including descriptor/TMA load/store handling and positional TMA predicate support.
- Extend symbolic sanitizer descriptor-access modeling for TMA OOB checks, including descriptors created inside kernels.
- Add a Gluon TMA OOB sanitizer example and focused unit/e2e coverage.

## Validation
- `pre-commit run -a`
- `python -m pytest tests/unit/test_adapters.py tests/unit/test_wrapper.py tests/unit/test_sanitizer.py tests/unit/test_symbolic_client.py -q`
- `python -m pytest tests/end_to_end/test_core.py tests/end_to_end/test_race_detector.py -q`
- `CUDA_VISIBLE_DEVICES='' python -m pytest tests/end_to_end/test_gluon.py --collect-only -q`