### PR TITLE
[codex] Extract core loop lifecycle hooks

### DIFF
--- a/tests/end_to_end/test_race_detector.py
+++ b/tests/end_to_end/test_race_detector.py
@@ -332,7 +332,82 @@ def test_tl_range_load_store_cross_iteration_race():
     assert {r.race_type for r in detector.last_reports} == {RaceType.WAW}
 
 
-# ======== Loop Lifecycle — nested re-entry ========
+# ======== Loop Lifecycle — break / abort / nested re-entry / file identity ==
+
+
+def test_loop_break_marks_unsupported_and_next_launch_recovers():
+    """A `break` exits the loop without exhausting it, so the deferred
+    accesses are never flushed. Regression test: LoopIter only fired
+    after_loop on StopIteration, so the pending WAW store was silently
+    dropped (last_status == 'ok' with no reports) and the dead LoopContext
+    stayed on loop_stack, swallowing every access of subsequent launches on
+    the same detector instance."""
+
+    detector = SymbolicRaceDetector()
+
+    @triton_viz.trace(detector)
+    @triton.jit
+    def break_kernel(out_ptr):
+        pid = tl.program_id(0)
+        for i in range(4):
+            tl.store(out_ptr + pid, 1.0)
+            break
+
+    out = torch.zeros(8, dtype=torch.float32)
+    break_kernel[(2,)](out)
+
+    # Never a silent clean verdict for an early-exited loop.
+    assert detector.last_status == "unsupported"
+    assert detector.unsupported_reason is not None
+    assert "loop exited early" in detector.unsupported_reason
+    assert detector.loop_stack == []
+
+    # The next launch on the same detector instance must be unaffected:
+    # both blocks write out[0] — a real WAW race.
+    @triton_viz.trace(detector)
+    @triton.jit
+    def racy_kernel(out_ptr):
+        tl.store(out_ptr, 1.0)
+
+    racy_kernel[(2,)](out)
+
+    assert detector.last_status == "ok"
+    assert any(r.race_type == RaceType.WAW for r in detector.last_reports)
+    assert detector.loop_stack == []
+
+
+def test_abort_mid_loop_does_not_poison_next_launch():
+    """abort_on_error raising from inside a loop body (atomic-in-loop)
+    bypasses the StopIteration flush. Regression test: the stale LoopContext
+    survived _clear_launch_runtime/grid_callback, so the next launch's
+    accesses were deferred into the dead context and a genuinely racy
+    kernel finished with last_status == 'ok' and zero reports."""
+
+    detector = SymbolicRaceDetector(abort_on_error=True)
+
+    @triton_viz.trace(detector)
+    @triton.jit
+    def atomic_in_loop_kernel(out_ptr):
+        for _i in range(4):
+            tl.atomic_add(out_ptr, 1)
+
+    flag = torch.zeros(4, dtype=torch.int32)
+    with pytest.raises(UnsupportedSymbolicRaceQuery, match="atomic_rmw inside loop"):
+        atomic_in_loop_kernel[(2,)](flag)
+    assert detector.loop_stack == []
+    # The aborted launch must not read as a clean verdict.
+    assert detector.last_status == "unsupported"
+
+    @triton_viz.trace(detector)
+    @triton.jit
+    def racy_kernel(out_ptr):
+        tl.store(out_ptr, 1.0)
+
+    out = torch.zeros(8, dtype=torch.float32)
+    racy_kernel[(2,)](out)
+
+    assert detector.last_status == "ok"
+    assert any(r.race_type == RaceType.WAW for r in detector.last_reports)
 
 
 def test_nested_loop_records_do_not_scale_with_outer_trip_count():
@@ -1404,6 +1479,66 @@ def test_clamp_on_symbolic_values_is_supported():
     racy_kernel[(2,)](x, out, 4)
     assert racy.last_status == "ok"
     assert any(r.race_type == RaceType.WAW for r in racy.last_reports)
