### PR TITLE
[TEST] Cover Gluon AMD warp pipeline stages

### DIFF
--- a/tests/end_to_end/test_gluon_amd_warp_pipeline_stage_ops.py
+++ b/tests/end_to_end/test_gluon_amd_warp_pipeline_stage_ops.py
@@ -1,0 +1,66 @@
+import torch
+from triton.experimental import gluon
+from triton.experimental.gluon import language as gl
+
+import triton_viz
+from triton_viz.core.callbacks import ForLoopCallbacks, OpCallbacks
+from triton_viz.core.client import Client
+
+
+class _NoOpClient(Client):
+    NAME = "noop"
+
+    def pre_run_callback(self, fn):
+        return True
+
+    def post_run_callback(self, fn):
+        return True
+
+    def arg_callback(self, name, arg, arg_cvt):
+        pass
+
+    def grid_callback(self, grid):
+        pass
+
+    def grid_idx_callback(self, grid_idx):
+        pass
+
+    def register_op_callback(self, op_type, *args, **kwargs):
+        return OpCallbacks()
+
+    def register_for_loop_callback(self):
+        return ForLoopCallbacks()
+
+    def finalize(self):
+        return []
+
+    def pre_warmup_callback(self, jit_fn, *args, **kwargs):
+        return True
+
+    def post_warmup_callback(self, jit_fn, ret):
+        pass
+
+
+@gluon.jit
+def _amd_warp_pipeline_stage_kernel(x_ptr, y_ptr, out_ptr, BLOCK: gl.constexpr):
+    layout: gl.constexpr = gl.BlockedLayout([1], [32], [1], [0])
+    offsets = gl.arange(0, BLOCK, layout=layout)
+    with gl.amd.warp_pipeline_stage("load", priority=3):
+        x = gl.load(x_ptr + offsets)
+        y = gl.load(y_ptr + offsets)
+    with gl.amd.warp_pipeline_stage("compute", priority=0):
+        values = x * 2.0 + y
+    gl.store(out_ptr + offsets, values)
+
+
+def test_gluon_amd_warp_pipeline_stage_matches_cpu_results():
+    x = torch.tensor([1.0, -2.0, 3.5, 4.0], dtype=torch.float32)
+    y = torch.tensor([0.5, 8.0, -1.5, 2.0], dtype=torch.float32)
+    out = torch.empty_like(x)
+    kernel = triton_viz.trace(_NoOpClient(), frontend="gluon")(
+        _amd_warp_pipeline_stage_kernel
+    )
+
+    kernel[(1,)](x, y, out, x.numel(), num_warps=1)
+
+    torch.testing.assert_close(out, x * 2.0 + y, atol=0, rtol=0)

--- a/triton_viz/core/simulation/gluon.py
+++ b/triton_viz/core/simulation/gluon.py
@@ -2362,6 +2362,17 @@ def patch_lang(fn: Callable) -> _LangPatchScope:
     for cls in _GLUON_BUILTIN_CLASSES:
         _patch_gluon_builtins(cls, scope)
 
+    original_warp_pipeline_stage = getattr(gluon_amd, "warp_pipeline_stage", None)
+    if original_warp_pipeline_stage is not None:
+
+        def warp_pipeline_stage(*args: Any, **kwargs: Any):
+            kwargs = {key: value for key, value in kwargs.items() if key != "_semantic"}
+            return original_warp_pipeline_stage(
+                *args, **kwargs, _semantic=gluon_semantic
+            )
+
+        scope.set_attr(gluon_amd, "warp_pipeline_stage", warp_pipeline_stage)
+
     def allocate_mbarrier(*_args: Any, **_kwargs: Any):
         return TensorHandle(np.array([0], dtype=np.int32), tl.int32)
 


### PR DESCRIPTION
## Summary
- Add CPU parity coverage for AMD warp_pipeline_stage context manager execution under Gluon tracing.
- Patch the context-manager factory so simulated exits reach the builder-backed warp pipeline border hook.

## Validation
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_warp_pipeline_stage_ops.py -q
- PYTHONPATH=/mnt/keren/triton-viz pytest tests/end_to_end/test_gluon_amd_warp_pipeline_stage_ops.py tests/end_to_end/test_gluon_fp4_to_fp_ops.py tests/end_to_end/test_gluon_amd_scaled_upcast_ops.py tests/end_to_end/test_gluon_amd_wmma_ops.py tests/end_to_end/test_gluon_amd_buffer_ops.py tests/end_to_end/test_gluon_amd_cdna4_async_copy_ops.py tests/end_to_end/test_gluon_amd_tdm_ops.py tests/end_to_end/test_gluon_amd_core_helper_ops.py tests/end_to_end/test_gluon_libdevice_helper_ops.py tests/end_to_end/test_gluon_math_helper_ops.py tests/end_to_end/test_gluon_shared_memory_descriptor_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_multicast_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_two_cta_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_reduction_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_copy_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_scaled_ops.py tests/end_to_end/test_gluon_blackwell_tcgen05_ops.py tests/end_to_end/test_gluon_blackwell_tensor_memory_ops.py tests/end_to_end/test_gluon_wgmma_ops.py tests/end_to_end/test_gluon_tma_im2col_ops.py tests/end_to_end/test_gluon_blackwell_tma_ops.py tests/end_to_end/test_gluon_tma_ops.py tests/end_to_end/test_gluon_async_copy_ops.py tests/end_to_end/test_gluon_core_ops.py tests/end_to_end/test_gluon.py tests/end_to_end/test_core.py tests/unit/test_adapters.py -q
- pre-commit run --files tests/end_to_end/test_gluon_amd_warp_pipeline_stage_ops.py triton_viz/core/simulation/gluon.py
<git-pr-chain>


[TEST] Cover Gluon AMD warp pipeline stages


#### [PR chain](https://github.com/jlebar/git-pr-chain)
1. #472
1. #473
1. #474
1. 👉 #475 👈 **YOU ARE HERE**

⚠️⚠️ Please **do not click the green "merge" button** unless you know what
you're doing.  This PR is part of a chain of PRs, and clicking the merge
button will not merge it into master. ⚠️⚠️ 
</git-pr-chain>

