### PR TITLE
[TEST] Cover Gluon AMD core helper ops

### DIFF
--- a/tests/end_to_end/test_gluon_amd_core_helper_ops.py
+++ b/tests/end_to_end/test_gluon_amd_core_helper_ops.py
@@ -1,0 +1,67 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _amd_core_helpers_kernel(values_ptr, abs_out, old_out, lock, BLOCK: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    offsets = gl.arange(0, BLOCK, layout)
+    gl.assume(BLOCK > 0)
+    offsets = gl.multiple_of(offsets, [1])
+    values = gl.load(values_ptr + offsets)
+    gl.store(abs_out + offsets, gl.abs(values))
+    old = gl.atomic_cas(lock, 0, 7)
+    gl.store(old_out, old)
+
+
+def test_gluon_amd_core_helpers_match_cpu_results():
+    values = torch.tensor([-3, 4, -5, 6], dtype=torch.int32)
+    abs_out = torch.empty_like(values)
+    old_out = torch.empty((), dtype=torch.int32)
+    lock = torch.zeros((), dtype=torch.int32)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(_amd_core_helpers_kernel)
+
+    kernel[(1,)](values, abs_out, old_out, lock, values.numel(), num_warps=1)
+
+    torch.testing.assert_close(abs_out, torch.abs(values), atol=0, rtol=0)
+    assert old_out.item() == 0
+    assert lock.item() == 7

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -2429,6 +2429,41 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
         scope.set_attr(module, "sum", reduce_sum)
         scope.set_attr(module, "max", reduce_max)
 
+    # Public gl.* hint functions are copies of gluon_core functions, so patch
+    # both namespaces to accept ordinary Python values in interpreter mode.
+    def set_tensor_attr(input: Any, values: Any, name: str):
+        if not isinstance(input, gluon_core.tensor):
+            return input
+        values = [values] if not isinstance(values, (list, tuple)) else values
+        values = [_unwrap_constexpr(value) for value in values]
+        if len(values) != max(1, len(input.type.shape)):
+            raise ValueError(f"len(values) != len(input.shape) for {name}")
+        input.handle.set_attr(name, values)
+        return input
+
+    for module in (gl, gluon_core):
+        scope.set_attr(
+            module,
+            "multiple_of",
+            lambda input, values, _semantic=None: set_tensor_attr(
+                input, values, "tt.divisibility"
+            ),
+        )
+        scope.set_attr(
+            module,
+            "max_contiguous",
+            lambda input, values, _semantic=None: set_tensor_attr(
+                input, values, "tt.contiguity"
+            ),
+        )
+        scope.set_attr(
+            module,
+            "max_constancy",
+            lambda input, values, _semantic=None: set_tensor_attr(
+                input, values, "tt.constancy"
+            ),
+        )
+
     if triton_libdevice is not None:
         # Triton's Python libdevice helpers are declaration stubs; install CPU
         # equivalents before Gluon kernels call them in interpreter mode.


### PR DESCRIPTION
## Summary
- add Gluon end-to-end coverage for AMD core helper operations
- cover integer abs, metadata hints, and atomic_cas against CPU expected results
- patch Gluon public hint functions so interpreter mode accepts ordinary Python hint values

## Tests
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_core_helper_ops.py -q
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_core_helper_ops.py tests/end_to_end/test_gluon_libdevice_helper_ops.py tests/end_to_end/test_gluon_math_helper_ops.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q
- pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_amd_core_helper_ops.py