### PR TITLE
[TEST] Cover Gluon libdevice helper ops

### DIFF
--- a/tests/end_to_end/test_gluon_libdevice_helper_ops.py
+++ b/tests/end_to_end/test_gluon_libdevice_helper_ops.py
@@ -1,0 +1,77 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+import triton.language.extra.libdevice as libdevice
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _libdevice_helpers_kernel(
+    x_ptr,
+    y_ptr,
+    exp_out,
+    fast_exp_out,
+    div_out,
+    BLOCK: gl.constexpr,
+):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    offsets = gl.arange(0, BLOCK, layout=layout)
+    x = gl.load(x_ptr + offsets)
+    y = gl.load(y_ptr + offsets)
+    gl.store(exp_out + offsets, libdevice.exp(x))
+    gl.store(fast_exp_out + offsets, libdevice.fast_expf(x))
+    gl.store(div_out + offsets, libdevice.fast_dividef(x, y))
+
+
+def test_gluon_libdevice_helpers_match_cpu_results():
+    x = torch.tensor([-2.0, -0.5, 0.25, 1.5], dtype=torch.float32)
+    y = torch.tensor([2.0, -4.0, 0.5, 3.0], dtype=torch.float32)
+    exp_out = torch.empty_like(x)
+    fast_exp_out = torch.empty_like(x)
+    div_out = torch.empty_like(x)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(
+        _libdevice_helpers_kernel
+    )
+
+    kernel[(1,)](x, y, exp_out, fast_exp_out, div_out, x.numel(), num_warps=1)
+
+    torch.testing.assert_close(exp_out, torch.exp(x), atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(fast_exp_out, torch.exp(x), atol=1e-6, rtol=1e-6)
+    torch.testing.assert_close(div_out, x / y, atol=0, rtol=0)

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -62,6 +62,11 @@ from triton.runtime.interpreter import (  # type: ignore
 from ..frontend.base import _LangPatchScope
 
 try:
+    import triton.language.extra.libdevice as triton_libdevice
+except ImportError:
+    triton_libdevice = None
+
+try:
     from triton.experimental.gluon.language.amd import gfx1250 as gluon_amd_gfx1250  # type: ignore
     from triton.experimental.gluon.language.amd.gfx1250 import (  # type: ignore
         async_copy as gluon_amd_async_copy,
@@ -2423,6 +2428,37 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
     for module in (gl, gluon_standard):
         scope.set_attr(module, "sum", reduce_sum)
         scope.set_attr(module, "max", reduce_max)
+
+    if triton_libdevice is not None:
+        # Triton's Python libdevice helpers are declaration stubs; install CPU
+        # equivalents before Gluon kernels call them in interpreter mode.
+
+        def libdevice_exp(input: Any):
+            input = gluon_semantic.to_tensor(input)
+            result = np.exp(np.asarray(input.handle.data, dtype=np.float32))
+            ret_ty = gluon_core.distributed_type(
+                tl.float32, input.type.shape, input.type.layout
+            )
+            return gluon_core.tensor(
+                _tensor_result(result, tl.float32, input.type.layout), ret_ty
+            )
+
+        def libdevice_fast_dividef(lhs: Any, rhs: Any):
+            lhs = gluon_semantic.to_tensor(lhs)
+            rhs = gluon_semantic.to_tensor(rhs)
+            result = np.asarray(lhs.handle.data, dtype=np.float32) / np.asarray(
+                rhs.handle.data, dtype=np.float32
+            )
+            ret_ty = gluon_core.distributed_type(
+                tl.float32, lhs.type.shape, lhs.type.layout
+            )
+            return gluon_core.tensor(
+                _tensor_result(result, tl.float32, lhs.type.layout), ret_ty
+            )
+
+        scope.set_attr(triton_libdevice, "exp", libdevice_exp)
+        scope.set_attr(triton_libdevice, "fast_expf", libdevice_exp)
+        scope.set_attr(triton_libdevice, "fast_dividef", libdevice_fast_dividef)
 
     if gluon_ampere_mbarrier is not None:
         scope.set_attr(gluon_ampere_mbarrier, "allocate_mbarrier", allocate_mbarrier)


### PR DESCRIPTION
## Summary
- add Gluon end-to-end coverage for libdevice helper functions
- patch libdevice exp, fast_expf, and fast_dividef stubs for CPU simulation
- validate results against torch CPU outputs

## Tests
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_libdevice_helper_ops.py -q
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_libdevice_helper_ops.py tests/end_to_end/test_gluon_math_helper_ops.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q
- pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_libdevice_helper_ops.py