### PR TITLE
[TEST] Cover Gluon TMA simulation ops

### DIFF
--- a/tests/end_to_end/test_gluon.py
+++ b/tests/end_to_end/test_gluon.py
@@ -6,8 +6,16 @@ import torch
 from triton import knobs
 from triton.experimental import gluon
 from triton.experimental.gluon import language as gl
+from triton.experimental.gluon.language.nvidia import hopper
+from triton.experimental.gluon.language.nvidia.hopper import (
+    mbarrier,
+    tma,
+)
+from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 
 import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
 from triton_viz.clients.sanitizer.sanitizer import SymbolicSanitizer
 from triton_viz.core.data import Load
 
@@ -30,6 +38,40 @@ _HAS_AMD_CDNA4_ASYNC_COPY = (
     amd_cdna4_cp is not None
     and getattr(amd_cdna4_cp, "global_load_to_shared", None) is not None
 )
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
 
 
 @gluon.jit
@@ -241,6 +283,79 @@ def _async_copy_elementwise_add_kernel(
     )
 
 
+@gluon.jit
+def _tma_copy_1d_kernel(in_desc, out_desc, BLOCK: gl.constexpr):
+    pid = gl.program_id(0)
+    smem = gl.allocate_shared_memory(in_desc.dtype, [BLOCK], in_desc.layout)
+    barrier = gl.allocate_shared_memory(gl.int64, [1], in_desc.layout)
+
+    mbarrier.init(barrier, count=1)
+    mbarrier.expect(barrier, in_desc.block_type.nbytes)
+    tma.async_load(in_desc, [pid * BLOCK], barrier, smem)
+    mbarrier.wait(barrier, phase=0)
+    mbarrier.invalidate(barrier)
+    tma.async_store(out_desc, [pid * BLOCK], smem)
+    tma.store_wait(0)
+
+
+@gluon.jit
+def _tma_elementwise_add_kernel(
+    a_desc,
+    b_desc,
+    out_desc,
+    xnumel,
+    ynumel,
+    XBLOCK: gl.constexpr,
+    YBLOCK: gl.constexpr,
+):
+    layout: gl.constexpr = gl.BlockedLayout([1, 1], [1, 32], [1, 4], [1, 0])
+    a_smem = gl.allocate_shared_memory(a_desc.dtype, [XBLOCK, YBLOCK], a_desc.layout)
+    b_smem = gl.allocate_shared_memory(b_desc.dtype, [XBLOCK, YBLOCK], b_desc.layout)
+    out_smem = gl.allocate_shared_memory(
+        out_desc.dtype,
+        [XBLOCK, YBLOCK],
+        out_desc.layout,
+    )
+    barrier = gl.allocate_shared_memory(gl.int64, [1], a_desc.layout)
+
+    mbarrier.init(barrier, count=1)
+    mbarrier.expect(barrier, a_desc.block_type.nbytes + b_desc.block_type.nbytes)
+    tma.async_load(a_desc, [0, 0], barrier, a_smem)
+    tma.async_load(b_desc, [0, 0], barrier, b_smem)
+    mbarrier.wait(barrier, phase=0)
+    out_smem.store(a_smem.load(layout) + b_smem.load(layout))
+    hopper.fence_async_shared()
+    tma.async_store(out_desc, [0, 0], out_smem)
+    tma.store_wait(0)
+
+
+@gluon.jit
+def _tma_atomic_float_kernel(
+    add_desc,
+    min_desc,
+    max_desc,
+    src_ptr,
+    BLOCK_M: gl.constexpr,
+    BLOCK_N: gl.constexpr,
+):
+    layout: gl.constexpr = gl.BlockedLayout(
+        [1, 1],
+        [1, 32],
+        [1, gl.num_warps()],
+        [1, 0],
+    )
+    offs_m = gl.arange(0, BLOCK_M, gl.SliceLayout(1, layout))
+    offs_n = gl.arange(0, BLOCK_N, gl.SliceLayout(0, layout))
+    src = gl.load(src_ptr + offs_m[:, None] * BLOCK_N + offs_n[None, :])
+    smem = gl.allocate_shared_memory(src.dtype, [BLOCK_M, BLOCK_N], add_desc.layout)
+    smem.store(src)
+    hopper.fence_async_shared()
+    tma.async_atomic_add(add_desc, [1, 2], smem)
+    tma.async_atomic_min(min_desc, [1, 2], smem)
+    tma.async_atomic_max(max_desc, [1, 2], smem)
+    tma.store_wait(0)
+
+
 def test_gluon_trace_runs_copy_scalar_kernel():
     kernel = triton_viz.trace("tracer", frontend="gluon")(_copy_scalar_kernel)
 
