### PR TITLE
[TEST] Cover Gluon math helper ops

### DIFF
--- a/tests/end_to_end/test_gluon_math_helper_ops.py
+++ b/tests/end_to_end/test_gluon_math_helper_ops.py
@@ -1,0 +1,66 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _math_helpers_kernel(out, clamp_out, BLOCK: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    offsets = gl.arange(0, BLOCK, layout=layout)
+    values = gl.exp2(offsets.to(gl.float32))
+    logs = gl.log2(values)
+    mask = offsets < (BLOCK // 2)
+    selected = gl.where(mask, logs, 0.0)
+    gl.store(out, gl.sum(selected, axis=0))
+    centered = offsets.to(gl.float32) - (BLOCK // 2)
+    gl.store(clamp_out + offsets, gl.clamp(centered, -2.0, 2.0))
+
+
+def test_gluon_math_helpers_match_cpu_results():
+    out = torch.empty((1,), dtype=torch.float32)
+    clamp_out = torch.empty((8,), dtype=torch.float32)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(_math_helpers_kernel)
+
+    kernel[(1,)](out, clamp_out, 8, num_warps=1)
+
+    assert out.item() == sum(range(4))
+    expected_clamp = torch.clamp(torch.arange(8, dtype=torch.float32) - 4, -2.0, 2.0)
+    torch.testing.assert_close(clamp_out, expected_clamp, atol=0, rtol=0)

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -991,6 +991,16 @@ def _tensor_result(
     return handle
 
 
+def _language_tensor_result(data: np.ndarray, dtype: tl.dtype) -> tl.tensor:
+    data = np.asarray(data, dtype=_get_np_dtype(dtype))
+    if data.shape:
+        ty = tl.block_type(dtype, list(data.shape))
+    else:
+        data = data.reshape(1)
+        ty = dtype
+    return tl.tensor(TensorHandle(data, dtype), ty)
+
+
 def _local_indices(
     indices: np.ndarray, axis: int
 ) -> Iterator[tuple[tuple[int, ...], tuple[int, ...]]]:
@@ -2376,6 +2386,43 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
         )
 
     scope.set_attr(gluon_core.shared_memory_descriptor, "slice", slice_shared_memory)
+
+    def reduce_sum(
+        input: Any,
+        axis: Any = None,
+        keep_dims: Any = False,
+        dtype: Any = None,
+    ):
+        input = gluon_semantic.to_tensor(input)
+        result_dtype = input.dtype if dtype is None else _unwrap_constexpr(dtype)
+        data = np.asarray(input.handle.data, dtype=_get_np_dtype(result_dtype))
+        axis_value = None if axis is None else int(_unwrap_constexpr(axis))
+        result = np.sum(
+            data, axis=axis_value, keepdims=bool(_unwrap_constexpr(keep_dims))
+        )
+        return _language_tensor_result(result, result_dtype)
+
+    def reduce_max(
+        input: Any,
+        axis: Any = None,
+        return_indices: Any = False,
+        return_indices_tie_break_left: Any = True,
+        keep_dims: Any = False,
+    ):
+        if bool(_unwrap_constexpr(return_indices)):
+            raise NotImplementedError("Gluon interpreter max indices are unsupported")
+        input = gluon_semantic.to_tensor(input)
+        axis_value = None if axis is None else int(_unwrap_constexpr(axis))
+        result = np.max(
+            np.asarray(input.handle.data),
+            axis=axis_value,
+            keepdims=bool(_unwrap_constexpr(keep_dims)),
+        )
+        return _language_tensor_result(result, input.dtype)
+
+    for module in (gl, gluon_standard):
+        scope.set_attr(module, "sum", reduce_sum)
+        scope.set_attr(module, "max", reduce_max)
 
     if gluon_ampere_mbarrier is not None:
         scope.set_attr(gluon_ampere_mbarrier, "allocate_mbarrier", allocate_mbarrier)


### PR DESCRIPTION
## Summary

Add CPU-result coverage for Gluon math helper operations.

This adds a focused end-to-end test that:
- runs `exp2` and `log2`
- uses `where` and `sum` for a masked scalar reduction
- uses `clamp` for vector output
- checks all results against CPU/PyTorch references

The branch also patches Gluon standard `sum` and `max` helpers in the simulation scope. These helpers are Gluon JIT functions rather than builtin-marked functions, so they need explicit NumPy-backed replacements when running through the interpreter.

## Validation

- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_math_helper_ops.py -q`
- `PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_math_helper_ops.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q`
- `pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_math_helper_ops.py`
