### PR TITLE
[TEST] Cover Gluon shared memory descriptor ops

### DIFF
--- a/tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py
+++ b/tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py
@@ -1,0 +1,77 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _shared_memory_slice_kernel(in_ptr, out_ptr, M: gl.constexpr, N: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout(
+        [1, 1],
+        [1, 32],
+        [1, gl.num_warps()],
+        [1, 0],
+    )
+    offs_m = gl.arange(0, M, gl.SliceLayout(1, layout))
+    offs_n = gl.arange(0, N, gl.SliceLayout(0, layout))
+    data = gl.load(in_ptr + offs_m[:, None] * N + offs_n[None, :])
+    smem_layout: gl.constexpr = gl.NVMMASharedLayout.get_default_for(
+        [M, N],
+        data.dtype,
+    )
+    smem = gl.allocate_shared_memory(data.dtype, [M, N], smem_layout)
+    smem.store(data)
+    left = smem.slice(0, N // 2, dim=1)
+    right = smem.slice(N // 2, N // 2, dim=1)
+    out = left.load(layout) + right.load(layout)
+    half_n = gl.arange(0, N // 2, gl.SliceLayout(0, layout))
+    gl.store(out_ptr + offs_m[:, None] * (N // 2) + half_n[None, :], out)
+
+
+def test_gluon_shared_memory_slice_sums_halves_on_cpu():
+    inp = torch.arange(32 * 16, dtype=torch.float32).reshape(32, 16)
+    out = torch.empty((32, 8), dtype=torch.float32)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(
+        _shared_memory_slice_kernel
+    )
+
+    kernel[(1,)](inp, out, *inp.shape, num_warps=4)
+
+    torch.testing.assert_close(out, inp[:, :8] + inp[:, 8:], atol=0, rtol=0)

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -2361,6 +2361,22 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
     def invalidate_mbarrier(mbarrier: Any, **_kwargs: Any):
         return gluon_builder.create_mbarrier_inval(mbarrier)
 
+    def slice_shared_memory(
+        mem_desc: Any,
+        start: Any,
+        length: Any,
+        dim: Any = 0,
+        **_kwargs: Any,
+    ):
+        return gluon_semantic.memdesc_slice(
+            mem_desc,
+            _unwrap_constexpr(start),
+            _unwrap_constexpr(length),
+            _unwrap_constexpr(dim),
+        )
+
+    scope.set_attr(gluon_core.shared_memory_descriptor, "slice", slice_shared_memory)
+
     if gluon_ampere_mbarrier is not None:
         scope.set_attr(gluon_ampere_mbarrier, "allocate_mbarrier", allocate_mbarrier)
         scope.set_attr(gluon_ampere_mbarrier, "init", init_mbarrier)


### PR DESCRIPTION
## Summary

Add CPU-result coverage for Gluon shared-memory descriptor slicing.

This adds a focused end-to-end test that:
- loads a 2D tile into shared memory
- slices the shared-memory descriptor into left/right column halves
- loads both descriptor slices
- checks their sum against a PyTorch CPU reference

The branch also patches `shared_memory_descriptor.slice` through the Gluon CPU simulation scope. Current Gluon does not mark this method as a builtin, so the generic builtin patcher does not inject the builder-backed semantic automatically.

## Validation

- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py -q`
- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q`
- `pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py`
