### PR TITLE
[REFACTOR] Key loop hooks by LoopSite

### DIFF
--- a/tests/end_to_end/loop_site_cross_file_helper.py
+++ b/tests/end_to_end/loop_site_cross_file_helper.py
@@ -1,0 +1,14 @@
+"""Helper jit function for the cross-file LoopSite regression test.
+
+The for-loop below must stay at function-relative line 2 (the line right
+after ``def``), matching the outer loop in ``loop_site_cross_file_kernel.py``.
+"""
+
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def inner_store_helper(out_ptr, i):
+    for j in range(0, 2):
+        tl.store(out_ptr + 2 * i + j, j)

--- a/tests/end_to_end/loop_site_cross_file_kernel.py
+++ b/tests/end_to_end/loop_site_cross_file_kernel.py
@@ -1,0 +1,24 @@
+"""Kernel fixture for the cross-file LoopSite regression test.
+
+The for-loop below must stay at function-relative line 2 (the line right
+after ``def``), matching the inner loop in ``loop_site_cross_file_helper.py``.
+With bare-lineno loop identity both loops would map to the same symbolic
+iterator variable.
+"""
+
+import triton
+import triton.language as tl  # noqa: F401  (the interpreter requires tl in the kernel's globals)
+
+import triton_viz
+from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
+
+from .loop_site_cross_file_helper import inner_store_helper
+
+cross_file_loop_sanitizer = SymbolicSanitizer(abort_on_error=False)
+
+
+@triton_viz.trace(client=cross_file_loop_sanitizer)
+@triton.jit
+def cross_file_outer_loop_kernel(out_ptr):
+    for i in range(0, 8):
+        inner_store_helper(out_ptr, i)

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -20,6 +20,11 @@ from triton_viz.core.config import config
 from triton_viz.core.patch import LoopSite, loop_file_token
 from z3.z3 import BoolRef
 
+from .loop_site_cross_file_kernel import (
+    cross_file_loop_sanitizer,
+    cross_file_outer_loop_kernel,
+)
+
 
 def _loop_var_name(lineno: int) -> str:
     """Expected symbolic iterator name for a loop in this test file."""
@@ -360,6 +365,33 @@ def test_loop_deferred_checks_after_context():
     assert f"{loop_var} >= 0" in iterator_constraints_str
     assert f"{loop_var} < 4" in iterator_constraints_str
     assert loop_deferred_check_recorder.records
+
+
+def test_cross_file_same_relative_lineno_loops_detect_oob():
+    """A cross-file nested-loop OOB must be reported regardless of how loop
+    identity is keyed.
+
+    The outer loop (i in [0, 8), kernel file) and the inner loop (j in [0, 2),
+    helper file) both sit at function-relative line 2. The store touches
+    elements 2*i + j, up to 15, while ``out`` has only 8 elements — a real
+    OOB.
+
+    Today device jit functions run un-rewritten (``_jit_function_call``
+    executes the raw fn), so j stays concrete and each unrolled address is
+    checked against the outer iterator alone — the OOB is found. If device
+    function loops are ever wired into the symbolic loop hooks, bare-lineno
+    identity would collapse both iterators into one variable v < 2, turning
+    the address into 3*v (max element 3) and silently missing the OOB;
+    LoopSite identity keeps the iterators distinct. Either way this test must
+    keep reporting the OOB.
+    """
+    cross_file_loop_sanitizer.records.clear()
+
+    out = torch.empty((8,), dtype=torch.int32)
+
+    cross_file_outer_loop_kernel[(1,)](out)
+
+    assert cross_file_loop_sanitizer.records
 
 
 def test_loop_deferred_checks_simplify():

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -17,7 +17,14 @@ from triton_viz.core.symbolic_metadata import is_pointer_dtype
 from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.core.callbacks import ForLoopCallbacks
 from triton_viz.core.config import config
+from triton_viz.core.patch import LoopSite, loop_file_token
 from z3.z3 import BoolRef
+
+
+def _loop_var_name(lineno: int) -> str:
+    """Expected symbolic iterator name for a loop in this test file."""
+    token = loop_file_token(_loop_var_name.__code__.co_filename)
+    return f"loop_i_{LoopSite(lineno, token)}"
 
 
 @pytest.fixture
