### PR TITLE
[TEST] Cover Gluon TMA simulation

### DIFF
--- a/tests/end_to_end/test_gluon_simulation.py
+++ b/tests/end_to_end/test_gluon_simulation.py
@@ -448,6 +448,253 @@ def _cpasync_elementwise_add_pipelined_kernel(
 
 
 @gluon.jit
+def _tma_memcpy_1d_kernel(in_desc, out_desc, XBLOCK: gl.constexpr):
+    pid = gl.program_id(0)
+    smem = gl.allocate_shared_memory(in_desc.dtype, [XBLOCK], in_desc.layout)
+    bar = gl.allocate_shared_memory(gl.int64, [1], in_desc.layout)
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.block_type.nbytes)
+    tma.async_load(in_desc, [pid * XBLOCK], bar, smem)
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    tma.async_copy_shared_to_global(out_desc, [pid * XBLOCK], smem)
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def _issue_tma_loads(
+    copy_index,
+    a_desc,
+    b_desc,
+    a_smem,
+    b_smem,
+    bars,
+    xoff,
+    YBLOCK: gl.constexpr,
+    num_buffers: gl.constexpr,
+):
+    yoff = copy_index * YBLOCK
+    bar = bars.index(copy_index % num_buffers)
+    mbarrier.expect(bar, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+    tma.async_load(a_desc, [xoff, yoff], bar, a_smem.index(copy_index % num_buffers))
+    tma.async_load(b_desc, [xoff, yoff], bar, b_smem.index(copy_index % num_buffers))
+    return copy_index + 1
+
+
+@gluon.jit
+def _perform_tma_add(
+    read_index,
+    bars,
+    a_smem,
+    b_smem,
+    c_smem,
+    c_desc,
+    xoff,
+    layout: gl.constexpr,
+    YBLOCK: gl.constexpr,
+    num_buffers: gl.constexpr,
+):
+    mbarrier.wait(bars.index(read_index % num_buffers), read_index // num_buffers & 1)
+    c_smem.store(
+        a_smem.index(read_index % num_buffers).load(layout)
+        + b_smem.index(read_index % num_buffers).load(layout)
+    )
+    fence_async_shared()
+    tma.async_copy_shared_to_global(c_desc, [xoff, read_index * YBLOCK], c_smem)
+    return read_index + 1
+
+
+@gluon.jit
+def _tma_elementwise_add_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    xnumel,
+    ynumel,
+    XBLOCK: gl.constexpr,
+    YBLOCK: gl.constexpr,
+    num_buffers: gl.constexpr,
+):
+    pid = gl.program_id(0)
+    layout: gl.constexpr = gl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
+    xoff = pid * XBLOCK
+    dtype: gl.constexpr = a_desc.type.block_type.element_ty
+    a_smem = gl.allocate_shared_memory(
+        dtype,
+        [num_buffers, XBLOCK, YBLOCK],
+        a_desc.layout,
+    )
+    b_smem = gl.allocate_shared_memory(
+        dtype,
+        [num_buffers, XBLOCK, YBLOCK],
+        b_desc.layout,
+    )
+    c_smem = gl.allocate_shared_memory(dtype, [XBLOCK, YBLOCK], c_desc.layout)
+    bars = gl.allocate_shared_memory(gl.int64, [num_buffers, 1], a_desc.layout)
+    for i in gl.static_range(num_buffers):
+        mbarrier.init(bars.index(i), count=1)
+    copy_index = 0
+    read_index = 0
+    for _ in gl.static_range(num_buffers - 1):
+        copy_index = _issue_tma_loads(
+            copy_index,
+            a_desc,
+            b_desc,
+            a_smem,
+            b_smem,
+            bars,
+            xoff,
+            YBLOCK,
+            num_buffers,
+        )
+    for _ in range(gl.cdiv(ynumel, YBLOCK) - (num_buffers - 1)):
+        copy_index = _issue_tma_loads(
+            copy_index,
+            a_desc,
+            b_desc,
+            a_smem,
+            b_smem,
+            bars,
+            xoff,
+            YBLOCK,
+            num_buffers,
+        )
+        read_index = _perform_tma_add(
+            read_index,
+            bars,
+            a_smem,
+            b_smem,
+            c_smem,
+            c_desc,
+            xoff,
+            layout,
+            YBLOCK,
+            num_buffers,
+        )
+    for _ in gl.static_range(num_buffers - 1):
+        read_index = _perform_tma_add(
+            read_index,
+            bars,
+            a_smem,
+            b_smem,
+            c_smem,
+            c_desc,
+            xoff,
+            layout,
+            YBLOCK,
+            num_buffers,
+        )
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def _tma_message_passing_kernel(
+    message_desc, ready, output, MESSAGE_SIZE: gl.constexpr
+):
+    pid = gl.program_id(0)
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    offsets = gl.arange(0, MESSAGE_SIZE, layout)
+    smem = gl.allocate_shared_memory(
+        message_desc.dtype,
+        message_desc.block_shape,
+        message_desc.layout,
+    )
+
+    if pid == 0:
+        smem.store(offsets + 1000)
+        fence_async_shared()
+        tma.async_copy_shared_to_global(message_desc, [0], smem)
+        tma.store_wait(pendings=0, read_only=False)
+        gl.atomic_xchg(ready, 1, sem="release", scope="gpu")
+    else:
+        ready_value = 0
+        while ready_value != 1:
+            ready_value = gl.atomic_add(ready, 0, sem="acquire", scope="gpu")
+        bar = gl.allocate_shared_memory(gl.int64, [1], message_desc.layout)
+        mbarrier.init(bar, count=1)
+        mbarrier.expect(bar, message_desc.block_type.nbytes)
+        tma.async_load(message_desc, [0], bar, smem)
+        mbarrier.wait(bar, phase=0, deps=[smem])
+        mbarrier.invalidate(bar)
+        gl.store(output + offsets, smem.load(layout))
+
+
+@gluon.jit
+def _tma_multicast_copy_kernel(in_desc, out_desc):
+    gl.static_assert(gl.num_ctas() == 2)
+    smem = gl.allocate_shared_memory(in_desc.dtype, in_desc.block_shape, in_desc.layout)
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.nbytes_per_cta)
+    tma.async_load(in_desc, [0, 0], bar, smem, multicast=True)
+    mbarrier.wait(bar, phase=0, deps=[smem])
+    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+
+
+@gluon.jit
+def _tma_alias_shared_reshape_kernel(in_desc, out_desc):
+    smem = gl.allocate_shared_memory(in_desc.dtype, in_desc.block_shape, in_desc.layout)
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.nbytes_per_cta)
+    tma.async_copy_global_to_shared(in_desc, [0, 0], bar, smem)
+    mbarrier.wait(bar, phase=0, deps=[smem])
+    reshaped = smem.reshape((2, 16)).reshape((4, 8)).permute((1, 0))
+    tma.async_copy_shared_to_global(out_desc, [0, 0], reshaped)
+
+
+@gluon.jit
+def _tma_im2col_kernel(
+    in_desc,
+    out_desc,
+    coord_n,
+    coord_h,
+    coord_w,
+    coord_c,
+    offset_h: gl.constexpr,
+    offset_w: gl.constexpr,
+):
+    smem = gl.allocate_shared_memory(in_desc.dtype, in_desc.block_shape, in_desc.layout)
+    bar = mbarrier.allocate_mbarrier()
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, in_desc.block_type.nbytes)
+    tma.async_load_im2col(
+        in_desc,
+        [coord_n, coord_h, coord_w, coord_c],
+        [offset_h, offset_w],
+        bar,
+        smem,
+    )
+    mbarrier.wait(bar, phase=0)
+    mbarrier.invalidate(bar)
+    tma.async_copy_shared_to_global(out_desc, [0, 0], smem)
+    tma.store_wait(pendings=0)
+
+
+@gluon.jit
+def _tma_oob_kernel(
+    x,
+    m: gl.constexpr,
+    n: gl.constexpr,
+    block_m: gl.constexpr,
+    block_n: gl.constexpr,
+    layout: gl.constexpr,
+):
+    desc = tma.make_tensor_descriptor(
+        x,
+        [m, n],
+        [n, 1],
+        [block_m, block_n],
+        layout,
+    )
+    smem = gl.allocate_shared_memory(gl.float32, [block_m, block_n], layout)
+    bar = gl.allocate_shared_memory(gl.int64, [1], layout)
+    mbarrier.init(bar, count=1)
+    mbarrier.expect(bar, desc.nbytes_per_cta)
+    tma.async_load(desc, [m, 0], bar, smem)
+
+
+@gluon.jit
 def _layout_anchor_and_barrier_kernel(in_ptr, out_ptr, N: gl.constexpr):
     layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
     offsets = gl.arange(0, N, layout)
