### PR TITLE
[REFACTOR] Clean up Gluon load adapters

### DIFF
--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -182,6 +182,23 @@ def test_program_id_adapter_returns_axis_only():
 def test_gluon_descriptor_memory_adapters_accept_async_signatures():
     load = GLUON_ADAPTERS[Load]
     store = GLUON_ADAPTERS[Store]
+    from triton_viz.core.frontend import gluon as gluon_frontend
+
+    normal_descriptor_load = gluon_frontend._gluon_descriptor_load_adapter(
+        3,
+        descriptor_kwarg="tensor_desc",
+        coords_kwarg="coord",
+    )
+    im2col_descriptor_load = gluon_frontend._gluon_descriptor_load_adapter(
+        4,
+        descriptor_kwarg="tensor_desc",
+        coords_kwarg="coord",
+    )
+    tdm_descriptor_load = gluon_frontend._gluon_descriptor_load_adapter(
+        2,
+        descriptor_kwarg="src",
+        coords_kwarg="offsets",
+    )
     desc = type("TensorDescriptor", (), {"block_shape": (1,)})()
 
     def assert_descriptor_access(result, coords, mask=None):
@@ -193,10 +210,17 @@ def test_gluon_descriptor_memory_adapters_accept_async_signatures():
         assert other is None
 
     assert load("ptr", "mask").args == ("ptr", "mask", None)
-    assert_descriptor_access(load(desc, "coord", "bar", "result"), "coord")
-    assert_descriptor_access(load(desc, "coord", "bar", "result", "pred"), "coord")
     assert_descriptor_access(
-        load(
+        normal_descriptor_load(desc, "coord", "bar", "result"),
+        "coord",
+    )
+    assert_descriptor_access(
+        normal_descriptor_load(desc, "coord", "bar", "result", "pred"),
+        "coord",
+        "pred",
+    )
+    assert_descriptor_access(
+        im2col_descriptor_load(
             desc,
             "coord",
             "offsets",
@@ -205,13 +229,40 @@ def test_gluon_descriptor_memory_adapters_accept_async_signatures():
             "pred",
         ),
         "coord",
+        "pred",
     )
-    assert_descriptor_access(load(desc, "offsets", "dest"), "offsets")
-    assert_descriptor_access(load(desc, "offsets", "dest", "pred"), "offsets")
     assert_descriptor_access(
-        load(desc, "coord", "bar", "result", pred="pred"),
+        tdm_descriptor_load(desc, "offsets", "dest"),
+        "offsets",
+    )
+    assert_descriptor_access(
+        tdm_descriptor_load(desc, "offsets", "dest", "pred"),
+        "offsets",
+        "pred",
+    )
+    assert_descriptor_access(
+        normal_descriptor_load(desc, "coord", "bar", "result", pred="pred"),
         "coord",
         "pred",
+    )
+    assert_descriptor_access(
+        normal_descriptor_load(desc, coord="kw_coord", barrier="bar", result="result"),
+        "kw_coord",
+    )
+    assert_descriptor_access(
+        normal_descriptor_load(
+            tensor_desc=desc,
+            coord="kw_coord",
+            barrier="bar",
+            result="result",
+            pred="kw_pred",
+        ),
+        "kw_coord",
+        "kw_pred",
+    )
+    assert_descriptor_access(
+        tdm_descriptor_load(src=desc, offsets="kw_offsets", dest="dest"),
+        "kw_offsets",
     )
 
     assert store("ptr", "value", "mask").args == ("ptr", "mask", None)
@@ -231,9 +282,21 @@ def test_gluon_descriptor_load_adapters_honor_positional_predicates():
     from triton_viz.core.frontend import gluon as gluon_frontend
 
     desc = type("TensorDescriptor", (), {"block_shape": (1,)})()
-    normal_load = gluon_frontend._gluon_descriptor_load_adapter(3)
-    im2col_load = gluon_frontend._gluon_descriptor_load_adapter(4)
-    tdm_load = gluon_frontend._gluon_descriptor_load_adapter(2)
+    normal_load = gluon_frontend._gluon_descriptor_load_adapter(
+        3,
+        descriptor_kwarg="tensor_desc",
+        coords_kwarg="coord",
+    )
+    im2col_load = gluon_frontend._gluon_descriptor_load_adapter(
+        4,
+        descriptor_kwarg="tensor_desc",
+        coords_kwarg="coord",
+    )
+    tdm_load = gluon_frontend._gluon_descriptor_load_adapter(
+        2,
+        descriptor_kwarg="src",
+        coords_kwarg="offsets",
+    )
 
     access, mask, other = normal_load(desc, "coord", "barrier", "result", False).args
     assert access.pred is False
@@ -260,10 +323,10 @@ def test_gluon_descriptor_load_adapters_honor_positional_predicates():
     assert other is None
 
 
-def test_gluon_shared_memory_descriptor_is_not_patched():
+def test_gluon_shared_memory_descriptor_class_is_not_an_op():
     from triton.experimental.gluon.language import _core as gluon_core
 
-    assert gluon_core.shared_memory_descriptor not in GLUON_FRONTEND.namespaces
+    assert "shared_memory_descriptor" not in GLUON_FRONTEND.namespaces[gluon_core]
 
 
 def test_gluon_load_store_adapters_keep_first_positional_mask():
@@ -282,14 +345,26 @@ def test_gluon_load_store_adapters_keep_first_positional_mask():
     )
 
 