@@ -432,6 +547,66 @@ def test_gluon_async_copy_runs_staged_elementwise_add_on_cpu():
     )
 
     torch.testing.assert_close(out, a + b, atol=0, rtol=0)
+
+
+def test_gluon_tma_runs_1d_copy_on_cpu():
+    inp = torch.arange(40, dtype=torch.float32)
+    out = torch.full_like(inp, -1)
+    layout = gl.NVMMASharedLayout.get_default_for([64], gl.float32)
+    in_desc = TensorDescriptor.from_tensor(inp, [64], layout)
+    out_desc = TensorDescriptor.from_tensor(out, [64], layout)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(_tma_copy_1d_kernel)
+
+    kernel[(1,)](in_desc, out_desc, 64, num_warps=1)
+
+    torch.testing.assert_close(out, inp, atol=0, rtol=0)
+
+
+def test_gluon_tma_runs_staged_elementwise_add_on_cpu():
+    a = torch.arange(32, dtype=torch.float32).reshape(4, 8)
+    b = 10 + a
+    out = torch.full_like(a, -1)
+    layout = gl.NVMMASharedLayout.get_default_for([4, 8], gl.float32)
+    a_desc = TensorDescriptor.from_tensor(a, [4, 8], layout)
+    b_desc = TensorDescriptor.from_tensor(b, [4, 8], layout)
+    out_desc = TensorDescriptor.from_tensor(out, [4, 8], layout)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(
+        _tma_elementwise_add_kernel
+    )
+
+    kernel[(1,)](a_desc, b_desc, out_desc, *a.shape, 4, 8, num_warps=4)
+
+    torch.testing.assert_close(out, a + b, atol=0, rtol=0)
+
+
+def test_gluon_tma_runs_float_atomics_on_cpu():
+    block_m = 2
+    block_n = 4
+    src = torch.tensor(
+        [[3.0, -2.0, 0.5, 8.0], [1.5, 7.0, -4.0, 0.25]],
+        dtype=torch.float32,
+    )
+    add_dst = torch.arange(40, dtype=torch.float32).reshape(5, 8)
+    min_dst = add_dst + 10.0
+    max_dst = add_dst - 10.0
+    layout = gl.NVMMASharedLayout.get_default_for([block_m, block_n], gl.float32)
+    add_desc = TensorDescriptor.from_tensor(add_dst, [block_m, block_n], layout)
+    min_desc = TensorDescriptor.from_tensor(min_dst, [block_m, block_n], layout)
+    max_desc = TensorDescriptor.from_tensor(max_dst, [block_m, block_n], layout)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(_tma_atomic_float_kernel)
+
+    expected_add = add_dst.clone()
+    expected_min = min_dst.clone()
+    expected_max = max_dst.clone()
+    expected_add[1:3, 2:6] += src
+    expected_min[1:3, 2:6] = torch.minimum(expected_min[1:3, 2:6], src)
+    expected_max[1:3, 2:6] = torch.maximum(expected_max[1:3, 2:6], src)
+
+    kernel[(1,)](add_desc, min_desc, max_desc, src, block_m, block_n, num_warps=4)
+
+    torch.testing.assert_close(add_dst, expected_add, atol=0, rtol=0)
+    torch.testing.assert_close(min_dst, expected_min, atol=0, rtol=0)
+    torch.testing.assert_close(max_dst, expected_max, atol=0, rtol=0)
 
 
 def test_gluon_tma_oob_example_reports(capsys):

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -509,6 +509,10 @@ class TensorDescriptor(gluon_hopper_tma.tensor_descriptor):
     def data(self) -> np.ndarray:
         return self._array
 
+    @property
+    def handle(self):
+        return self
+
     def data_ptr(self) -> int:
         data_ptr = getattr(self.base, "data_ptr", None)
         if callable(data_ptr):
@@ -1103,6 +1107,9 @@ class Builder(interpreter_builder.__class__):
         self._pending_clc_barriers: set[int] = set()
 
     def _barrier_key(self, barrier: Any) -> int:
+        handle = getattr(barrier, "handle", None)
+        if isinstance(handle, SharedMemoryHandle):
+            barrier = handle
         if isinstance(barrier, SharedMemoryHandle):
             # Shared memory descriptors can be rewrapped; the backing buffer is
             # the stable identity for matching expect/arrive/wait calls.
