### PR TITLE
[TEST] Cover Gluon AMD CDNA4 async copy ops

### DIFF
--- a/tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py
+++ b/tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py
@@ -1,0 +1,82 @@
+import pytest
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+cdna4_async_copy = pytest.importorskip(
+    "triton.experimental.gluon.language.amd.cdna4.async_copy",
+    reason="AMD CDNA4 async-copy helpers are unavailable",
+)
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _amd_cdna4_async_copy_kernel(inp, out_global, out_buffer, BLOCK: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    shared_layout: gl.constexpr = gl.SwizzledSharedLayout(1, 1, 1, [0])
+    offsets = gl.arange(0, BLOCK, layout).to(gl.int32)
+    smem = gl.allocate_shared_memory(gl.float32, [BLOCK], shared_layout)
+    cdna4_async_copy.global_load_to_shared(smem, inp + offsets)
+    cdna4_async_copy.commit_group()
+    cdna4_async_copy.wait_group(0)
+    global_values = cdna4_async_copy.load_shared_relaxed(smem, layout)
+    gl.store(out_global + offsets, global_values)
+
+    mask = offsets < (BLOCK - 1)
+    cdna4_async_copy.buffer_load_to_shared(smem, inp, offsets, mask, other=-3.0)
+    cdna4_async_copy.commit_group()
+    cdna4_async_copy.wait_group(0)
+    buffer_values = cdna4_async_copy.load_shared_relaxed(smem, layout)
+    gl.store(out_buffer + offsets, buffer_values)
+
+
+def test_gluon_amd_cdna4_async_copy_matches_cpu_results():
+    values = torch.tensor([1.0, -2.0, 3.5, 4.25], dtype=torch.float32)
+    out_global = torch.full_like(values, -1.0)
+    out_buffer = torch.full_like(values, -1.0)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(
+        _amd_cdna4_async_copy_kernel
+    )
+
+    kernel[(1,)](values, out_global, out_buffer, values.numel(), num_warps=1)
+
+    torch.testing.assert_close(out_global, values, atol=0, rtol=0)
+    expected_buffer = torch.tensor([1.0, -2.0, 3.5, -3.0], dtype=torch.float32)
+    torch.testing.assert_close(out_buffer, expected_buffer, atol=0, rtol=0)

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -1124,6 +1124,9 @@ class Builder(interpreter_builder.__class__):
     def get_coalesced_layout(self):
         return gluon_layouts.CoalescedLayout()
 
+    def get_bool_attr(self, value: Any) -> bool:
+        return bool(value)
+
     def get_blocked_layout(
         self,
         size_per_thread: Any,
@@ -1828,6 +1831,10 @@ class Builder(interpreter_builder.__class__):
         cache_modifier: Any = None,
     ):
         ptrs = self._buffer_ptrs(ptr, offsets)
+        if not isinstance(mask, TensorHandle):
+            mask = None
+        if not isinstance(other, TensorHandle):
+            other = None
         if mask is None:
             mask = TensorHandle(np.ones_like(ptrs.data, dtype=bool), tl.int1)
         return self.create_masked_load(ptrs, mask, other, None, None, False)
@@ -1841,6 +1848,8 @@ class Builder(interpreter_builder.__class__):
         cache_modifier: Any = None,
     ):
         ptrs = self._buffer_ptrs(ptr, offsets)
+        if not isinstance(mask, TensorHandle):
+            mask = None
         if mask is None:
             mask = TensorHandle(np.ones_like(ptrs.data, dtype=bool), tl.int1)
         return self.create_masked_store(ptrs, stored_value, mask, None, None)
@@ -1856,6 +1865,8 @@ class Builder(interpreter_builder.__class__):
         mask: TensorHandle | None,
     ):
         ptrs = self._buffer_ptrs(ptr, offsets)
+        if not isinstance(mask, TensorHandle):
+            mask = None
         if mask is None:
             mask = TensorHandle(np.ones_like(ptrs.data, dtype=bool), tl.int1)
         old = self.create_masked_load(ptrs, mask, None, None, None, False)
@@ -1885,8 +1896,6 @@ class Builder(interpreter_builder.__class__):
         other: TensorHandle | None = None,
         *args: Any,
     ):
-        if not isinstance(other, TensorHandle):
-            other = None
         value = self.create_buffer_load(
             None,
             ptr,
@@ -1905,6 +1914,8 @@ class Builder(interpreter_builder.__class__):
         *args: Any,
     ):
         value = TensorHandle(np.asarray(src.data), src.element_ty)
+        if not isinstance(mask, TensorHandle):
+            mask = None
         if mask is None:
             mask = TensorHandle(np.ones_like(value.data, dtype=bool), tl.int1)
         return self.create_masked_store(ptr, value, mask, None, None)


### PR DESCRIPTION
## Summary
- add Gluon end-to-end coverage for AMD CDNA4 async-copy helpers
- cover global_load_to_shared, buffer_load_to_shared, load_shared_relaxed, commit_group, and wait_group
- normalize placeholder async-copy mask/other operands in the simulator and support boolean handle attributes

## Tests
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py -q
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py tests/end_to_end/test_gluon_amd_tdm_ops.py tests/end_to_end/test_gluon_amd_core_helper_ops.py tests/end_to_end/test_gluon_libdevice_helper_ops.py tests/end_to_end/test_gluon_math_helper_ops.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q
- pre-commit run --files triton_viz/core/simulation/gluon.py tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py