### PR TITLE
[TEST] Cover Gluon Hopper WGMMA ops

### DIFF
--- a/tests/end_to_end/test_gluon.py
+++ b/tests/end_to_end/test_gluon.py
@@ -525,6 +525,102 @@ def _run_im2col_case(
     return out
 
 
+@gluon.constexpr_function
+def _wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
+    instr_m = 16
+    instr_n = min(BLOCK_N, 64)
+    while BLOCK_N % instr_n != 0:
+        instr_n -= 8
+    return gl.NVMMADistributedLayout(
+        version=[3, 0],
+        warps_per_cta=[num_warps, 1],
+        instr_shape=[instr_m, instr_n, 256 // dtype.primitive_bitwidth],
+    )
+
+
+@gluon.jit
+def _small_wgmma_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    out_desc,
+    LHS_IN_REG: gl.constexpr,
+    num_warps: gl.constexpr,
+):
+    barrier = gl.allocate_shared_memory(gl.int64, [1], mbarrier.MBarrierLayout())
+    mbarrier.init(barrier, count=1)
+    a_smem = gl.allocate_shared_memory(
+        a_desc.dtype,
+        a_desc.block_type.shape,
+        a_desc.layout,
+    )
+    b_smem = gl.allocate_shared_memory(
+        b_desc.dtype,
+        b_desc.block_type.shape,
+        b_desc.layout,
+    )
+    c_smem = gl.allocate_shared_memory(
+        c_desc.dtype,
+        c_desc.block_type.shape,
+        c_desc.layout,
+    )
+    mbarrier.expect(
+        barrier,
+        a_desc.block_type.nbytes + b_desc.block_type.nbytes + c_desc.block_type.nbytes,
+    )
+    tma.async_load(a_desc, [0, 0], barrier, a_smem)
+    tma.async_load(b_desc, [0, 0], barrier, b_smem)
+    tma.async_load(c_desc, [0, 0], barrier, c_smem)
+    mbarrier.wait(barrier, phase=0)
+    mbarrier.invalidate(barrier)
+
+    acc_layout: gl.constexpr = _wgmma_layout(
+        a_desc.dtype,
+        out_desc.block_type.shape[0],
+        out_desc.block_type.shape[1],
+        num_warps,
+    )
+    a_reg_layout: gl.constexpr = gl.DotOperandLayout(
+        operand_index=0,
+        parent=acc_layout,
+        k_width=32 // a_desc.dtype.primitive_bitwidth,
+    )
+    a = a_smem.load(a_reg_layout) if LHS_IN_REG else a_smem
+    c = c_smem.load(acc_layout)
+    out = hopper.warpgroup_mma(a, b_smem, c, is_async=True, use_acc=True)
+    out = hopper.warpgroup_mma_wait(num_outstanding=0, deps=(out,))
+
+    out_smem = gl.allocate_shared_memory(
+        out_desc.dtype,
+        out_desc.block_type.shape,
+        out_desc.layout,
+    )
+    out_smem.store(out)
+    hopper.fence_async_shared()
+    tma.async_store(out_desc, [0, 0], out_smem)
+    tma.store_wait(0)
+
+
+def _run_small_wgmma_case(seed: int, lhs_in_reg: bool):
+    torch.manual_seed(seed)
+    a = torch.randn(64, 32, dtype=torch.float16) / 4
+    b = torch.randn(32, 32, dtype=torch.float16) / 4
+    c = torch.randn(64, 32, dtype=torch.float32) / 4
+    out = torch.empty_like(c)
+    a_layout = gl.NVMMASharedLayout.get_default_for(a.shape, gl.float16)
+    b_layout = gl.NVMMASharedLayout.get_default_for(b.shape, gl.float16)
+    c_layout = gl.NVMMASharedLayout.get_default_for(c.shape, gl.float32)
+    a_desc = TensorDescriptor.from_tensor(a, list(a.shape), a_layout)
+    b_desc = TensorDescriptor.from_tensor(b, list(b.shape), b_layout)
+    c_desc = TensorDescriptor.from_tensor(c, list(c.shape), c_layout)
+    out_desc = TensorDescriptor.from_tensor(out, list(out.shape), c_layout)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(_small_wgmma_kernel)
+
+    kernel[(1,)](a_desc, b_desc, c_desc, out_desc, lhs_in_reg, num_warps=4)
+
+    torch.testing.assert_close(out, a.float() @ b.float() + c, atol=1e-2, rtol=1e-2)
+
+
 def test_gluon_trace_runs_copy_scalar_kernel():
     kernel = triton_viz.trace("tracer", frontend="gluon")(_copy_scalar_kernel)
 
@@ -819,6 +915,14 @@ def test_gluon_tma_im2col_honors_runtime_offsets_on_cpu():
     out = _run_im2col_case(inp, [-1, -1], [-1, -1], [0, -1, -1, 0], [1, 1])
 
     torch.testing.assert_close(out, inp.reshape(16, 32), atol=0, rtol=0)
+
+
+def test_gluon_wgmma_runs_small_mma_on_cpu():
+    _run_small_wgmma_case(seed=0, lhs_in_reg=False)
+
+
+def test_gluon_wgmma_runs_small_mma_with_lhs_registers_on_cpu():
+    _run_small_wgmma_case(seed=1, lhs_in_reg=True)
 
 
 def test_gluon_blackwell_tma_runs_gather_on_cpu():


### PR DESCRIPTION
## Summary

Adds CPU regression coverage for the Hopper WGMMA small-MMA operator category, stacked on the TMA im2col PR.

The new tests cover:

- `hopper.warpgroup_mma` with shared-memory operands
- `hopper.warpgroup_mma` with the LHS operand loaded into registers
- `hopper.warpgroup_mma_wait` for the async result path

Both variants compare the simulated result against `a.float() @ b.float() + c` on CPU.

## Validation

- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_wgmma_ops.py -q`
- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q`
- `pre-commit run --files tests/end_to_end/test_gluon_wgmma_ops.py`