+
+
+# ======== tl.assume — conditions constrain the two-copy model ========
+
+
+def test_assume_constrains_the_model():
+    """tl.assume conditions hold on every feasible execution, so they are
+    sound solver assumptions (instantiated per program copy). Regression
+    test: the interpreter's `assert condition` was object-truthy on the
+    symbolic condition and silently dropped it."""
+
+    restricting = SymbolicRaceDetector()
+
+    @triton_viz.trace(restricting)
+    @triton.jit
+    def assumed(out_ptr):
+        pid = tl.program_id(0)
+        tl.assume(pid < 1)
+        tl.store(out_ptr, pid.to(tl.float32))
+
+    out = torch.zeros(4, dtype=torch.float32)
+    assumed[(2,)](out)
+    assert restricting.last_status == "ok"
+    assert restricting.last_reports == []
+
+    loose = SymbolicRaceDetector()
+
+    @triton_viz.trace(loose)
+    @triton.jit
+    def assumed_loose(out_ptr):
+        pid = tl.program_id(0)
+        tl.assume(pid >= 0)
+        tl.store(out_ptr, pid.to(tl.float32))
+
+    assumed_loose[(2,)](out)
+    assert loose.last_status == "ok"
+    assert any(r.race_type == RaceType.WAW for r in loose.last_reports)
+
+
+def test_assume_inside_loop_is_unsupported():
+    """Loop-body assumptions are per-iteration path conditions the one-shot
+    capture cannot attribute; mark unsupported instead of misapplying them
+    launch-wide."""
+
+    detector = SymbolicRaceDetector()
+
+    @triton_viz.trace(detector)
+    @triton.jit
+    def kernel(out_ptr):
+        pid = tl.program_id(0)
+        for i in range(2):
+            tl.assume(pid >= 0)
+            tl.store(out_ptr + pid + i, 1.0)
+
+    out = torch.zeros(8, dtype=torch.float32)
+    kernel[(2,)](out)
+
+    assert detector.last_status == "unsupported"
+    assert detector.unsupported_reason is not None
+    assert "inside a loop" in detector.unsupported_reason
 
 
 # ======== Atomic scope — cta atomics are not cross-CTA atomic ========

