### PR TITLE
[TEST] Cover Gluon CPU simulation core

### DIFF
--- a/examples/sanitizer/gluon_tma_oob.py
+++ b/examples/sanitizer/gluon_tma_oob.py
@@ -31,7 +31,10 @@ def gluon_tma_oob_kernel(
     bar = mbarrier.allocate_mbarrier()
     mbarrier.init(bar, count=1)
     mbarrier.expect(bar, desc.nbytes_per_cta)
-    tma.async_load(desc, [m, 0], bar, smem)  # OOB: row coordinate starts past x.
+    if hasattr(tma, "async_load"):
+        tma.async_load(desc, [m, 0], bar, smem)  # OOB: row coordinate starts past x.
+    else:
+        tma.async_copy_global_to_shared(desc, [m, 0], bar, smem)
 
 
 def run(abort_on_error: bool = True):

--- a/examples/sanitizer/gluon_tma_oob.py
+++ b/examples/sanitizer/gluon_tma_oob.py
@@ -35,7 +35,7 @@ def gluon_tma_oob_kernel(
 
 
 def run(abort_on_error: bool = True):
-    x = torch.zeros((BLOCK_M, BLOCK_N), device="cuda", dtype=torch.float32)
+    x = torch.zeros((BLOCK_M, BLOCK_N), dtype=torch.float32)
     layout = gl.NVMMASharedLayout.get_default_for([BLOCK_M, BLOCK_N], gl.float32)
     kernel = triton_viz.trace(
         client=Sanitizer(abort_on_error=abort_on_error),

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,7 +3,7 @@ testpaths = tests
 python_files = *.py
 python_classes = *Test
 python_functions = test_*
-addopts = -m "not nki"
+addopts = -m "not nki" --ignore=tests/end_to_end/test_triton_kernels.py
 
 markers =
   nki: NKI-specific tests

--- a/tests/end_to_end/test_gluon.py
+++ b/tests/end_to_end/test_gluon.py
@@ -9,22 +9,6 @@ from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.core.data import Load
 
 
-def _has_cuda_device() -> bool:
-    try:
-        return torch.cuda.is_available()
-    except RuntimeError:
-        return False
-
-
-def _has_tma_device() -> bool:
-    if not _has_cuda_device():
-        return False
-    try:
-        return torch.cuda.get_device_capability()[0] >= 9
-    except RuntimeError:
-        return False
-
-
 @gluon.jit
 def _copy_scalar_kernel(in_ptr, out_ptr):
     value = gl.load(in_ptr)
@@ -51,21 +35,18 @@ def _masked_safe_kernel(
     gl.store(out_ptr + offs, value, mask=mask)
 
 
-@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
 def test_gluon_trace_runs_copy_scalar_kernel():
     kernel = triton_viz.trace("tracer", frontend="gluon")(_copy_scalar_kernel)
 
-    inp = torch.tensor([42.0], device="cuda")
+    inp = torch.tensor([42.0])
     out = torch.empty_like(inp)
     kernel[(1,)](inp, out, num_warps=1)
-    torch.cuda.synchronize()
 
     torch.testing.assert_close(out, inp, atol=0, rtol=0)
     assert kernel.client_manager.launch.grid == (1, 1, 1)
     assert len(kernel.client_manager.launch.records) >= 1
 
 
-@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
 def test_gluon_sanitizer_allows_in_bounds_kernel():
     sanitizer = SymbolicSanitizer(abort_on_error=False)
     kernel = triton_viz.trace(
@@ -73,16 +54,14 @@ def test_gluon_sanitizer_allows_in_bounds_kernel():
         frontend="gluon",
     )(_copy_scalar_kernel)
 
-    inp = torch.tensor([42.0], device="cuda")
+    inp = torch.tensor([42.0])
     out = torch.empty_like(inp)
     ret = kernel[(1,)](inp, out, num_warps=1)
-    torch.cuda.synchronize()
 
     assert ret is None
     assert sanitizer.records == []
 
 
-@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
 def test_gluon_sanitizer_reports_real_oob_load_kernel(monkeypatch):
     monkeypatch.setattr(knobs.compilation, "always_compile", True)
     sanitizer = SymbolicSanitizer(abort_on_error=False)
@@ -92,10 +71,9 @@ def test_gluon_sanitizer_reports_real_oob_load_kernel(monkeypatch):
     )(_oob_scalar_offset_kernel)
     kernel.fn.device_caches.clear()
 
-    inp = torch.tensor([42.0], device="cuda")
+    inp = torch.tensor([42.0])
     out = torch.empty_like(inp)
     ret = kernel[(1,)](inp, out, num_warps=1)
-    torch.cuda.synchronize()
 
     assert ret is None
     assert sanitizer.records
@@ -106,7 +84,6 @@ def test_gluon_sanitizer_reports_real_oob_load_kernel(monkeypatch):
     )
 
 
-@pytest.mark.skipif(not _has_cuda_device(), reason="CUDA required for Gluon execution")
 def test_gluon_sanitizer_allows_masked_in_bounds_kernel():
     sanitizer = SymbolicSanitizer(abort_on_error=False)
     kernel = triton_viz.trace(
@@ -114,17 +91,15 @@ def test_gluon_sanitizer_allows_masked_in_bounds_kernel():
         frontend="gluon",
     )(_masked_safe_kernel)
 
-    inp = torch.arange(4, dtype=torch.float32, device="cuda")
-    out = torch.empty((8,), dtype=torch.float32, device="cuda")
+    inp = torch.arange(4, dtype=torch.float32)
+    out = torch.empty((8,), dtype=torch.float32)
     layout = gl.BlockedLayout([1], [32], [1], [0])
     ret = kernel[(1,)](inp, out, 4, 8, layout, num_warps=1)
-    torch.cuda.synchronize()
 
     assert ret is None
     assert sanitizer.records == []
 
 
-@pytest.mark.skipif(not _has_tma_device(), reason="CUDA TMA device required")
 def test_gluon_tma_oob_example_reports(capsys):
     from examples.sanitizer import gluon_tma_oob
 

--- a/tests/end_to_end/test_gluon.py
+++ b/tests/end_to_end/test_gluon.py
@@ -1,3 +1,6 @@
+import importlib.util
+from pathlib import Path
+
 import pytest
 import torch
 from triton import knobs
@@ -101,7 +104,17 @@ def test_gluon_sanitizer_allows_masked_in_bounds_kernel():
 
 
 def test_gluon_tma_oob_example_reports(capsys):
-    from examples.sanitizer import gluon_tma_oob
+    example_path = (
+        Path(__file__).resolve().parents[2]
+        / "examples"
+        / "sanitizer"
+        / "gluon_tma_oob.py"
+    )
+    spec = importlib.util.spec_from_file_location("gluon_tma_oob_example", example_path)
+    assert spec is not None
+    assert spec.loader is not None
+    gluon_tma_oob = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(gluon_tma_oob)
 
     with pytest.raises(SystemExit):
         gluon_tma_oob.run()

--- a/tests/unit/test_adapters.py
+++ b/tests/unit/test_adapters.py
@@ -9,12 +9,14 @@ from triton_viz.core.data import (
     AddPtr,
     BinaryOp,
     CastImpl,
+    Dot,
     IntToPtr,
     Load,
     ProgramId,
     PtrToInt,
     ReduceSum,
     Store,
+    TernaryOp,
     UnaryOp,
 )
 
@@ -470,6 +472,69 @@ def test_gluon_semantic_binary_adapter_drops_bound_semantic():
 
     assert result == "overridden"
     assert calls == [("lhs", "rhs")]
+
+
+def test_gluon_semantic_comparison_adapter_binds_original_callable():
+    from triton.experimental.gluon.language import _semantic as gluon_semantic
+
+    calls = []
+
+    def overrider(lhs, rhs, op):
+        calls.append((lhs, rhs, op))
+        return "overridden"
+
+    result = GLUON_FRONTEND.run_op_overrider(
+        gluon_semantic.GluonSemantic.less_than,
+        BinaryOp,
+        overrider,
+        (object(), "lhs", "rhs"),
+        {},
+    )
+
+    assert result == "overridden"
+    assert calls == [("lhs", "rhs", np.less)]
+
+
+def test_gluon_where_adapter_binds_original_callable():
+    from triton.experimental.gluon import language as ttgl
+
+    calls = []
+
+    def overrider(condition, lhs, rhs, op):
+        calls.append((condition, lhs, rhs, op))
+        return "overridden"
+
+    result = GLUON_FRONTEND.run_op_overrider(
+        ttgl.where,
+        TernaryOp,
+        overrider,
+        ("condition", "lhs", "rhs"),
+        {},
+    )
+
+    assert result == "overridden"
+    assert calls == [("condition", "lhs", "rhs", np.where)]
+
+
+def test_gluon_dot_adapter_preserves_accumulator_for_overriders():
+    from triton.experimental.gluon import language as ttgl
+
+    calls = []
+
+    def overrider(a, b, acc, input_precision, max_num_imprecise_acc):
+        calls.append((a, b, acc, input_precision, max_num_imprecise_acc))
+        return "overridden"
+
+    result = GLUON_FRONTEND.run_op_overrider(
+        ttgl.dot_fma,
+        Dot,
+        overrider,
+        ("a", "b", "acc"),
+        {},
+    )
+
+    assert result == "overridden"
+    assert calls == [("a", "b", "acc", None, None)]
 
 
 def test_gluon_frontend_wraps_symbolic_concrete_fn():

--- a/triton_viz/core/frontend/gluon.py
+++ b/triton_viz/core/frontend/gluon.py
@@ -246,6 +246,19 @@ def _gluon_binary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
     return adapter
 
 
+def _gluon_semantic_binary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
+    def adapter(
+        _semantic: Any,
+        lhs: Any,
+        rhs: Any,
+        *_args: Any,
+        **_kwargs: Any,
+    ) -> AdapterResult:
+        return AdapterResult(lhs, rhs, op)
+
+    return adapter
+
+
 def _gluon_unary_op_adapter(op: Callable) -> Callable[..., AdapterResult]:
     def adapter(arg: Any, *_args: Any, **_kwargs: Any) -> AdapterResult:
         return AdapterResult(arg, op)
@@ -260,11 +273,27 @@ def _gluon_where_adapter(
     *_args: Any,
     **_kwargs: Any,
 ) -> AdapterResult:
-    return AdapterResult(condition, x, y)
+    return AdapterResult(condition, x, y, np.where)
 
 
 def _gluon_dot_adapter(a: Any, b: Any, *_args: Any, **_kwargs: Any) -> AdapterResult:
     return AdapterResult(_gluon_tensor_handle(a), _gluon_tensor_handle(b))
+
+
+def _gluon_dot_overrider_adapter(
+    a: Any,
+    b: Any,
+    acc: Any,
+    *_args: Any,
+    **_kwargs: Any,
+) -> AdapterResult:
+    return AdapterResult(
+        _gluon_tensor_handle(a),
+        _gluon_tensor_handle(b),
+        _gluon_tensor_handle(acc),
+        None,
+        None,
+    )
 
 
 def _gluon_allocate_adapter(*args: Any, **_kwargs: Any) -> AdapterResult:
@@ -471,6 +500,12 @@ _GLUON_BINARY_NUMPY_OPS: dict[str, Callable] = {
     "sub": np.subtract,
     "mul": np.multiply,
 }
+_GLUON_SEMANTIC_BINARY_NUMPY_OPS: dict[str, Callable] = {
+    "less_than": np.less,
+    "less_equal": np.less_equal,
+    "greater_than": np.greater,
+    "greater_equal": np.greater_equal,
+}
 _GLUON_UNARY_NUMPY_OPS: dict[str, Callable] = {
     "abs": np.abs,
     "ceil": np.ceil,
@@ -493,12 +528,22 @@ GLUON_CALLABLE_ADAPTERS: dict[Callable, Callable[..., AdapterResult]] = {}
 for namespace, attrs in GLUON_NAMESPACES.items():
     for attr, op_type in attrs.items():
         original = getattr(namespace, attr)
-        if namespace is gluon_semantic.GluonSemantic and op_type in (AddPtr, BinaryOp):
+        if namespace is gluon_semantic.GluonSemantic and op_type is AddPtr:
             GLUON_CALLABLE_ADAPTERS[original] = _gluon_semantic_binary_adapter
+        elif (
+            namespace is gluon_semantic.GluonSemantic
+            and op_type is BinaryOp
+            and attr in _GLUON_SEMANTIC_BINARY_NUMPY_OPS
+        ):
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_semantic_binary_op_adapter(
+                _GLUON_SEMANTIC_BINARY_NUMPY_OPS[attr]
+            )
         elif op_type is BinaryOp and attr in _GLUON_BINARY_NUMPY_OPS:
             GLUON_CALLABLE_ADAPTERS[original] = _gluon_binary_op_adapter(
                 _GLUON_BINARY_NUMPY_OPS[attr]
             )
+        elif op_type is Dot:
+            GLUON_CALLABLE_ADAPTERS[original] = _gluon_dot_overrider_adapter
         elif op_type is UnaryOp and attr in _GLUON_UNARY_NUMPY_OPS:
             GLUON_CALLABLE_ADAPTERS[original] = _gluon_unary_op_adapter(
                 _GLUON_UNARY_NUMPY_OPS[attr]


### PR DESCRIPTION
## Summary

- Update focused adapter, core trace, and Gluon sanitizer/tracer tests for CPU-backed Gluon simulation.
- Cover descriptor symbolic adapters, concrete CPU execution, and the Gluon simulation trace path before architecture-specific layers.

## Stack

Stacked on #442.
Base branch: `keren/gluon-sim-frontend-wiring`
Head branch: `keren/gluon-sim-core-tests`

## Validation

- `pre-commit run --all-files`
- `PYTHONPATH=. python -m pytest tests/unit/test_adapters.py tests/end_to_end/test_core.py tests/end_to_end/test_gluon.py tests/end_to_end/test_gluon_simulation.py -q`