@@ -1762,7 +1769,15 @@ class Builder(interpreter_builder.__class__):
             result.data[...] = tensor_desc.load_block(coord)
         else:
             result.data[...] = tensor_desc.load_im2col_block(coord, offsets)
-        self._signal_barrier(barrier)
+        state = self._barrier_state(barrier)
+        nbytes = tensor_desc.block_type.nbytes
+        should_signal = True
+        with state.condition:
+            if state.pending_bytes > nbytes:
+                state.pending_bytes -= nbytes
+                should_signal = False
+        if should_signal:
+            self._signal_barrier(barrier)
         return None
 
     def create_async_tma_copy_local_to_global(
@@ -1783,6 +1798,9 @@ class Builder(interpreter_builder.__class__):
     ):
         kind_name = str(kind).split(".")[-1].lower()
         tensor_desc.reduce_block(coord, np.asarray(src.data), kind_name)
+        return None
+
+    def create_async_tma_store_wait(self, pendings: Any = 0, read_only: Any = True):
         return None
 
     def create_async_tma_gather(
@@ -2413,6 +2431,48 @@ _GLUON_BUILTIN_CLASSES: tuple[Any, ...] = tuple(
 )
 
 
+def _make_tma_atomic_reduce(kind: Any) -> Callable:
+    @gluon_core.builtin
+    def async_atomic_reduce(tensor_desc, coord, src, _semantic=None):
+        semantic = gluon_semantic if _semantic is None else _semantic
+        coord = semantic._convert_to_ir_values(coord, require_i64=False)
+        semantic.builder.create_async_tma_reduce(
+            kind,
+            tensor_desc.handle,
+            coord,
+            src.handle,
+        )
+
+    return async_atomic_reduce
+
+
+def _patch_tma_compat_aliases(module: Any, scope: _LangPatchScope) -> None:
+    if module is None:
+        return
+
+    for new_name, old_name in (
+        ("async_load", "async_copy_global_to_shared"),
+        ("async_load_im2col", "async_copy_global_to_shared_im2col"),
+        ("async_store", "async_copy_shared_to_global"),
+    ):
+        if not hasattr(module, new_name) and hasattr(module, old_name):
+            scope.set_attr(module, new_name, getattr(module, old_name))
+
+    reduce_kind = getattr(gluon_core.ir, "DESCRIPTOR_REDUCE_KIND", None)
+    if reduce_kind is None:
+        return
+    for name, kind in (
+        ("async_atomic_add", reduce_kind.ADD),
+        ("async_atomic_min", reduce_kind.MIN),
+        ("async_atomic_max", reduce_kind.MAX),
+        ("async_atomic_and", reduce_kind.AND),
+        ("async_atomic_or", reduce_kind.OR),
+        ("async_atomic_xor", reduce_kind.XOR),
+    ):
+        if not hasattr(module, name):
+            scope.set_attr(module, name, _make_tma_atomic_reduce(kind))
+
+
 def _yield_warp_specialize() -> None:
     from triton_viz.core.frontend import gluon as gluon_frontend
 
@@ -2443,6 +2503,8 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
     """Patch Gluon builtins to execute through the NumPy interpreter builder."""
 
     scope = _LangPatchScope()
+    _patch_tma_compat_aliases(gluon_hopper_tma, scope)
+    _patch_tma_compat_aliases(gluon_blackwell_tma, scope)
     for module in _GLUON_BUILTIN_MODULES:
         _patch_gluon_builtins(module, scope)
     for cls in _GLUON_BUILTIN_CLASSES:


### PR DESCRIPTION
## Summary

Adds CPU regression coverage for the Gluon TMA descriptor-memory category, stacked on the async-copy simulation PR.

The new tests cover:

- Hopper TMA descriptor 1D load/store roundtrip
- staged 2D elementwise add through TMA loads into shared memory and TMA store back to global memory
- TMA async float atomics for add/min/max

The tests assert against expected torch CPU tensors and use a no-op client because descriptor-based Tracer/Profiler callbacks are intentionally not covered right now.

This also fixes the CPU simulator pieces needed by those supported TMA ops: descriptor `.handle` access, wrapper/handle barrier identity, expected-byte barrier completion for multiple TMA loads, and TMA store-wait as a synchronous no-op.

## Validation

- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_tma_ops.py -q`
- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q`
- `pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_tma_ops.py`