--- a/tests/unit/test_race_detector.py
+++ b/tests/unit/test_race_detector.py
@@ -19,6 +19,7 @@ from triton_viz.clients.race_detector.race_detector import (
 from triton_viz.clients.symbolic_engine import (
     ConstSymbolicExpr,
     LoadSymbolicExpr,
+    RangeWrapper,
     SymbolicExpr,
     _triton_frame_dirs,
 )
@@ -368,6 +369,61 @@ def test_null_race_detector_reports_disabled_status():
     assert detector.last_status == "disabled"
     assert detector.last_reports == []
     assert detector.unsupported_reason == "race detector disabled"
+
+
+# ======== Loop Lifecycle ========
+
+
+def _range_wrapper(start: int, stop: int) -> RangeWrapper:
+    return RangeWrapper(
+        range(start, stop),
+        length=len(range(start, stop)),
+        start=start,
+        stop=stop,
+        step=1,
+    )
+
+
+def test_abandoned_loop_pops_context_and_marks_unsupported():
+    """An abandoned loop (break / early return) must pop its context — a
+    stale entry would swallow all later accesses — and the launch must not
+    read as a clean verdict because the deferred events were never flushed.
+    """
+    detector = SymbolicRaceDetector()
+    lineno = 7
+    detector._loop_hook_before(lineno, _range_wrapper(0, 4))
+    assert len(detector.loop_stack) == 1
+
+    detector._loop_hook_abandoned(lineno, None)
+
+    assert detector.loop_stack == []
+    assert detector._suspended_iter_subs == []
+    assert detector.last_status == "unsupported"
+    assert "loop exited early" in (detector.unsupported_reason or "")
+
+
+def test_abandoned_loop_policy_respects_abort_and_inflight_exception():
+    """abort_on_error raises on a plain break, but never raises while an
+    exception is already unwinding through the loop (that would mask the
+    original failure) — it only marks the launch unsupported."""
+    detector = SymbolicRaceDetector(abort_on_error=True)
+    lineno = 9
+
+    detector._loop_hook_before(lineno, _range_wrapper(0, 4))
+    detector._loop_hook_abandoned(lineno, ValueError)  # exception in flight
+    assert detector.loop_stack == []
+    assert detector.last_status == "unsupported"
+
+    detector.grid_callback((1, 1, 1))
+    try:
+        detector._loop_hook_before(lineno, _range_wrapper(0, 4))
+        with pytest.raises(UnsupportedSymbolicRaceQuery, match="loop exited early"):
+            detector._loop_hook_abandoned(lineno, None)
+        # Bookkeeping stays balanced even when the policy raises.
+        assert detector.loop_stack == []
+        assert detector._suspended_iter_subs == []
+    finally:
+        detector._clear_launch_runtime()
 
 
 # ======== Launch lifecycle — capture slot and eval-scoped hooks ========

--- a/triton_viz/clients/race_detector/race_detector.py
+++ b/triton_viz/clients/race_detector/race_detector.py
@@ -266,6 +266,9 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         # (idx_z3, IntVal(final iteration value)). See _apply_finished_iter_subs
         # for why leftover iterator references must be concretized at record time.
         self._finished_loop_iter_subs: dict[Any, tuple[Any, Any]] = {}
+        # tl.assume / tl.device_assert conditions captured this launch,
+        # fed to the two-copy solver as per-copy assumption templates.
+        self._launch_assumptions: list[Any] = []
         # Stash of the substitution entry popped when a loop re-enters,
         # restored on a zero-iteration exit (a zero-trip loop leaves the
         # leftover Python variable — and thus its final value — unchanged).
@@ -451,6 +454,44 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
             "instance (program id, tl.arange, or loaded data) is "
             "unsupported by one-shot symbolic capture"
         )