@@ -345,12 +352,13 @@ def test_loop_deferred_checks_after_context():
 
     assert loop_deferred_check_recorder.after_loop_pending == [1]
     addr_expr, _ = loop_deferred_check_recorder.check_inside_loop[0]
-    assert "4*loop_i_2" in str(addr_expr)
+    loop_var = _loop_var_name(2)
+    assert f"4*{loop_var}" in str(addr_expr)
     iterator_constraints_str = " ".join(
         str(c) for c in loop_deferred_check_recorder.iterator_constraints
     )
-    assert "loop_i_2 >= 0" in iterator_constraints_str
-    assert "loop_i_2 < 4" in iterator_constraints_str
+    assert f"{loop_var} >= 0" in iterator_constraints_str
+    assert f"{loop_var} < 4" in iterator_constraints_str
     assert loop_deferred_check_recorder.records
 
 

--- a/tests/end_to_end/test_sanitizer.py
+++ b/tests/end_to_end/test_sanitizer.py
@@ -131,9 +131,9 @@ class LoopBoundsChecker(SymbolicSanitizer):
         callbacks = super().register_for_loop_callback()
         orig_before = callbacks.before_loop_callback
 
-        def _before_loop(lineno, iterable):
+        def _before_loop(loop_site, iterable):
             if orig_before is not None:
-                orig_before(lineno, iterable)
+                orig_before(loop_site, iterable)
             if isinstance(iterable, RangeWrapper):
                 self._bounds.append((iterable.start, iterable.stop, iterable.step))
 
@@ -177,9 +177,9 @@ class LoopDeferredCheckRecorder(SymbolicSanitizer):
         callbacks = super().register_for_loop_callback()
         orig_after = callbacks.after_loop_callback
 
-        def _after_loop(lineno: int) -> None:
+        def _after_loop(loop_site: LoopSite) -> None:
             pending = 0
-            if self.loop_stack and self.loop_stack[-1].lineno == lineno:
+            if self.loop_stack and self.loop_stack[-1].loop_site == loop_site:
                 ctx = self.loop_stack[-1]
                 pending = len(ctx.pending_checks)
                 self.iterator_constraints.append(
@@ -188,7 +188,7 @@ class LoopDeferredCheckRecorder(SymbolicSanitizer):
                     )
                 )
             if orig_after is not None:
-                orig_after(lineno)
+                orig_after(loop_site)
             self.after_loop_pending.append(pending)
 
         return ForLoopCallbacks(

--- a/tests/unit/test_sanitizer.py
+++ b/tests/unit/test_sanitizer.py
@@ -24,6 +24,7 @@ from triton_viz.clients.sanitizer.sanitizer import (
 from triton_viz.clients.sanitizer.range_summary import IntRange, access_interval_summary
 from triton_viz.clients.symbolic_engine import LoopContext, PendingCheck, SymbolicExpr
 from triton_viz.clients.symbolic_engine import symbolic_tensor_descriptor_access
+from triton_viz.core.patch import LoopSite, loop_file_token
 
 
 # ======== Init Tests ===========
@@ -393,7 +394,7 @@ def _make_loop_affine_access(
     idx_z3 = Int("loop_i_123")
     idx_sym = SymbolicExpr.create("const", 0, INT32)
     ctx = LoopContext(
-        lineno=123,
+        loop_site=LoopSite(123, loop_file_token(__file__)),
         length=len(range(start, stop, step)),
         idx=idx_sym,
         idx_z3=idx_z3,

--- a/tests/unit/test_symbolic_client.py
+++ b/tests/unit/test_symbolic_client.py
@@ -21,12 +21,14 @@ from triton_viz.clients.symbolic_engine import (
     SymbolicClient,
     SymbolicExpr,
     ConstSymbolicExpr,
+    RangeWrapper,
     ReduceSymbolicExpr,
     LoadSymbolicExpr,
     StoreSymbolicExpr,
     _range_to_iterator_constraint,
 )
 from triton_viz.core.data import Sort
+from triton_viz.core.patch import LoopSite, loop_file_token
 from triton_viz.core.symbolic_metadata import (
     FLOAT16,
     FLOAT32,
@@ -40,6 +42,16 @@ from triton_viz.core.symbolic_metadata import (
 )
 from z3.z3 import ArithRef, BoolRef, IntNumRef
 from z3 import Solver, Int, sat
+
+
+class _LoopSiteSymbolicClient(SymbolicClient):
+    NAME = "loop_site_symbolic_client"
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs) -> bool:
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret) -> None:
+        pass
 
 
 # ======== Range Constraint Tests ===========
@@ -103,6 +115,27 @@ def test_range_to_iterator_constraint():
     assert_constraint_allows(constraint, i, 0)
     assert_constraint_forbids(constraint, i, 1)
     assert_constraint_forbids(constraint, i, -1)
+
+
+def test_loop_sites_in_different_files_get_distinct_iterator_state():
+    client = _LoopSiteSymbolicClient()
+    iterable = RangeWrapper(range(3), length=3, start=0, stop=3, step=1)
+    site_a = LoopSite(5, loop_file_token("/src/kernel_a.py"))
+    site_b = LoopSite(5, loop_file_token("/src/helper_b.py"))
+
+    client._loop_hook_before(site_a, iterable)
+    ctx_a = client.loop_stack[-1]
+    client._loop_hook_after(site_a)
+
+    client._loop_hook_before(site_b, iterable)
+    ctx_b = client.loop_stack[-1]
+    client._loop_hook_after(site_b)
+
+    assert ctx_a.idx_z3.decl().name() == f"loop_i_{site_a}"
+    assert ctx_b.idx_z3.decl().name() == f"loop_i_{site_b}"
+    assert ctx_a.idx_z3.decl().name() != ctx_b.idx_z3.decl().name()
+    assert (site_a, 0, 3, 1) in client.loop_iterator_constraint_cache
+    assert (site_b, 0, 3, 1) in client.loop_iterator_constraint_cache
 
 
 # ======== Reduce Operations Tests =========

--- a/tests/unit/test_symbolic_client.py
+++ b/tests/unit/test_symbolic_client.py
@@ -136,6 +136,10 @@ def test_loop_sites_in_different_files_get_distinct_iterator_state():
     assert ctx_a.idx_z3.decl().name() != ctx_b.idx_z3.decl().name()
     assert (site_a, 0, 3, 1) in client.loop_iterator_constraint_cache
     assert (site_b, 0, 3, 1) in client.loop_iterator_constraint_cache
+    # A cache keyed by lineno alone would hand site_b the constraint built
+    # for site_a's variable, leaving site_b's own iterator unconstrained.
+    assert f"loop_i_{site_a}" in str(ctx_a.iterator_constraint)
+    assert f"loop_i_{site_b}" in str(ctx_b.iterator_constraint)
 
 
 # ======== Reduce Operations Tests =========

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -8,6 +8,7 @@ from z3 import Int
 
 from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.clients.symbolic_engine import LoopContext
+from triton_viz.core.patch import LoopSite, loop_file_token
 from triton_viz.clients.tracer.tracer import Tracer
 from triton_viz.clients.utils import (
     check_inner_stride_equal_to_one,
@@ -58,7 +59,7 @@ def _capture_sanitizer_traceback(
     sanitizer = SymbolicSanitizer(abort_on_error=False)
     sanitizer.loop_stack.append(
         LoopContext(
-            lineno=1,
+            loop_site=LoopSite(1, loop_file_token(__file__)),
             length=1,
             idx=0,
             idx_z3=Int("loop_idx"),

--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -4,6 +4,7 @@ from ...core.client import Client
 from ...core.callbacks import OpCallbacks, ForLoopCallbacks
 from ...core.data import Op, Load, Store, AddPtr, Dot
 from ...core.config import config as cfg
+from ...core.patch import LoopSite
 from .data import LoadStoreBytes
 from ...utils.traceback_utils import (
     extract_user_frames,
@@ -12,10 +13,6 @@ from ...utils.traceback_utils import (
 from triton.runtime.interpreter import _get_np_dtype, TensorHandle
 import numpy as np
 from dataclasses import dataclass, replace
-
-
-def _loop_lineno(loop_site) -> int:
-    return loop_site.lineno if hasattr(loop_site, "lineno") else loop_site
 
 
 @dataclass(frozen=False)
@@ -334,20 +331,20 @@ class Profiler(Client):
 
     def register_for_loop_callback(self):
         @self.lock_fn
-        def loop_hook_range_type(loop_site, range_type: str) -> None:
-            lineno = _loop_lineno(loop_site)
+        def loop_hook_range_type(loop_site: LoopSite, range_type: str) -> None:
+            lineno = loop_site.lineno
             cur = self.loop_info.get(lineno, LoopInfo())
             self.loop_info[lineno] = replace(cur, range_type=range_type)
 
         @self.lock_fn
-        def loop_hook_before(loop_site, iterable):
+        def loop_hook_before(loop_site: LoopSite, iterable):
             if self.disable_for_loop_unroll_check:
                 return
 
             if not isinstance(iterable, range):
                 return
 
-            lineno = _loop_lineno(loop_site)
+            lineno = loop_site.lineno
             # Only record each unique loop (by line number) once
             # Different blocks will execute the same loop, so we deduplicate by lineno
             if self.loop_info[lineno].length is not None:
@@ -360,7 +357,7 @@ class Profiler(Client):
             self.loop_info[lineno] = replace(cur, length=length)
 
         @self.lock_fn
-        def loop_hook_after(loop_site) -> None:
+        def loop_hook_after(loop_site: LoopSite) -> None:
             # No action needed after loop for profiler
             pass
 

--- a/triton_viz/clients/profiler/profiler.py
+++ b/triton_viz/clients/profiler/profiler.py
@@ -14,6 +14,10 @@ import numpy as np
 from dataclasses import dataclass, replace
 
 
+def _loop_lineno(loop_site) -> int:
+    return loop_site.lineno if hasattr(loop_site, "lineno") else loop_site
+
+
 @dataclass(frozen=False)
 class LoopInfo:
     length: int | None = None
@@ -330,18 +334,20 @@ class Profiler(Client):
 
     def register_for_loop_callback(self):
         @self.lock_fn
-        def loop_hook_range_type(lineno: int, range_type: str) -> None:
+        def loop_hook_range_type(loop_site, range_type: str) -> None:
+            lineno = _loop_lineno(loop_site)
             cur = self.loop_info.get(lineno, LoopInfo())
             self.loop_info[lineno] = replace(cur, range_type=range_type)
 
         @self.lock_fn
-        def loop_hook_before(lineno, iterable):
+        def loop_hook_before(loop_site, iterable):
             if self.disable_for_loop_unroll_check:
                 return
 
             if not isinstance(iterable, range):
                 return
 
+            lineno = _loop_lineno(loop_site)
             # Only record each unique loop (by line number) once
             # Different blocks will execute the same loop, so we deduplicate by lineno
             if self.loop_info[lineno].length is not None:
@@ -354,7 +360,7 @@ class Profiler(Client):
             self.loop_info[lineno] = replace(cur, length=length)
 
         @self.lock_fn
-        def loop_hook_after(lineno: int) -> None:
+        def loop_hook_after(loop_site) -> None:
             # No action needed after loop for profiler
             pass
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -217,10 +217,7 @@ class PendingCheck:
 
 @dataclass
 class LoopContext:
-    # Loop identity delivered by the loop hooks. Newer frontends pass a
-    # LoopSite so loops at the same function-relative line in different files
-    # do not share iterator state; int is kept for older hook callers.
-    lineno: LoopSite | int
+    loop_site: LoopSite
     length: int
     idx: Any
     idx_z3: ArithRef
@@ -2623,7 +2620,7 @@ class SymbolicClient(Client):
         self.addr_sym: ArithRef | None = Int("addr")
         self.addr_ok_cache: dict[int, BoolRef] = {}
         self.loop_iterator_constraint_cache: dict[
-            tuple[LoopSite | int, int, int, int], BoolRef
+            tuple[LoopSite, int, int, int], BoolRef
         ] = {}
         self.access_check_cache: set[int] = set()
         self.op_overrider_map = self._build_op_overrider_map()
@@ -2969,7 +2966,7 @@ class SymbolicClient(Client):
     def _wrap_range(
         self,
         iterable,
-        _lineno,
+        _loop_site,
         _range_type,
         iter_args=None,
         iter_kwargs=None,
@@ -3028,7 +3025,7 @@ class SymbolicClient(Client):
             concrete_range, length=length, start=start, stop=stop, step=step
         )
 
-    def _loop_hook_before(self, lineno, iterable):
+    def _loop_hook_before(self, loop_site: LoopSite, iterable):
         if self._should_skip_loop_hooks():
             return
         if not isinstance(iterable, RangeWrapper):
@@ -3036,13 +3033,13 @@ class SymbolicClient(Client):
                 print("not a range wrapper, skipping for-loop iterator association.")
             return
 
-        # `lineno` may be a LoopSite. Its string form embeds both the
-        # function-relative line and file token, keeping symbolic iterator vars
-        # distinct for loops at the same relative line in different files.
-        idx_z3 = Int(f"loop_i_{lineno}")
+        # LoopSite's string form embeds both the function-relative line and
+        # file token, keeping symbolic iterator vars distinct for loops at the
+        # same relative line in different files.
+        idx_z3 = Int(f"loop_i_{loop_site}")
         sym = SymbolicExpr.create("const", idx_z3, INT32)
         idx = SymbolicExpr.wrap_loop_index(sym, INT32)
-        constraint_key = (lineno, iterable.start, iterable.stop, iterable.step)
+        constraint_key = (loop_site, iterable.start, iterable.stop, iterable.step)
         iterator_constraint = self.loop_iterator_constraint_cache.get(constraint_key)
         if iterator_constraint is None:
             iterator_constraint = _range_to_iterator_constraint(
@@ -3053,7 +3050,7 @@ class SymbolicClient(Client):
             )
             self.loop_iterator_constraint_cache[constraint_key] = iterator_constraint
         ctx = LoopContext(
-            lineno,
+            loop_site,
             iterable.length,
             idx,
             idx_z3,
@@ -3066,20 +3063,20 @@ class SymbolicClient(Client):
         self.loop_stack.append(ctx)
 
         if cfg.verbose:
-            print(f"[{self.LOG_TAG}] ▶ enter loop@{lineno}, len={iterable.length}")
+            print(f"[{self.LOG_TAG}] ▶ enter loop@{loop_site}, len={iterable.length}")
 
-    def _loop_hook_iter_overrider(self, lineno, idx):
+    def _loop_hook_iter_overrider(self, loop_site: LoopSite, idx):
         if self._should_skip_loop_hooks():
             return idx
-        if self.loop_stack and self.loop_stack[-1].lineno == lineno:
+        if self.loop_stack and self.loop_stack[-1].loop_site == loop_site:
             self.loop_stack[-1].current_value = int(idx)
             return self.loop_stack[-1].idx
         return idx
 
-    def _loop_hook_after(self, lineno: int) -> None:
+    def _loop_hook_after(self, loop_site: LoopSite) -> None:
         if self._should_skip_loop_hooks():
             return
-        if not self.loop_stack or self.loop_stack[-1].lineno != lineno:
+        if not self.loop_stack or self.loop_stack[-1].loop_site != loop_site:
             return
         ctx = self.loop_stack.pop()
 
@@ -3118,7 +3115,7 @@ class SymbolicClient(Client):
 
         if cfg.verbose:
             print(
-                f"[{self.LOG_TAG}] ▶ leave loop@{lineno} end. "
+                f"[{self.LOG_TAG}] ▶ leave loop@{loop_site} end. "
                 f"(processed {len(ctx.pending_checks)} unique addr patterns)"
             )
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -37,6 +37,7 @@ from z3.z3 import BoolRef, ArithRef, IntNumRef, ExprRef, Tactic, Probe
 from ..core.client import Client
 from ..core.callbacks import OpCallbacks, ForLoopCallbacks
 from ..core.config import config as cfg
+from ..core.patch import LoopSite
 from ..core.data import (
     Op,
     UnaryOp,
@@ -199,7 +200,10 @@ class PendingCheck:
 
 @dataclass
 class LoopContext:
-    lineno: int
+    # Loop identity delivered by the loop hooks. Newer frontends pass a
+    # LoopSite so loops at the same function-relative line in different files
+    # do not share iterator state; int is kept for older hook callers.
+    lineno: LoopSite | int
     length: int
     idx: Any
     idx_z3: ArithRef
@@ -2385,7 +2389,7 @@ class SymbolicClient(Client):
         self.addr_sym: ArithRef | None = Int("addr")
         self.addr_ok_cache: dict[int, BoolRef] = {}
         self.loop_iterator_constraint_cache: dict[
-            tuple[int, int, int, int], BoolRef
+            tuple[LoopSite | int, int, int, int], BoolRef
         ] = {}
         self.access_check_cache: set[int] = set()
         self.op_overrider_map = self._build_op_overrider_map()
@@ -2789,6 +2793,9 @@ class SymbolicClient(Client):
                 print("not a range wrapper, skipping for-loop iterator association.")
             return
 
+        # `lineno` may be a LoopSite. Its string form embeds both the
+        # function-relative line and file token, keeping symbolic iterator vars
+        # distinct for loops at the same relative line in different files.
         idx_z3 = Int(f"loop_i_{lineno}")
         sym = SymbolicExpr.create("const", idx_z3, INT32)
         idx = SymbolicExpr.wrap_loop_index(sym, INT32)

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -266,35 +266,35 @@ class ClientManager:
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
 
-    def range_type(self, lineno: int, range_type: str) -> None:
+    def range_type(self, loop_site, range_type: str) -> None:
         for hook in self._range_type_hooks:
-            hook(lineno, range_type)
+            hook(loop_site, range_type)
 
-    def before_loop(self, lineno: int, iterable: Any) -> None:
+    def before_loop(self, loop_site, iterable: Any) -> None:
         for hook in self._before:
-            hook(lineno, iterable)
+            hook(loop_site, iterable)
 
-    def loop_iter(self, lineno: int, idx: Any) -> Any:
+    def loop_iter(self, loop_site, idx: Any) -> Any:
         if self._iter_overrider is not None:
-            new_idx = self._iter_overrider(lineno, idx)
+            new_idx = self._iter_overrider(loop_site, idx)
             if new_idx is not None:
                 idx = new_idx
 
         for hook in self._iter_listeners:
-            hook(lineno, idx)
+            hook(loop_site, idx)
 
         return idx
 
-    def after_loop(self, lineno: int) -> None:
+    def after_loop(self, loop_site) -> None:
         for hook in self._after:
-            hook(lineno)
+            hook(loop_site)
 
     def loop_iter_wrapper(
         self,
         iterable_callable: Callable,
         iter_args,
         iter_kwargs,
-        lineno: int,
+        loop_site,
         range_type: str,
     ) -> "LoopIter":
         args = tuple(iter_args) if iter_args is not None else ()
@@ -302,7 +302,7 @@ class ClientManager:
 
         if self._range_wrapper_factory is not None:
             wrapped = self._range_wrapper_factory(
-                None, lineno, range_type, args, kwargs, iterable_callable
+                None, loop_site, range_type, args, kwargs, iterable_callable
             )
             if wrapped is not None:
                 iterable = wrapped
@@ -310,4 +310,4 @@ class ClientManager:
                 iterable = iterable_callable(*args, **kwargs)
         else:
             iterable = iterable_callable(*args, **kwargs)
-        return LoopIter(self, iterable, lineno, range_type)
+        return LoopIter(self, iterable, loop_site, range_type)

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -13,6 +13,7 @@ from .patch import (
     unpatch_for_loop,
     patch_calls,
     LoopIter,
+    LoopSite,
 )
 from functools import wraps
 from .callbacks import OpCallbacks, ForLoopCallbacks
@@ -267,15 +268,15 @@ class ClientManager:
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
 
-    def range_type(self, loop_site, range_type: str) -> None:
+    def range_type(self, loop_site: LoopSite, range_type: str) -> None:
         for hook in self._range_type_hooks:
             hook(loop_site, range_type)
 
-    def before_loop(self, loop_site, iterable: Any) -> None:
+    def before_loop(self, loop_site: LoopSite, iterable: Any) -> None:
         for hook in self._before:
             hook(loop_site, iterable)
 
-    def loop_iter(self, loop_site, idx: Any) -> Any:
+    def loop_iter(self, loop_site: LoopSite, idx: Any) -> Any:
         if self._iter_overrider is not None:
             new_idx = self._iter_overrider(loop_site, idx)
             if new_idx is not None:
@@ -286,7 +287,7 @@ class ClientManager:
 
         return idx
 
-    def after_loop(self, loop_site) -> None:
+    def after_loop(self, loop_site: LoopSite) -> None:
         for hook in self._after:
             hook(loop_site)
 
@@ -295,7 +296,7 @@ class ClientManager:
         iterable_callable: Callable,
         iter_args,
         iter_kwargs,
-        loop_site,
+        loop_site: LoopSite,
         range_type: str,
     ) -> "LoopIter":
         args = tuple(iter_args) if iter_args is not None else ()

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -6,6 +6,7 @@ from functools import partial
 import ast
 import inspect
 from queue import Empty, SimpleQueue
+import sys
 import threading
 import time
 from typing import Any, ClassVar, cast
@@ -107,6 +108,7 @@ from ..symbolic_metadata import (
     dtype_to_numpy,
     pointer_type as symbolic_pointer_type,
 )
+from ..patch import LoopSite, loop_file_token
 from .base import (
     AdapterResult,
     Frontend,
@@ -384,11 +386,17 @@ class TritonFrontend(Frontend):
             args = tuple(iter_args) if iter_args is not None else ()
             kwargs = dict(iter_kwargs) if iter_kwargs is not None else {}
             return iterable_callable(*args, **kwargs)
+        # The rewritten lineno is function-relative (Triton parses the kernel
+        # source with `def` at line 1), so loops in different files can share
+        # it. The caller frame is the rewritten kernel, compiled under the
+        # kernel's real filename; combine both pieces into the loop identity.
+        caller_file = sys._getframe(1).f_code.co_filename
+        loop_site = LoopSite(lineno, loop_file_token(caller_file))
         return client_manager.loop_iter_wrapper(
             iterable_callable,
             iter_args,
             iter_kwargs,
-            lineno,
+            loop_site,
             range_type,
         )
 

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -196,6 +196,12 @@ class LoopIter:
     """
 
     def __init__(self, hooks, iterable, loop_site, range_type):
+        if not isinstance(loop_site, LoopSite):
+            raise NotImplementedError(
+                "loop hooks are keyed by LoopSite; bare line numbers are not "
+                "supported because loops in different files can share a "
+                "function-relative lineno"
+            )
         self._it = iter(iterable)
         self._loop_site = loop_site
         self._hooks = hooks

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from contextlib import contextmanager
-from typing import Any
+import hashlib
+from typing import Any, NamedTuple
 
 from .frontend.base import AdapterResult, LANG_PATCH_SCOPES
 from .frontend.base import get_frontend
@@ -135,6 +136,35 @@ def unpatch_op(namespace: Any, attr: str, frontend_name: str):
     setattr(namespace, attr, original_op)
 
 
+class LoopSite(NamedTuple):
+    """Identity of one rewritten for-loop.
+
+    The loop rewrite records function-relative line numbers because Triton
+    parses the kernel source with ``def`` at line 1. Two loops in different
+    source files can therefore share a line number, so hook bookkeeping should
+    key per-loop state by ``(lineno, file_token)`` rather than lineno alone.
+    """
+
+    lineno: int
+    file_token: str
+
+    def __str__(self) -> str:
+        # Embedded in symbolic iterator var names, so keep it deterministic.
+        return f"{self.lineno}_{self.file_token}"
+
+
+_FILE_TOKEN_CACHE: dict[str, str] = {}
+
+
+def loop_file_token(filename: str) -> str:
+    """Short stable token identifying a source file inside a LoopSite."""
+    token = _FILE_TOKEN_CACHE.get(filename)
+    if token is None:
+        token = hashlib.blake2s(filename.encode(), digest_size=4).hexdigest()
+        _FILE_TOKEN_CACHE[filename] = token
+    return token
+
+
 class LoopIter:
     """
     Purpose:
@@ -143,22 +173,22 @@ class LoopIter:
     Args:
         hooks: Object that owns range_type, before_loop, loop_iter, and after_loop hooks.
         iterable: Iterable produced by the patched loop expression.
-        lineno: Source line number for the loop.
+        loop_site: LoopSite identifying the loop's source location.
         range_type: Frontend-specific classification of the loop iterable.
 
     Returns:
         Iterator that yields possibly overridden loop indices.
     """
 
-    def __init__(self, hooks, iterable, lineno, range_type):
+    def __init__(self, hooks, iterable, loop_site, range_type):
         self._it = iter(iterable)
-        self._lineno = lineno
+        self._loop_site = loop_site
         self._hooks = hooks
         # triggering range_type
-        self._hooks.range_type(self._lineno, range_type)
+        self._hooks.range_type(self._loop_site, range_type)
         # triggering before_loop
         if self._hooks.before_loop:
-            self._hooks.before_loop(self._lineno, iterable)
+            self._hooks.before_loop(self._loop_site, iterable)
 
     def __iter__(self):
         return self
@@ -170,11 +200,11 @@ class LoopIter:
         except StopIteration:
             # Exiting the loop and triggering after_loop
             if self._hooks.after_loop:
-                self._hooks.after_loop(self._lineno)
+                self._hooks.after_loop(self._loop_site)
             raise
 
         # trigger loop overriders and loop listeners
-        idx = self._hooks.loop_iter(self._lineno, idx)
+        idx = self._hooks.loop_iter(self._loop_site, idx)
         return idx
 
 


### PR DESCRIPTION
## Summary

Refactor loop hook identity from a bare function-relative `lineno` to a `LoopSite` that combines the rewritten loop line number with a stable source-file token.

Triton's interpreter parses each jit function with `def` at line 1, so loops in different files can share a function-relative line number. With bare-lineno identity, two such loops collide in two places inside `SymbolicClient`:

- the z3 iterator variable `loop_i_{lineno}` — both loops would share one symbolic variable;
- the iterator-constraint cache keyed by `(lineno, start, stop, step)` — distinct loop sites could hit each other's cached constraint.

**Scope note (verified experimentally):** these collisions are an identity-correctness hazard, not a currently reproducible end-to-end mischeck. Device jit functions are executed un-rewritten (`_jit_function_call` calls the raw fn), so nested cross-file loops never reach the loop hooks today, and sequential launches that share a lineno also share the variable name *and* the cache key consistently, which yields correct constraints. The fix removes the latent collision and becomes load-bearing if device-function loops are ever wired into the loop hooks.

## Changes

- Add `LoopSite` and `loop_file_token` in the loop patching layer.
- Pass `LoopSite` through loop hook dispatch from the Triton frontend and client manager.
- Require `LoopSite` as the only loop identity: `LoopIter` raises `NotImplementedError` on bare line numbers, and `ClientManager` hook signatures are annotated with `LoopSite`.
- Rename `LoopContext.lineno` to `loop_site` and key symbolic loop context/constraint caches strictly by `LoopSite`.
- Keep profiler loop reports grouped by integer line number (via `loop_site.lineno`), dropping its int-compat helper.
- Update sanitizer string expectations and add tests:
  - a unit test asserting two same-lineno sites in different files get distinct z3 variables and distinct cached constraints bound to their own variables (guards against a cache key regressing to lineno-only);
  - an end-to-end cross-file nested-loop OOB test (kernel loop + device-fn helper loop at the same relative line) documenting today's concrete-unroll behavior and guarding the scenario if device-fn loops become symbolic later.

## Known limitation

The profiler still aggregates `loop_info` by bare `loop_site.lineno`, so loops at the same relative line in different files still merge in profiler reports (pre-existing behavior, kept intentionally; possible follow-up).

## Validation

- `uv run pytest tests/unit/test_symbolic_client.py`
- `uv run pytest tests/end_to_end/test_sanitizer.py::test_loop_deferred_checks_after_context tests/end_to_end/test_sanitizer.py::test_cross_file_same_relative_lineno_loops_detect_oob tests/unit/test_profiler.py`
- `uv run pytest tests/unit/test_sanitizer.py -k loop` (loop-affine `LoopContext` construction)
- `uv run pytest tests/unit/test_utils.py -k sanitizer_trace` (traceback tests constructing `LoopContext`)