-def test_gluon_frontend_routes_tensor_descriptor_access_to_overrider():
+def test_gluon_load_adapter_does_not_treat_pred_as_mask():
+    from triton_viz.core.frontend import gluon as gluon_frontend
+
+    assert gluon_frontend._gluon_load_adapter("ptr", pred="pred").args == (
+        "ptr",
+        None,
+        None,
+    )
+
+
+def test_gluon_frontend_routes_tensor_descriptor_access_to_overrider(monkeypatch):
+    from triton_viz.core.frontend import gluon as gluon_frontend
+
     class FakeTensor:
         dtype = "float32"
 
         def data_ptr(self):
             return 4096
 
-    class FakeDescriptor:
+    class TensorDescriptor:
         base = FakeTensor()
         shape = (4, 4)
         strides = (4, 1)
@@ -304,7 +379,17 @@ def test_gluon_frontend_routes_tensor_descriptor_access_to_overrider():
         calls.append((ptr, mask, other))
         return "overridden"
 
-    desc = FakeDescriptor()
+    monkeypatch.setitem(
+        gluon_frontend.GLUON_CALLABLE_ADAPTERS,
+        original,
+        gluon_frontend._gluon_descriptor_load_adapter(
+            1,
+            descriptor_kwarg="desc",
+            coords_kwarg="coords",
+        ),
+    )
+
+    desc = TensorDescriptor()
     result = GLUON_FRONTEND.run_op_overrider(
         original,
         Load,

--- a/triton_viz/core/frontend/gluon.py
+++ b/triton_viz/core/frontend/gluon.py
@@ -53,44 +53,37 @@ def _gluon_load_adapter(
     *_args: Any,
     mask: Any = None,
     other: Any = None,
-    pred: Any = None,
     **_kwargs: Any,
 ) -> AdapterResult:
-    if mask is None:
-        mask = pred
-    if _is_global_tensor_descriptor_like(ptr) and _args:
-        return AdapterResult(TensorDescriptorAccess(ptr, _args[0], mask), mask, None)
-    if mask is None and not _is_descriptor_like(ptr):
-        if _args:
-            mask = _args[0]
+    if mask is None and _args:
+        mask = _args[0]
     return AdapterResult(ptr, mask, None)
 
 
 def _gluon_descriptor_load_adapter(
     pred_arg_index: int,
+    *,
+    descriptor_kwarg: str,
+    coords_kwarg: str,
 ) -> Callable[..., AdapterResult]:
     def adapter(
-        ptr: Any,
-        *_args: Any,
+        *args: Any,
         mask: Any = None,
         pred: Any = None,
-        **_kwargs: Any,
+        **kwargs: Any,
     ) -> AdapterResult:
         if mask is None:
             mask = pred
-        if mask is None and len(_args) > pred_arg_index:
-            mask = _args[pred_arg_index]
-        if _is_global_tensor_descriptor_like(ptr) and _args:
-            return AdapterResult(
-                TensorDescriptorAccess(ptr, _args[0], mask), mask, None
-            )
-        return _gluon_load_adapter(ptr, *_args, mask=mask)
+        load_args = args[1:] if args else ()
+        if mask is None and len(load_args) > pred_arg_index:
+            mask = load_args[pred_arg_index]
+        descriptor = args[0] if args else kwargs[descriptor_kwarg]
+        coords = load_args[0] if load_args else kwargs[coords_kwarg]
+        return AdapterResult(
+            TensorDescriptorAccess(descriptor, coords, mask), mask, None
+        )
 
     return adapter
-
-
-def _set_descriptor_load_adapter(op: Callable, pred_arg_index: int) -> None:
-    GLUON_CALLABLE_ADAPTERS[op] = _gluon_descriptor_load_adapter(pred_arg_index)
 
 
 def _gluon_store_adapter(
@@ -105,21 +98,14 @@ def _gluon_store_adapter(
         mask = pred
     if _is_global_tensor_descriptor_like(ptr) and value is not None:
         return AdapterResult(TensorDescriptorAccess(ptr, value, mask), mask, None)
-    if mask is None and not _is_descriptor_like(ptr):
+    if (
+        mask is None
+        and not _is_global_tensor_descriptor_like(ptr)
+        and not _is_shared_memory_descriptor_like(ptr)
+    ):
         if _args:
             mask = _args[0]
     return AdapterResult(ptr, mask, None)
-
-
-def _is_descriptor_like(value: Any) -> bool:
-    type_name = type(value).__name__
-    return type_name in {
-        "shared_memory_descriptor",
-        "tensor_descriptor",
-        "tensor_descriptor_im2col",
-        "TensorDescriptor",
-        "TensorDescriptorIm2Col",
-    } or hasattr(value, "block_shape")
 
 
 def _is_shared_memory_descriptor_like(value: Any) -> bool:
@@ -127,9 +113,13 @@ def _is_shared_memory_descriptor_like(value: Any) -> bool:
 
 
 def _is_global_tensor_descriptor_like(value: Any) -> bool:
-    # Shared-memory descriptor accesses are not modeled yet; only global tensor
-    # descriptors become TensorDescriptorAccess records for symbolic checking.
-    return _is_descriptor_like(value) and not _is_shared_memory_descriptor_like(value)
+    type_name = type(value).__name__
+    return type_name in {
+        "tensor_descriptor",
+        "tensor_descriptor_im2col",
+        "TensorDescriptor",
+        "TensorDescriptorIm2Col",
+    }
 
 
 def _gluon_binary_adapter(
@@ -346,9 +336,17 @@ for namespace, attrs in GLUON_NAMESPACES.items():
                 _GLUON_UNARY_NUMPY_OPS[attr]
             )
         if namespace is gluon_amd_tdm and attr == "async_load":
-            _set_descriptor_load_adapter(original, 2)
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_descriptor_load_adapter(
+                2,
+                descriptor_kwarg="src",
+                coords_kwarg="offsets",
+            )
         elif attr in _TMA_LOAD_PRED_ARG_INDICES:
-            _set_descriptor_load_adapter(original, _TMA_LOAD_PRED_ARG_INDICES[attr])
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_descriptor_load_adapter(
+                _TMA_LOAD_PRED_ARG_INDICES[attr],
+                descriptor_kwarg="tensor_desc",
+                coords_kwarg="coord",
+            )
 
 GLUON_ADAPTERS: dict[type[Op], Callable[..., AdapterResult]] = {
     ProgramId: lambda axis, *_args, **_kwargs: AdapterResult(axis),


### PR DESCRIPTION
## Summary

- Split normal Gluon load handling from descriptor load handling.
- Make descriptor load adapters create `TensorDescriptorAccess` directly for registered descriptor load call sites.
- Support descriptor load helpers when descriptor/coord arguments are passed by keyword, including TMA `coord=` and TDM `src=`/`offsets=` forms.
- Keep `pred` handling on descriptor loads only; normal Gluon loads use `mask`.
- Leave `shared_memory_descriptor` unpatched because it is a class, not an op.

## Validation

- `python -m pytest tests/unit/test_adapters.py` (`24 passed, 1 skipped`)
- `pre-commit run --all-files`

Note: A full `python -m pytest tests/` run currently fails in CUDA/Gluon and triton_kernels end-to-end tests in this environment.