+
+    def _handle_assumption(self, condition: Any) -> None:
+        """Collect ``tl.assume`` / ``tl.device_assert`` conditions.
+
+        Every feasible real execution satisfies these, so they are sound
+        constraints on the two-copy model (instantiated once per program
+        copy by the solver). Without this the interpreter's ``assert`` was
+        object-truthy on the symbolic condition and the hint/check was
+        silently dropped.
+        """
+        if self._unsupported_capture or not self._capture_active():
+            return
+        if self.loop_stack:
+            self._raise_or_mark(
+                "tl.assume / tl.device_assert inside a loop is unsupported "
+                "by one-shot symbolic capture"
+            )
+            return
+        cond_sym = SymbolicExpr.from_value(condition)
+        if not isinstance(cond_sym, SymbolicExpr):
+            self._raise_or_mark(
+                "tl.assume / tl.device_assert on a non-tensor condition is "
+                "unsupported"
+            )
+            return
+        result = self._safe_eval(cond_sym, "assumption eval")
+        if result is None:
+            return
+        z3_cond, _ = result
+        z3_cond = self._apply_finished_iter_subs(z3_cond)
+        if self._refs_unresolved_iter_var((z3_cond,), ()):
+            self._raise_or_mark(
+                "assumption references a finished loop iterator with no "
+                "stable final value"
+            )
+            return
+        lanes = z3_cond if isinstance(z3_cond, list) else [z3_cond]
+        self._launch_assumptions.extend(_constraint_to_bool(lane) for lane in lanes)
 
     def _on_data_dependent_value(self, expr: Any = None) -> None:
         """Loop bounds / materialized operands that depend on loads or pids
@@ -776,6 +817,7 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
                     self.records,
                     grid=self._launch_grid,
                     arange_dict=self._arange_dict_snapshot,
+                    extra_assumptions=tuple(self._launch_assumptions),
                 ).find_races()
                 self.last_status = "ok"
             except UnsupportedSymbolicRaceQuery as exc:
@@ -832,6 +874,7 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         self._known_iter_var_keys = set()
         self._unstable_iter_var_keys = set()
         self._loop_flush_signatures = set()
+        self._launch_assumptions = []
         SymbolicExpr.ARANGE_DICT.clear()
         # SymbolicClient.grid_callback also clears loop_stack, so a launch
         # that aborted mid-loop cannot poison this one.
@@ -995,6 +1038,7 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
         self._known_iter_var_keys = set()
         self._unstable_iter_var_keys = set()
         self._loop_flush_signatures = set()
+        self._launch_assumptions = []
         if SymbolicExpr._load_value_provider_owner == id(self):
             SymbolicExpr._load_value_provider = None
             SymbolicExpr._load_value_provider_owner = None
@@ -1158,6 +1202,40 @@ class SymbolicRaceDetector(RaceDetector, SymbolicClient):
             self._unstable_iter_var_keys.add(var_key)
             return
         self._finished_loop_iter_subs[lineno] = (ctx.idx_z3, final)
+
+    def _loop_hook_abandoned(self, lineno: Any, exc_type: Any) -> None:
+        if not self._capture_active():
+            return
+        if self.loop_stack and self.loop_stack[-1].lineno == lineno:
+            # Keep the suspended-substitution stash in lockstep with the pop
+            # in the base hook — before the policy hook, which may raise
+            # under abort_on_error. No substitution is re-registered: the
+            # leftover variable's value at an early exit is not the loop's
+            # final value, and the launch is marked unsupported anyway.
+            stashed_lineno, _stashed = self._suspended_iter_subs.pop()
+            assert stashed_lineno == lineno
+        SymbolicClient._loop_hook_abandoned(self, lineno, exc_type)
+
+    def _process_abandoned_loop(self, ctx: LoopContext, exc_type: Any) -> None:
+        """A loop exited early (break / early return / exception). Part of
+        its iteration space never ran, so flushing the deferred events with
+        their full-range iterator constraints would model accesses that did
+        not execute, while dropping them would hide accesses that DID — the
+        only sound verdict is unsupported.
+
+        When an exception is already unwinding through the loop, only mark:
+        raising here (abort_on_error) would mask the original failure.
+        """
+        if self._unsupported_capture:
+            return
+        reason = (
+            "loop exited early (break/early return/exception); its deferred "
+            "accesses cannot be modeled by one-shot symbolic capture"
+        )
+        if exc_type is not None:
+            self._mark_unsupported(reason)
+            return
+        self._raise_or_mark(reason)
 
     def _apply_finished_iter_subs(self, value: Any) -> Any:
         if not self._finished_loop_iter_subs:

--- a/triton_viz/clients/race_detector/two_copy_symbolic_hb_solver.py
+++ b/triton_viz/clients/race_detector/two_copy_symbolic_hb_solver.py
@@ -229,7 +229,20 @@ class TwoCopySymbolicHBSolver:
             copy_local_substitutions=tuple(copy_local_subs_b),
         )
 
-        # 6. Lower every record under both contexts.
+        # 6. Lower every record under both contexts. extra_assumptions are
+        # capture-side templates (tl.assume / tl.device_assert conditions
+        # over PID0/1/2 and arange vars): every feasible execution satisfies
+        # them, so instantiate one copy per program instance.
+        self.assumption_constraints: tuple[Any, ...] = tuple(
+            apply_sub(
+                a,
+                ctx.pid_substitutions
+                + ctx.arange_substitutions
+                + ctx.copy_local_substitutions,
+            )
+            for ctx in (self.ctx_a, self.ctx_b)
+            for a in self.extra_assumptions
+        )
         self.events: list[SymbolicMemoryEvent] = self._lower_two_copies()
 
         # 7. Atomic-order vars + RF source booleans, BEFORE building the HB
@@ -960,7 +973,7 @@ class TwoCopySymbolicHBSolver:
             solver.add(c)
         for c in self.atomic_coherence_constraints:
             solver.add(c)
-        for c in self.extra_assumptions:
+        for c in self.assumption_constraints:
             solver.add(as_bool(c))
         return solver
 

--- a/triton_viz/clients/symbolic_engine.py
+++ b/triton_viz/clients/symbolic_engine.py
@@ -78,6 +78,8 @@ from ..core.data import (
     IntToPtr,
     AtomicCas,
     AtomicRMW,
+    DeviceAssert,
+    Assume,
     RawLoad,
     RawStore,
     Load,
@@ -2600,6 +2602,7 @@ class SymbolicClient(Client):
             before_loop_callback=self.lock_fn(self._loop_hook_before),
             loop_iter_overrider=self.lock_fn(self._loop_hook_iter_overrider),
             after_loop_callback=self.lock_fn(self._loop_hook_after),
+            abandoned_loop_callback=self.lock_fn(self._loop_hook_abandoned),
         )
         SymbolicExpr.set_loop_ctx_provider(
             lambda *_args, **_kwargs: (self.loop_stack[-1] if self.loop_stack else None)
@@ -2823,6 +2826,22 @@ class SymbolicClient(Client):
         mask_sym = SymbolicExpr.from_value(mask)
         return SymbolicExpr.create("atomic_rmw", ptr_sym, val_sym, mask_sym)
 
+    def _op_device_assert_overrider(self, condition, *args, **kwargs):
+        # The interpreter's create_assert does `assert condition`, which is
+        # object-truthy on a SymbolicExpr and would silently pass — route the
+        # condition to the client hook instead of evaluating it concretely.
+        self._handle_assumption(condition)
+
+    def _op_assume_overrider(self, condition, *args, **kwargs):
+        self._handle_assumption(condition)
+
+    def _handle_assumption(self, condition: Any) -> None:
+        """Hook for ``tl.device_assert`` / ``tl.assume`` conditions captured
+        symbolically. Default: drop the condition (the prior implicit
+        behavior, made explicit). Clients may collect conditions as solver
+        assumptions — every feasible real execution satisfies them.
+        """
+
     def _build_op_overrider_map(self) -> dict[type[Op], Callable]:
         """Return a mapping of shared Op types to their overrider methods."""
         return {
@@ -2862,6 +2881,8 @@ class SymbolicClient(Client):
             IntToPtr: self._op_bitcast_overrider,
             AtomicCas: self._op_atomic_cas_overrider,
             AtomicRMW: self._op_atomic_rmw_overrider,
+            DeviceAssert: self._op_device_assert_overrider,
+            Assume: self._op_assume_overrider,
             RawLoad: self._op_raw_load_overrider,
             RawStore: self._op_raw_store_overrider,
             Load: self._op_load_overrider,
@@ -3101,6 +3122,32 @@ class SymbolicClient(Client):
                 f"[{self.LOG_TAG}] ▶ leave loop@{lineno} end. "
                 f"(processed {len(ctx.pending_checks)} unique addr patterns)"
             )
+
+    def _loop_hook_abandoned(self, lineno, exc_type) -> None:
+        """Teardown for a loop that exited without exhausting its iterable
+        (break / early return / an exception in the loop body). Pops the
+        context so loop_stack stays balanced — a stale context would swallow
+        every later access into its never-flushed pending queue — and defers
+        the pending-check policy to ``_process_abandoned_loop``.
+        """
+        if self._should_skip_loop_hooks():
+            return
+        if not self.loop_stack or self.loop_stack[-1].lineno != lineno:
+            return
+        ctx = self.loop_stack.pop()
+        if cfg.verbose:
+            print(
+                f"[{self.LOG_TAG}] ▶ abandon loop@{lineno} "
+                f"({len(ctx.pending_checks)} pending addr patterns)"
+            )
+        self._process_abandoned_loop(ctx, exc_type)
+
+    def _process_abandoned_loop(self, ctx: LoopContext, exc_type) -> None:
+        """Policy hook for an abandoned loop's never-flushed pending checks.
+
+        The default keeps the legacy behavior of dropping them; clients that
+        cannot afford silent drops (e.g. the race detector) override this.
+        """
 
     def register_for_loop_callback(self) -> ForLoopCallbacks:
         return self.for_loop_callbacks

--- a/triton_viz/core/callbacks.py
+++ b/triton_viz/core/callbacks.py
@@ -19,3 +19,6 @@ class ForLoopCallbacks:
     loop_iter_overrider: Callable | None = None
     loop_iter_listener: Callable | None = None
     after_loop_callback: Callable | None = None
+    # (lineno, exc_type) -> None; fired when a loop exits without
+    # exhausting its iterable (break / early return / exception).
+    abandoned_loop_callback: Callable | None = None

--- a/triton_viz/core/client.py
+++ b/triton_viz/core/client.py
@@ -245,6 +245,7 @@ class ClientManager:
         self._iter_overrider: Callable | None = None
         self._range_wrapper_factory: Callable | None = None
         self._after: list[Callable] = []
+        self._abandoned: list[Callable] = []
 
     def _populate_loop_hooks(self, callbacks_list: list[ForLoopCallbacks]) -> None:
         self._clear_loop_hooks()
@@ -265,6 +266,8 @@ class ClientManager:
                 self._range_wrapper_factory = cb.range_wrapper_factory
             if cb.after_loop_callback is not None:
                 self._after.append(cb.after_loop_callback)
+            if cb.abandoned_loop_callback is not None:
+                self._abandoned.append(cb.abandoned_loop_callback)
 
     def range_type(self, lineno: int, range_type: str) -> None:
         for hook in self._range_type_hooks:
@@ -288,6 +291,10 @@ class ClientManager:
     def after_loop(self, lineno: int) -> None:
         for hook in self._after:
             hook(lineno)
+
+    def abandoned_loop(self, lineno: int, exc_type) -> None:
+        for hook in self._abandoned:
+            hook(lineno, exc_type)
 
     def loop_iter_wrapper(
         self,

--- a/triton_viz/core/data.py
+++ b/triton_viz/core/data.py
@@ -304,6 +304,16 @@ class AtomicRMW(Op):
 
 
 @dataclass
+class DeviceAssert(Op):
+    name: ClassVar[str] = "device_assert"
+
+
+@dataclass
+class Assume(Op):
+    name: ClassVar[str] = "assume"
+
+
+@dataclass
 class Tensor:
     ptr: int
     dtype: str

--- a/triton_viz/core/frontend/triton.py
+++ b/triton_viz/core/frontend/triton.py
@@ -39,6 +39,8 @@ from ..data import (
     Ashr,
     AtomicCas,
     AtomicRMW,
+    DeviceAssert,
+    Assume,
     BinaryOp,
     Bitcast,
     Broadcast,
@@ -107,6 +109,7 @@ from ..symbolic_metadata import (
     dtype_to_numpy,
     pointer_type as symbolic_pointer_type,
 )
+from ..patch import PassthroughLoopIter
 from .base import (
     AdapterResult,
     Frontend,
@@ -154,6 +157,8 @@ TRITON_NAMESPACES: dict[Any, dict[str, type[Op]]] = {
         "create_int_to_ptr": IntToPtr,
         "create_atomic_cas": AtomicCas,
         "create_atomic_rmw": AtomicRMW,
+        "create_assert": DeviceAssert,
+        "create_assume": Assume,
     },
     tl: {
         "max": ReduceMax,
@@ -249,6 +254,7 @@ class TritonFrontend(Frontend):
         self._thread_local_interpreter_state.grid_idx = None
         self._current_client_manager = None
         self._loop_wrapper_arg = "_triton_viz_loop_iter_wrapper"
+        self._loop_iter_name = "_triton_viz_loop_iter"
         self._loop_ast_methods: dict[str, Callable | object] = {}
         self._loop_ast_patched = False
         self._patch_calls_scope = 0
@@ -325,26 +331,47 @@ class TritonFrontend(Frontend):
             iter_args = ast.Tuple(elts=[], ctx=ast.Load())
             iter_kwargs = ast.Dict(keys=[], values=[])
 
+        # The loop runs inside a `with` block over the wrapper object so the
+        # `abandoned_loop` hook fires deterministically when the loop exits
+        # without exhausting its iterable (break / early return / exception);
+        # a bare `for` would silently skip all loop teardown in those cases.
+        # A single shared target name is safe even for nested loops: both the
+        # `with` block and the `for` statement keep their own object reference
+        # on the interpreter stack, so an inner rebinding of the name cannot
+        # affect the outer loop or its teardown.
         return ast.fix_missing_locations(
-            ast.For(
-                target=node.target,
-                iter=ast.Call(
-                    # `_loop_wrapper_arg` is injected as a hidden keyword-only
-                    # default by `_visit_triton_function_def`, avoiding any
-                    # helper name in user kernel globals.
-                    func=ast.Name(id=self._loop_wrapper_arg, ctx=ast.Load()),
-                    args=[
-                        iter_callable,
-                        iter_args,
-                        iter_kwargs,
-                        ast.Constant(value=node.lineno),
-                        ast.Constant(value=range_type),
-                    ],
-                    keywords=[],
-                ),
-                body=node.body,
-                orelse=node.orelse,
-                type_comment=node.type_comment,
+            ast.With(
+                items=[
+                    ast.withitem(
+                        context_expr=ast.Call(
+                            # `_loop_wrapper_arg` is injected as a hidden
+                            # keyword-only default by
+                            # `_visit_triton_function_def`, avoiding any
+                            # helper name in user kernel globals.
+                            func=ast.Name(id=self._loop_wrapper_arg, ctx=ast.Load()),
+                            args=[
+                                iter_callable,
+                                iter_args,
+                                iter_kwargs,
+                                ast.Constant(value=node.lineno),
+                                ast.Constant(value=range_type),
+                            ],
+                            keywords=[],
+                        ),
+                        optional_vars=ast.Name(
+                            id=self._loop_iter_name, ctx=ast.Store()
+                        ),
+                    )
+                ],
+                body=[
+                    ast.For(
+                        target=node.target,
+                        iter=ast.Name(id=self._loop_iter_name, ctx=ast.Load()),
+                        body=node.body,
+                        orelse=node.orelse,
+                        type_comment=node.type_comment,
+                    )
+                ],
             )
         )
 
@@ -380,10 +407,11 @@ class TritonFrontend(Frontend):
         if client_manager is None:
             # Device-function rewrites can run outside a top-level traced launch.
             # In that case, preserve Triton's normal behavior and just evaluate
-            # the original iterable.
+            # the original iterable (wrapped so the rewritten `with` block
+            # still has a context manager to enter).
             args = tuple(iter_args) if iter_args is not None else ()
             kwargs = dict(iter_kwargs) if iter_kwargs is not None else {}
-            return iterable_callable(*args, **kwargs)
+            return PassthroughLoopIter(iterable_callable(*args, **kwargs))
         return client_manager.loop_iter_wrapper(
             iterable_callable,
             iter_args,

--- a/triton_viz/core/patch.py
+++ b/triton_viz/core/patch.py
@@ -141,19 +141,26 @@ class LoopIter:
         Wrap an iterable so registered loop hooks run around each iteration.
 
     Args:
-        hooks: Object that owns range_type, before_loop, loop_iter, and after_loop hooks.
+        hooks: Object that owns range_type, before_loop, loop_iter,
+            after_loop, and abandoned_loop hooks.
         iterable: Iterable produced by the patched loop expression.
         lineno: Source line number for the loop.
         range_type: Frontend-specific classification of the loop iterable.
 
     Returns:
         Iterator that yields possibly overridden loop indices.
+
+    The for-loop rewrite executes the loop inside a ``with`` block over this
+    object, giving early exits (break / return / an exception in the loop
+    body) a deterministic teardown point: ``abandoned_loop`` fires exactly
+    when the iterable was NOT exhausted. The hook owner decides policy.
     """
 
     def __init__(self, hooks, iterable, lineno, range_type):
         self._it = iter(iterable)
         self._lineno = lineno
         self._hooks = hooks