@@ -613,6 +860,186 @@ def test_gluon_simulator_runs_pipelined_cpasync_add_on_cpu():
     )
 
     torch.testing.assert_close(c, a + b, atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_tma_memcpy_1d_synchronously_on_cpu():
+    inp = torch.arange(40, dtype=torch.float32)
+    out = torch.full_like(inp, -1)
+    layout = gl.NVMMASharedLayout.get_default_for([64], gl.float32)
+    in_desc = TensorDescriptor.from_tensor(inp, [64], layout)
+    out_desc = TensorDescriptor.from_tensor(out, [64], layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_tma_memcpy_1d_kernel)
+
+    kernel[(1,)](in_desc, out_desc, 64, num_warps=1)
+
+    torch.testing.assert_close(out, inp, atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_pipelined_tma_add_on_cpu():
+    a = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    b = 10 + a
+    c = torch.empty_like(a)
+    layout = gl.NVMMASharedLayout.get_default_for([8, 4], gl.float32)
+    a_desc = TensorDescriptor.from_tensor(a, [8, 4], layout)
+    b_desc = TensorDescriptor.from_tensor(b, [8, 4], layout)
+    c_desc = TensorDescriptor.from_tensor(c, [8, 4], layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_tma_elementwise_add_kernel)
+
+    kernel[(1,)](
+        a_desc,
+        b_desc,
+        c_desc,
+        *a.shape,
+        8,
+        4,
+        2,
+        num_warps=4,
+    )
+
+    torch.testing.assert_close(c, a + b, atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_tma_message_passing_synchronously_on_cpu():
+    message_size = 16
+    message = torch.full((message_size,), -1, dtype=torch.int32)
+    ready = torch.zeros(1, dtype=torch.int32)
+    output = torch.full((message_size,), -1, dtype=torch.int32)
+    layout = gl.NVMMASharedLayout.get_default_for([message_size], gl.int32)
+    message_desc = TensorDescriptor.from_tensor(message, [message_size], layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_tma_message_passing_kernel)
+
+    kernel[(2,)](message_desc, ready, output, message_size, num_warps=1)
+
+    expected = torch.arange(message_size, dtype=torch.int32) + 1000
+    torch.testing.assert_close(message, expected, atol=0, rtol=0)
+    torch.testing.assert_close(output, expected, atol=0, rtol=0)
+    assert ready.item() == 1
+
+
+def test_gluon_simulator_runs_tma_multicast_copy_on_cpu():
+    inp = torch.arange(16 * 16, dtype=torch.float16).reshape(16, 16)
+    out = torch.empty_like(inp)
+    layout = gl.NVMMASharedLayout.get_default_for(
+        list(inp.shape),
+        gl.float16,
+        cga_layout=[[0, 0]],
+    )
+    in_desc = TensorDescriptor.from_tensor(inp, list(inp.shape), layout)
+    out_desc = TensorDescriptor.from_tensor(out, list(out.shape), layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_tma_multicast_copy_kernel)
+
+    kernel[(1,)](in_desc, out_desc, num_warps=4, num_ctas=2)
+
+    torch.testing.assert_close(out, inp, atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_tma_alias_with_shared_reshape_on_cpu():
+    inp = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    out = torch.empty((8, 4), dtype=torch.float32)
+    in_layout = gl.NVMMASharedLayout.get_default_for([4, 8], gl.float32)
+    out_layout = gl.NVMMASharedLayout.get_default_for([8, 4], gl.float32)
+    in_desc = TensorDescriptor.from_tensor(inp, [4, 8], in_layout)
+    out_desc = TensorDescriptor.from_tensor(out, [8, 4], out_layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(
+        _tma_alias_shared_reshape_kernel
+    )
+
+    kernel[(1,)](in_desc, out_desc, num_warps=4)
+
+    torch.testing.assert_close(out, inp.T.contiguous(), atol=0, rtol=0)
+
+
+def _run_im2col_case(
+    inp,
+    pixel_box_lower_corner,
+    pixel_box_upper_corner,
+    coord,
+    offsets,
+):
+    out = torch.zeros((16, 32), dtype=torch.float32)
+    layout = gl.NVMMASharedLayout(
+        swizzle_byte_width=128,
+        element_bitwidth=32,
+        rank=2,
+    )
+    in_desc = TensorDescriptorIm2Col.from_tensor(
+        inp,
+        [16, 32],
+        layout,
+        padding="zero",
+        element_strides=[1, 1, 1, 1],
+        pixel_box_lower_corner=pixel_box_lower_corner,
+        pixel_box_upper_corner=pixel_box_upper_corner,
+    )
+    out_desc = TensorDescriptor.from_tensor(out, [16, 32], layout)
+    kernel = triton_viz.trace("tracer", frontend="gluon")(_tma_im2col_kernel)
+
+    kernel[(1,)](in_desc, out_desc, *coord, *offsets, num_warps=1)
+
+    return out
+
+
+def test_gluon_simulator_runs_tma_im2col_simple_on_cpu():
+    inp = torch.arange(1, 17, dtype=torch.float32).unsqueeze(1).repeat(1, 32)
+    inp = inp.reshape(1, 4, 4, 32)
+
+    out = _run_im2col_case(inp, [0, 0], [0, 0], [0, 0, 0, 0], [0, 0])
+
+    torch.testing.assert_close(out, inp.reshape(16, 32), atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_tma_im2col_padded_and_offset_on_cpu():
+    inp = torch.arange(1, 17, dtype=torch.float32).unsqueeze(1).repeat(1, 32)
+    inp = inp.reshape(1, 4, 4, 32)
+
+    padded = _run_im2col_case(inp, [-1, -1], [-1, -1], [0, -1, -1, 0], [0, 0])
+    expected_padded = torch.tensor(
+        [0, 0, 0, 0, 0, 1, 2, 3, 0, 5, 6, 7, 0, 9, 10, 11],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(padded[:, 0], expected_padded, atol=0, rtol=0)
+
+    shifted = _run_im2col_case(inp, [-1, -1], [-1, -1], [0, -1, -1, 0], [1, 1])
+    torch.testing.assert_close(shifted, inp.reshape(16, 32), atol=0, rtol=0)
+
+
+def test_gluon_simulator_runs_tma_im2col_multi_batch_on_cpu():
+    inp = torch.arange(1, 33, dtype=torch.float32).unsqueeze(1).repeat(1, 32)
+    inp = inp.reshape(2, 4, 4, 32)
+
+    out = _run_im2col_case(inp, [0, 0], [0, 0], [0, 1, 3, 0], [0, 0])
+    expected = torch.tensor(
+        [8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(out[:, 0], expected, atol=0, rtol=0)
+
+    padded = _run_im2col_case(inp, [-1, -1], [-1, -1], [0, 1, 2, 0], [0, 0])
+    expected_padded = torch.tensor(
+        [7, 0, 9, 10, 11, 0, 0, 0, 0, 0, 17, 18, 19, 0, 21, 22],
+        dtype=torch.float32,
+    )
+    torch.testing.assert_close(padded[:, 0], expected_padded, atol=0, rtol=0)
+
+
+def test_gluon_simulator_sanitizer_reports_tma_descriptor_oob_on_cpu():
+    block_m = 16
+    block_n = 16
+    x = torch.zeros((block_m, block_n), dtype=torch.float32)
+    layout = gl.NVMMASharedLayout.get_default_for([block_m, block_n], gl.float32)
+    sanitizer = SymbolicSanitizer(abort_on_error=False)
+    kernel = triton_viz.trace(sanitizer, frontend="gluon")(_tma_oob_kernel)
+
+    kernel[(1,)](x, block_m, block_n, block_m, block_n, layout, num_warps=4)
+
+    assert len(sanitizer.records) == 1
+    assert sanitizer.records[0].op_type is Load
+    assert sanitizer.records[0].tensor.data_ptr() == x.data_ptr()
+    assert tuple(sanitizer.records[0].tensor.shape) == tuple(x.shape)
+    assert sanitizer.records[0].violation_address == (
+        x.data_ptr() + block_m * block_n * x.element_size()
+    )
+    assert "descriptor_access" in str(sanitizer.records[0].symbolic_expr)
 
 
 def test_gluon_simulator_runs_layout_anchor_and_barrier_on_cpu():


### PR DESCRIPTION
## Summary

- Add Gluon CPU simulation coverage for TMA memcpy/add pipelines, message passing, multicast, shared-memory aliasing, im2col, and descriptor sanitizer OOB reporting.

## Stack

Stacked on #444.
Base branch: `keren/gluon-sim-tests-core-layout`
Head branch: `keren/gluon-sim-tests-tma`

## Validation

- `pre-commit run --all-files`
- `PYTHONPATH=. python -m pytest tests/unit/test_adapters.py tests/end_to_end/test_core.py tests/end_to_end/test_gluon.py tests/end_to_end/test_gluon_simulation.py -q`