+        self._exhausted = False
         # triggering range_type
         self._hooks.range_type(self._lineno, range_type)
         # triggering before_loop
@@ -169,6 +176,7 @@ class LoopIter:
             idx = next(self._it)
         except StopIteration:
             # Exiting the loop and triggering after_loop
+            self._exhausted = True
             if self._hooks.after_loop:
                 self._hooks.after_loop(self._lineno)
             raise
@@ -176,6 +184,36 @@ class LoopIter:
         # trigger loop overriders and loop listeners
         idx = self._hooks.loop_iter(self._lineno, idx)
         return idx
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if not self._exhausted and self._hooks.abandoned_loop:
+            self._hooks.abandoned_loop(self._lineno, exc_type)
+        return False
+
+
+class PassthroughLoopIter:
+    """Loop wrapper used when no client manager is active.
+
+    Preserves the original iterable's behavior while still satisfying the
+    ``with`` protocol emitted by the for-loop rewrite.
+    """
+
+    __slots__ = ("_iterable",)
+
+    def __init__(self, iterable):
+        self._iterable = iterable
+
+    def __iter__(self):
+        return iter(self._iterable)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
 
 
 def patch_for_loop(frontend_name: str = "triton"):

--- a/triton_viz/core/trace.py
+++ b/triton_viz/core/trace.py
@@ -168,7 +168,21 @@ class TritonTrace(LaunchInterface, TraceInterface):
         with self.client_manager.patch_run(self.base_fn, frontend_name="triton"):
             kwargs.update({"client_manager": self.client_manager})
             kwargs.update({"jit_fn": self.jit_fn})
-            ret = self.runner.run(*args, **kwargs)
+            try:
+                ret = self.runner.run(*args, **kwargs)
+            except BaseException:
+                # A mid-launch abort (e.g. a client raising under
+                # abort_on_error) must still release per-launch state —
+                # clients install class-level hooks (load-value provider,
+                # scalar-concretize observer) that would otherwise leak into
+                # the next launch of a different client. finalize() is the
+                # only place that clears them; best-effort, never masking
+                # the original exception.
+                try:
+                    self.finalize()
+                except Exception:
+                    pass
+                raise
             self.finalize()
             return ret
 


### PR DESCRIPTION
## What changed

This PR extracts the loop-lifecycle and assumption/assertion support out of `race-detector-z3-demo` into a separate review unit.

Core runtime support:

- Adds `abandoned_loop_callback` plumbing for loop clients.
- Rewrites Triton loop instrumentation to run through a context-managed `LoopIter`, so `break`, early `return`, and exceptions can trigger deterministic loop teardown.
- Adds `DeviceAssert` and `Assume` op records and registers Triton builder `create_assert` / `create_assume` hooks.
- Finalizes Triton traces on mid-launch exceptions so per-launch client state is cleaned up before re-raising.

Consumer support moved with it:

- Symbolic engine registers overriders for `DeviceAssert` / `Assume`.
- Symbolic race detector collects `tl.assume` / `tl.device_assert` conditions as solver assumptions.
- Race detector handles abandoned loops as unsupported instead of leaving stale loop state.
- Tests covering abandoned-loop teardown and `tl.assume` behavior are included here rather than remaining in the base branch.

## Why

The race detector consumer changes depend directly on the new core APIs. Keeping them together avoids leaving `race-detector-z3-demo` with dangling imports or callback fields while still making this runtime hook work reviewable independently.

## Validation

- `uv run python -c "import triton_viz.clients.symbolic_engine; import triton_viz.clients.race_detector.race_detector"`
- `uv run pytest tests/unit/test_race_detector.py -k abandoned_loop`
- `uv run pytest tests/end_to_end/test_race_detector.py -k assume`